### PR TITLE
minor fix after tendermint fork

### DIFF
--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -220,7 +220,14 @@ func (app *BaseApp) initFromStore(mainKey sdk.StoreKey) error {
 
 // NewContext returns a new Context with the correct store, the given header, and nil txBytes.
 func (app *BaseApp) NewContext(mode sdk.RunTxMode, header abci.Header) sdk.Context {
-	return sdk.NewContext(app.CheckState.ms, header, mode, app.Logger)
+	var ms sdk.CacheMultiStore
+	switch mode {
+	case sdk.RunTxModeDeliver:
+		ms = app.DeliverState.ms
+	default:
+		ms = app.CheckState.ms
+	}
+	return sdk.NewContext(ms, header, mode, app.Logger)
 }
 
 type state struct {

--- a/x/slashing/app_test.go
+++ b/x/slashing/app_test.go
@@ -84,7 +84,7 @@ func checkValidator(t *testing.T, mapp *mock.App, keeper stake.Keeper,
 
 func checkValidatorSigningInfo(t *testing.T, mapp *mock.App, keeper Keeper,
 	addr sdk.ConsAddress, expFound bool) ValidatorSigningInfo {
-	ctxCheck := mapp.BaseApp.NewContext(sdk.RunTxModeReCheck, abci.Header{})
+	ctxCheck := mapp.BaseApp.NewContext(sdk.RunTxModeCheck, abci.Header{})
 	signingInfo, found := keeper.getValidatorSigningInfo(ctxCheck, addr)
 	require.Equal(t, expFound, found)
 	return signingInfo


### PR DESCRIPTION
## Description

- Fix some interface for NewContext to handle different state correctly.
- Fix logic in AnteHandler. Please note this is not used in BinanceChain where the logic is duplicated. Here the change is to make it correct.

- [x] make build pass
- [x] make test pass
- [x] make test_race pass