### PR TITLE
[R4R]use int64 instead of BigInt

### DIFF
--- a/client/lcd/lcd_test.go
+++ b/client/lcd/lcd_test.go
@@ -265,7 +265,7 @@ func TestCoinSend(t *testing.T) {
 	mycoins := coins[0]
 
 	require.Equal(t, "steak", mycoins.Denom)
-	require.Equal(t, initialBalance[0].Amount.SubRaw(1), mycoins.Amount)
+	require.Equal(t, initialBalance[0].Amount-1, mycoins.Amount)
 
 	// query receiver
 	acc = getAccount(t, port, receiveAddr)
@@ -273,7 +273,7 @@ func TestCoinSend(t *testing.T) {
 	mycoins = coins[0]
 
 	require.Equal(t, "steak", mycoins.Denom)
-	require.Equal(t, int64(1), mycoins.Amount.Int64())
+	require.Equal(t, int64(1), mycoins.Amount)
 }
 
 func DisabledTestIBCTransfer(t *testing.T) {
@@ -300,7 +300,7 @@ func DisabledTestIBCTransfer(t *testing.T) {
 	mycoins := coins[0]
 
 	require.Equal(t, "steak", mycoins.Denom)
-	require.Equal(t, initialBalance[0].Amount.SubRaw(1), mycoins.Amount)
+	require.Equal(t, initialBalance[0].Amount-1, mycoins.Amount)
 
 	// TODO: query ibc egress packet state
 }
@@ -507,7 +507,7 @@ func TestBonding(t *testing.T) {
 	acc := getAccount(t, port, addr)
 	coins := acc.GetCoins()
 
-	require.Equal(t, int64(40), coins.AmountOf(denom).Int64())
+	require.Equal(t, int64(40), coins.AmountOf(denom))
 
 	// query validator
 	bond := getDelegation(t, port, addr, operAddrs[0])
@@ -535,10 +535,10 @@ func TestBonding(t *testing.T) {
 	// sender should have not received any coins as the unbonding has only just begun
 	acc = getAccount(t, port, addr)
 	coins = acc.GetCoins()
-	require.Equal(t, int64(40), coins.AmountOf("steak").Int64())
+	require.Equal(t, int64(40), coins.AmountOf("steak"))
 
 	unbonding := getUndelegation(t, port, addr, operAddrs[0])
-	require.Equal(t, "30", unbonding.Balance.Amount.String())
+	require.Equal(t, int64(30), unbonding.Balance.Amount)
 
 	// test redelegation
 	resultTx = doBeginRedelegation(t, port, seed, name, password, addr, operAddrs[0], operAddrs[1], 30)
@@ -550,23 +550,23 @@ func TestBonding(t *testing.T) {
 	// query delegations, unbondings and redelegations from validator and delegator
 	delegatorDels = getDelegatorDelegations(t, port, addr)
 	require.Len(t, delegatorDels, 1)
-	require.Equal(t, "30.0000000000", delegatorDels[0].GetShares().String())
+	require.Equal(t, "30.00000000", delegatorDels[0].GetShares().String())
 
 	delegatorUbds := getDelegatorUnbondingDelegations(t, port, addr)
 	require.Len(t, delegatorUbds, 1)
-	require.Equal(t, "30", delegatorUbds[0].Balance.Amount.String())
+	require.Equal(t, int64(30), delegatorUbds[0].Balance.Amount)
 
 	delegatorReds := getDelegatorRedelegations(t, port, addr)
 	require.Len(t, delegatorReds, 1)
-	require.Equal(t, "30", delegatorReds[0].Balance.Amount.String())
+	require.Equal(t, int64(30), delegatorReds[0].Balance.Amount)
 
 	validatorUbds := getValidatorUnbondingDelegations(t, port, operAddrs[0])
 	require.Len(t, validatorUbds, 1)
-	require.Equal(t, "30", validatorUbds[0].Balance.Amount.String())
+	require.Equal(t, int64(30), validatorUbds[0].Balance.Amount)
 
 	validatorReds := getValidatorRedelegations(t, port, operAddrs[0])
 	require.Len(t, validatorReds, 1)
-	require.Equal(t, "30", validatorReds[0].Balance.Amount.String())
+	require.Equal(t, int64(30), validatorReds[0].Balance.Amount)
 
 	// TODO Undonding status not currently implemented
 	// require.Equal(t, sdk.Unbonding, bondedValidators[0].Status)
@@ -634,11 +634,11 @@ func TestDeposit(t *testing.T) {
 
 	// query proposal
 	proposal = getProposal(t, port, proposalID)
-	require.True(t, proposal.GetTotalDeposit().IsEqual(sdk.Coins{sdk.NewInt64Coin("steak", 10)}))
+	require.True(t, proposal.GetTotalDeposit().IsEqual(sdk.Coins{sdk.NewCoin("steak", 10)}))
 
 	// query deposit
 	deposit := getDeposit(t, port, proposalID, addr)
-	require.True(t, deposit.Amount.IsEqual(sdk.Coins{sdk.NewInt64Coin("steak", 10)}))
+	require.True(t, deposit.Amount.IsEqual(sdk.Coins{sdk.NewCoin("steak", 10)}))
 }
 
 func TestVote(t *testing.T) {
@@ -832,7 +832,7 @@ func doSendWithGas(t *testing.T, port, seed, name, password string, addr sdk.Acc
 	sequence := acc.GetSequence()
 	chainID := viper.GetString(client.FlagChainID)
 	// send
-	coinbz, err := cdc.MarshalJSON(sdk.NewInt64Coin("steak", 1))
+	coinbz, err := cdc.MarshalJSON(sdk.NewCoin("steak", 1))
 	if err != nil {
 		panic(err)
 	}

--- a/client/lcd/test_helpers.go
+++ b/client/lcd/test_helpers.go
@@ -226,7 +226,7 @@ func InitializeTestLCD(
 		msg := stake.NewMsgCreateValidator(
 			sdk.ValAddress(operAddr),
 			pubKey,
-			sdk.NewCoin("steak", sdk.NewInt(int64(delegation))),
+			sdk.NewCoin("steak", int64(delegation)),
 			stake.Description{Moniker: fmt.Sprintf("validator-%d", i+1)},
 			stake.NewCommissionMsg(sdk.ZeroDec(), sdk.ZeroDec(), sdk.ZeroDec()),
 		)
@@ -250,7 +250,7 @@ func InitializeTestLCD(
 	// add some tokens to init accounts
 	for _, addr := range initAddrs {
 		accAuth := auth.NewBaseAccountWithAddress(addr)
-		accAuth.Coins = sdk.Coins{sdk.NewInt64Coin("steak", 100)}
+		accAuth.Coins = sdk.Coins{sdk.NewCoin("steak", 100)}
 		acc := gapp.NewGenesisAccount(&accAuth)
 		genesisState.Accounts = append(genesisState.Accounts, acc)
 		genesisState.StakeData.Pool.LooseTokens = genesisState.StakeData.Pool.LooseTokens.Add(sdk.NewDec(100))

--- a/cmd/gaia/app/benchmarks/txsize_test.go
+++ b/cmd/gaia/app/benchmarks/txsize_test.go
@@ -20,7 +20,7 @@ func ExampleTxSendSize() {
 	addr1 := sdk.AccAddress(priv1.PubKey().Address())
 	priv2 := secp256k1.GenPrivKeySecp256k1([]byte{1})
 	addr2 := sdk.AccAddress(priv2.PubKey().Address())
-	coins := []sdk.Coin{sdk.NewCoin("denom", sdk.NewInt(10))}
+	coins := []sdk.Coin{sdk.NewCoin("denom", 10)}
 	msg1 := bank.MsgSend{
 		Inputs:  []bank.Input{bank.NewInput(addr1, coins)},
 		Outputs: []bank.Output{bank.NewOutput(addr2, coins)},
@@ -30,6 +30,6 @@ func ExampleTxSendSize() {
 	tx := auth.NewStdTx([]sdk.Msg{msg1}, sigs, "")
 	fmt.Println(len(cdc.MustMarshalBinaryBare([]sdk.Msg{msg1})))
 	fmt.Println(len(cdc.MustMarshalBinaryBare(tx)))
-	// output: 80
-	// 152
+	// output: 76
+	// 148
 }

--- a/cmd/gaia/app/genesis.go
+++ b/cmd/gaia/app/genesis.go
@@ -25,7 +25,7 @@ import (
 var (
 	// bonded tokens given to genesis validators/accounts
 	freeFermionVal  = int64(100)
-	freeFermionsAcc = sdk.NewInt(150)
+	freeFermionsAcc = int64(150)
 )
 
 // State to Unmarshal
@@ -135,10 +135,10 @@ func GaiaAppGenState(cdc *codec.Codec, appGenTxs []json.RawMessage) (genesisStat
 	return
 }
 
-func genesisAccountFromMsgCreateValidator(msg stake.MsgCreateValidator, amount sdk.Int) GenesisAccount {
+func genesisAccountFromMsgCreateValidator(msg stake.MsgCreateValidator, amount int64) GenesisAccount {
 	accAuth := auth.NewBaseAccountWithAddress(sdk.AccAddress(msg.ValidatorAddr))
 	accAuth.Coins = []sdk.Coin{
-		{msg.Description.Moniker + "Token", sdk.NewInt(1000)},
+		{msg.Description.Moniker + "Token", 1000},
 		{"steak", amount},
 	}
 	return NewGenesisAccount(&accAuth)
@@ -251,7 +251,7 @@ func CollectStdTxs(moniker string, genTxsDir string, cdc *codec.Codec) (
 func NewDefaultGenesisAccount(addr sdk.AccAddress) GenesisAccount {
 	accAuth := auth.NewBaseAccountWithAddress(addr)
 	accAuth.Coins = []sdk.Coin{
-		{"fooToken", sdk.NewInt(1000)},
+		{"fooToken", 1000},
 		{"steak", freeFermionsAcc},
 	}
 	return NewGenesisAccount(&accAuth)

--- a/cmd/gaia/app/genesis_test.go
+++ b/cmd/gaia/app/genesis_test.go
@@ -77,7 +77,7 @@ func TestGaiaAppGenState(t *testing.T) {
 func makeMsg(name string, pk crypto.PubKey) auth.StdTx {
 	desc := stake.NewDescription(name, "", "", "")
 	comm := stakeTypes.CommissionMsg{}
-	msg := stake.NewMsgCreateValidator(sdk.ValAddress(pk.Address()), pk, sdk.NewInt64Coin("steak", 50), desc, comm)
+	msg := stake.NewMsgCreateValidator(sdk.ValAddress(pk.Address()), pk, sdk.NewCoin("steak", 50), desc, comm)
 	return auth.NewStdTx([]sdk.Msg{msg}, nil, "")
 }
 

--- a/cmd/gaia/app/sim_test.go
+++ b/cmd/gaia/app/sim_test.go
@@ -52,7 +52,7 @@ func appStateFn(r *rand.Rand, accs []simulation.Account) json.RawMessage {
 
 	// Randomly generate some genesis accounts
 	for _, acc := range accs {
-		coins := sdk.Coins{sdk.Coin{"steak", sdk.NewInt(amt)}}
+		coins := sdk.Coins{sdk.Coin{"steak", amt}}
 		genesisAccounts = append(genesisAccounts, GenesisAccount{
 			Address: acc.Address,
 			Coins:   coins,

--- a/cmd/gaia/init/init.go
+++ b/cmd/gaia/init/init.go
@@ -224,7 +224,7 @@ func initWithConfig(cdc *codec.Codec, config *cfg.Config, initCfg initConfig) (
 		msg := stake.NewMsgCreateValidator(
 			sdk.ValAddress(addr),
 			initCfg.ValPubKey,
-			sdk.NewInt64Coin("steak", 100),
+			sdk.NewCoin("steak", 100),
 			stake.NewDescription(config.Moniker, "", "", ""),
 			stake.NewCommissionMsg(sdk.ZeroDec(), sdk.ZeroDec(), sdk.ZeroDec()),
 		)

--- a/cmd/gaia/init/testnet.go
+++ b/cmd/gaia/init/testnet.go
@@ -147,7 +147,7 @@ func testnetWithConfig(config *cfg.Config, cdc *codec.Codec, appInit server.AppI
 		msg := stake.NewMsgCreateValidator(
 			sdk.ValAddress(addr),
 			valPubKeys[i],
-			sdk.NewInt64Coin("steak", 100),
+			sdk.NewCoin("steak", 100),
 			stake.NewDescription(nodeDirName, "", "", ""),
 			stake.NewCommissionMsg(sdk.ZeroDec(), sdk.ZeroDec(), sdk.ZeroDec()),
 		)

--- a/docs/sdk/core/examples/app2_test.go
+++ b/docs/sdk/core/examples/app2_test.go
@@ -20,7 +20,7 @@ func TestEncoding(t *testing.T) {
 	sendMsg := MsgSend{
 		From:   addr1,
 		To:     addr2,
-		Amount: sdk.Coins{{"testCoins", sdk.NewInt(100)}},
+		Amount: sdk.Coins{{"testCoins", 100}},
 	}
 
 	// Construct transaction
@@ -54,7 +54,7 @@ func TestEncoding(t *testing.T) {
 	issueMsg := MsgIssue{
 		Issuer:   addr1,
 		Receiver: addr2,
-		Coin:     sdk.Coin{"testCoin", sdk.NewInt(100)},
+		Coin:     sdk.Coin{"testCoin", 100},
 	}
 
 	signBytes = issueMsg.GetSignBytes()

--- a/docs/sdk/core/examples/app4_test.go
+++ b/docs/sdk/core/examples/app4_test.go
@@ -1,7 +1,7 @@
 package app
 
 import (
-	"encoding/json"
+	"github.com/cosmos/cosmos-sdk/codec"
 	"os"
 	"testing"
 
@@ -30,12 +30,12 @@ func InitTestChain(bc *bapp.BaseApp, chainID string, addrs ...sdk.AccAddress) {
 	for _, addr := range addrs {
 		acc := GenesisAccount{
 			Address: addr,
-			Coins:   sdk.Coins{{"testCoin", sdk.NewInt(100)}},
+			Coins:   sdk.Coins{{"testCoin", 100}},
 		}
 		accounts = append(accounts, &acc)
 	}
 	accountState := GenesisState{accounts}
-	genState, err := json.Marshal(accountState)
+	genState, err := codec.Cdc.MarshalJSON(accountState)
 	if err != nil {
 		panic(err)
 	}
@@ -61,7 +61,7 @@ func TestBadMsg(t *testing.T) {
 	addr2 := priv2.PubKey().Address().Bytes()
 
 	// Attempt to spend non-existent funds
-	msg := GenerateSpendMsg(addr1, addr2, sdk.Coins{{"testCoin", sdk.NewInt(100)}})
+	msg := GenerateSpendMsg(addr1, addr2, sdk.Coins{{"testCoin", 100}})
 
 	// Construct transaction
 	signBytes := auth.StdSignBytes("test-chain", 0, 0, []sdk.Msg{msg}, "")
@@ -103,7 +103,7 @@ func TestMsgSend(t *testing.T) {
 	InitTestChain(bc, "test-chain", addr1)
 
 	// Send funds to addr2
-	msg := GenerateSpendMsg(addr1, addr2, sdk.Coins{{"testCoin", sdk.NewInt(100)}})
+	msg := GenerateSpendMsg(addr1, addr2, sdk.Coins{{"testCoin", 100}})
 
 	signBytes := auth.StdSignBytes("test-chain", 0, 0, []sdk.Msg{msg}, "")
 	sig, err := priv1.Sign(signBytes)

--- a/types/coin.go
+++ b/types/coin.go
@@ -11,18 +11,14 @@ import (
 // Coin hold some amount of one currency
 type Coin struct {
 	Denom  string `json:"denom"`
-	Amount Int    `json:"amount"`
+	Amount int64  `json:"amount"`
 }
 
-func NewCoin(denom string, amount Int) Coin {
+func NewCoin(denom string, amount int64) Coin {
 	return Coin{
 		Denom:  denom,
 		Amount: amount,
 	}
-}
-
-func NewInt64Coin(denom string, amount int64) Coin {
-	return NewCoin(denom, NewInt(amount))
 }
 
 // String provides a human-readable representation of a coin
@@ -37,13 +33,13 @@ func (coin Coin) SameDenomAs(other Coin) bool {
 
 // IsZero returns if this represents no money
 func (coin Coin) IsZero() bool {
-	return coin.Amount.IsZero()
+	return coin.Amount == 0
 }
 
 // IsGTE returns true if they are the same type and the receiver is
 // an equal or greater value
 func (coin Coin) IsGTE(other Coin) bool {
-	return coin.SameDenomAs(other) && (!coin.Amount.LT(other.Amount))
+	return coin.SameDenomAs(other) && (!(coin.Amount < other.Amount))
 }
 
 // IsLT returns true if they are the same type and the receiver is
@@ -54,17 +50,17 @@ func (coin Coin) IsLT(other Coin) bool {
 
 // IsEqual returns true if the two sets of Coins have the same value
 func (coin Coin) IsEqual(other Coin) bool {
-	return coin.SameDenomAs(other) && (coin.Amount.Equal(other.Amount))
+	return coin.SameDenomAs(other) && (coin.Amount == other.Amount)
 }
 
 // IsPositive returns true if coin amount is positive
 func (coin Coin) IsPositive() bool {
-	return (coin.Amount.Sign() == 1)
+	return coin.Amount > 0
 }
 
 // IsNotNegative returns true if coin amount is not negative
 func (coin Coin) IsNotNegative() bool {
-	return (coin.Amount.Sign() != -1)
+	return coin.Amount >= 0
 }
 
 // Adds amounts of two coins with same denom
@@ -72,7 +68,7 @@ func (coin Coin) Plus(coinB Coin) Coin {
 	if !coin.SameDenomAs(coinB) {
 		return coin
 	}
-	return Coin{coin.Denom, coin.Amount.Add(coinB.Amount)}
+	return Coin{coin.Denom, coin.Amount + coinB.Amount}
 }
 
 // Subtracts amounts of two coins with same denom
@@ -80,7 +76,7 @@ func (coin Coin) Minus(coinB Coin) Coin {
 	if !coin.SameDenomAs(coinB) {
 		return coin
 	}
-	return Coin{coin.Denom, coin.Amount.Sub(coinB.Amount)}
+	return Coin{coin.Denom, coin.Amount - coinB.Amount}
 }
 
 //----------------------------------------
@@ -145,7 +141,7 @@ func (coins Coins) Plus(coinsB Coins) Coins {
 			sum = append(sum, coinA)
 			indexA++
 		case 0:
-			if coinA.Amount.Add(coinB.Amount).IsZero() {
+			if coinA.Amount+coinB.Amount == 0 {
 				// ignore 0 sum coin type
 			} else {
 				sum = append(sum, coinA.Plus(coinB))
@@ -165,7 +161,7 @@ func (coins Coins) Negative() Coins {
 	for _, coin := range coins {
 		res = append(res, Coin{
 			Denom:  coin.Denom,
-			Amount: coin.Amount.Neg(),
+			Amount: -coin.Amount,
 		})
 	}
 	return res
@@ -210,7 +206,7 @@ func (coins Coins) IsEqual(coinsB Coins) bool {
 		return false
 	}
 	for i := 0; i < len(coins); i++ {
-		if coins[i].Denom != coinsB[i].Denom || !coins[i].Amount.Equal(coinsB[i].Amount) {
+		if coins[i].Denom != coinsB[i].Denom || !(coins[i].Amount == coinsB[i].Amount) {
 			return false
 		}
 	}
@@ -246,16 +242,16 @@ func (coins Coins) IsNotNegative() bool {
 }
 
 // Returns the amount of a denom from coins
-func (coins Coins) AmountOf(denom string) Int {
+func (coins Coins) AmountOf(denom string) int64 {
 	switch len(coins) {
 	case 0:
-		return ZeroInt()
+		return 0
 	case 1:
 		coin := coins[0]
 		if coin.Denom == denom {
 			return coin.Amount
 		}
-		return ZeroInt()
+		return 0
 	default:
 		midIdx := len(coins) / 2 // 2:1, 3:1, 4:2
 		coin := coins[midIdx]
@@ -313,7 +309,7 @@ func ParseCoin(coinStr string) (coin Coin, err error) {
 		return
 	}
 
-	return Coin{denomStr, NewInt(int64(amount))}, nil
+	return Coin{denomStr, int64(amount)}, nil
 }
 
 // ParseCoins will parse out a list of coins separated by commas.

--- a/types/coin_test.go
+++ b/types/coin_test.go
@@ -13,9 +13,9 @@ func TestIsPositiveCoin(t *testing.T) {
 		inputOne Coin
 		expected bool
 	}{
-		{NewInt64Coin("A", 1), true},
-		{NewInt64Coin("A", 0), false},
-		{NewInt64Coin("a", -1), false},
+		{NewCoin("A", 1), true},
+		{NewCoin("A", 0), false},
+		{NewCoin("a", -1), false},
 	}
 
 	for tcIndex, tc := range cases {
@@ -29,9 +29,9 @@ func TestIsNotNegativeCoin(t *testing.T) {
 		inputOne Coin
 		expected bool
 	}{
-		{NewInt64Coin("A", 1), true},
-		{NewInt64Coin("A", 0), true},
-		{NewInt64Coin("a", -1), false},
+		{NewCoin("A", 1), true},
+		{NewCoin("A", 0), true},
+		{NewCoin("a", -1), false},
 	}
 
 	for tcIndex, tc := range cases {
@@ -46,11 +46,11 @@ func TestSameDenomAsCoin(t *testing.T) {
 		inputTwo Coin
 		expected bool
 	}{
-		{NewInt64Coin("A", 1), NewInt64Coin("A", 1), true},
-		{NewInt64Coin("A", 1), NewInt64Coin("a", 1), false},
-		{NewInt64Coin("a", 1), NewInt64Coin("b", 1), false},
-		{NewInt64Coin("steak", 1), NewInt64Coin("steak", 10), true},
-		{NewInt64Coin("steak", -11), NewInt64Coin("steak", 10), true},
+		{NewCoin("A", 1), NewCoin("A", 1), true},
+		{NewCoin("A", 1), NewCoin("a", 1), false},
+		{NewCoin("a", 1), NewCoin("b", 1), false},
+		{NewCoin("steak", 1), NewCoin("steak", 10), true},
+		{NewCoin("steak", -11), NewCoin("steak", 10), true},
 	}
 
 	for tcIndex, tc := range cases {
@@ -65,10 +65,10 @@ func TestIsGTECoin(t *testing.T) {
 		inputTwo Coin
 		expected bool
 	}{
-		{NewInt64Coin("A", 1), NewInt64Coin("A", 1), true},
-		{NewInt64Coin("A", 2), NewInt64Coin("A", 1), true},
-		{NewInt64Coin("A", -1), NewInt64Coin("A", 5), false},
-		{NewInt64Coin("a", 1), NewInt64Coin("b", 1), false},
+		{NewCoin("A", 1), NewCoin("A", 1), true},
+		{NewCoin("A", 2), NewCoin("A", 1), true},
+		{NewCoin("A", -1), NewCoin("A", 5), false},
+		{NewCoin("a", 1), NewCoin("b", 1), false},
 	}
 
 	for tcIndex, tc := range cases {
@@ -83,10 +83,10 @@ func TestIsLTCoin(t *testing.T) {
 		inputTwo Coin
 		expected bool
 	}{
-		{NewInt64Coin("A", 1), NewInt64Coin("A", 1), false},
-		{NewInt64Coin("A", 2), NewInt64Coin("A", 1), false},
-		{NewInt64Coin("A", -1), NewInt64Coin("A", 5), true},
-		{NewInt64Coin("a", 0), NewInt64Coin("b", 1), true},
+		{NewCoin("A", 1), NewCoin("A", 1), false},
+		{NewCoin("A", 2), NewCoin("A", 1), false},
+		{NewCoin("A", -1), NewCoin("A", 5), true},
+		{NewCoin("a", 0), NewCoin("b", 1), true},
 	}
 
 	for tcIndex, tc := range cases {
@@ -101,11 +101,11 @@ func TestIsEqualCoin(t *testing.T) {
 		inputTwo Coin
 		expected bool
 	}{
-		{NewInt64Coin("A", 1), NewInt64Coin("A", 1), true},
-		{NewInt64Coin("A", 1), NewInt64Coin("a", 1), false},
-		{NewInt64Coin("a", 1), NewInt64Coin("b", 1), false},
-		{NewInt64Coin("steak", 1), NewInt64Coin("steak", 10), false},
-		{NewInt64Coin("steak", -11), NewInt64Coin("steak", 10), false},
+		{NewCoin("A", 1), NewCoin("A", 1), true},
+		{NewCoin("A", 1), NewCoin("a", 1), false},
+		{NewCoin("a", 1), NewCoin("b", 1), false},
+		{NewCoin("steak", 1), NewCoin("steak", 10), false},
+		{NewCoin("steak", -11), NewCoin("steak", 10), false},
 	}
 
 	for tcIndex, tc := range cases {
@@ -120,9 +120,9 @@ func TestPlusCoin(t *testing.T) {
 		inputTwo Coin
 		expected Coin
 	}{
-		{NewInt64Coin("A", 1), NewInt64Coin("A", 1), NewInt64Coin("A", 2)},
-		{NewInt64Coin("A", 1), NewInt64Coin("B", 1), NewInt64Coin("A", 1)},
-		{NewInt64Coin("asdf", -4), NewInt64Coin("asdf", 5), NewInt64Coin("asdf", 1)},
+		{NewCoin("A", 1), NewCoin("A", 1), NewCoin("A", 2)},
+		{NewCoin("A", 1), NewCoin("B", 1), NewCoin("A", 1)},
+		{NewCoin("asdf", -4), NewCoin("asdf", 5), NewCoin("asdf", 1)},
 	}
 
 	for tcIndex, tc := range cases {
@@ -134,9 +134,9 @@ func TestPlusCoin(t *testing.T) {
 		inputOne Coin
 		inputTwo Coin
 		expected int64
-	}{NewInt64Coin("asdf", -1), NewInt64Coin("asdf", 1), 0}
+	}{NewCoin("asdf", -1), NewCoin("asdf", 1), 0}
 	res := tc.inputOne.Plus(tc.inputTwo)
-	require.Equal(t, tc.expected, res.Amount.Int64())
+	require.Equal(t, tc.expected, res.Amount)
 }
 
 func TestMinusCoin(t *testing.T) {
@@ -146,9 +146,9 @@ func TestMinusCoin(t *testing.T) {
 		expected Coin
 	}{
 
-		{NewInt64Coin("A", 1), NewInt64Coin("B", 1), NewInt64Coin("A", 1)},
-		{NewInt64Coin("asdf", -4), NewInt64Coin("asdf", 5), NewInt64Coin("asdf", -9)},
-		{NewInt64Coin("asdf", 10), NewInt64Coin("asdf", 1), NewInt64Coin("asdf", 9)},
+		{NewCoin("A", 1), NewCoin("B", 1), NewCoin("A", 1)},
+		{NewCoin("asdf", -4), NewCoin("asdf", 5), NewCoin("asdf", -9)},
+		{NewCoin("asdf", 10), NewCoin("asdf", 1), NewCoin("asdf", 9)},
 	}
 
 	for tcIndex, tc := range cases {
@@ -160,9 +160,9 @@ func TestMinusCoin(t *testing.T) {
 		inputOne Coin
 		inputTwo Coin
 		expected int64
-	}{NewInt64Coin("A", 1), NewInt64Coin("A", 1), 0}
+	}{NewCoin("A", 1), NewCoin("A", 1), 0}
 	res := tc.inputOne.Minus(tc.inputTwo)
-	require.Equal(t, tc.expected, res.Amount.Int64())
+	require.Equal(t, tc.expected, res.Amount)
 
 }
 
@@ -172,10 +172,10 @@ func TestIsZeroCoins(t *testing.T) {
 		expected bool
 	}{
 		{Coins{}, true},
-		{Coins{NewInt64Coin("A", 0)}, true},
-		{Coins{NewInt64Coin("A", 0), NewInt64Coin("B", 0)}, true},
-		{Coins{NewInt64Coin("A", 1)}, false},
-		{Coins{NewInt64Coin("A", 0), NewInt64Coin("B", 1)}, false},
+		{Coins{NewCoin("A", 0)}, true},
+		{Coins{NewCoin("A", 0), NewCoin("B", 0)}, true},
+		{Coins{NewCoin("A", 1)}, false},
+		{Coins{NewCoin("A", 0), NewCoin("B", 1)}, false},
 	}
 
 	for _, tc := range cases {
@@ -191,13 +191,13 @@ func TestEqualCoins(t *testing.T) {
 		expected bool
 	}{
 		{Coins{}, Coins{}, true},
-		{Coins{NewInt64Coin("A", 0)}, Coins{NewInt64Coin("A", 0)}, true},
-		{Coins{NewInt64Coin("A", 0), NewInt64Coin("B", 1)}, Coins{NewInt64Coin("A", 0), NewInt64Coin("B", 1)}, true},
-		{Coins{NewInt64Coin("A", 0)}, Coins{NewInt64Coin("B", 0)}, false},
-		{Coins{NewInt64Coin("A", 0)}, Coins{NewInt64Coin("A", 1)}, false},
-		{Coins{NewInt64Coin("A", 0)}, Coins{NewInt64Coin("A", 0), NewInt64Coin("B", 1)}, false},
+		{Coins{NewCoin("A", 0)}, Coins{NewCoin("A", 0)}, true},
+		{Coins{NewCoin("A", 0), NewCoin("B", 1)}, Coins{NewCoin("A", 0), NewCoin("B", 1)}, true},
+		{Coins{NewCoin("A", 0)}, Coins{NewCoin("B", 0)}, false},
+		{Coins{NewCoin("A", 0)}, Coins{NewCoin("A", 1)}, false},
+		{Coins{NewCoin("A", 0)}, Coins{NewCoin("A", 0), NewCoin("B", 1)}, false},
 		// TODO: is it expected behaviour? shouldn't we sort the coins before comparing them?
-		{Coins{NewInt64Coin("A", 0), NewInt64Coin("B", 1)}, Coins{NewInt64Coin("B", 1), NewInt64Coin("A", 0)}, false},
+		{Coins{NewCoin("A", 0), NewCoin("B", 1)}, Coins{NewCoin("B", 1), NewCoin("A", 0)}, false},
 	}
 
 	for tcnum, tc := range cases {
@@ -210,36 +210,36 @@ func TestCoins(t *testing.T) {
 
 	//Define the coins to be used in tests
 	good := Coins{
-		{"GAS", NewInt(1)},
-		{"MINERAL", NewInt(1)},
-		{"TREE", NewInt(1)},
+		{"GAS", 1},
+		{"MINERAL", 1},
+		{"TREE", 1},
 	}
 	neg := good.Negative()
 	sum := good.Plus(neg)
 	empty := Coins{
-		{"GOLD", NewInt(0)},
+		{"GOLD", 0},
 	}
 	null := Coins{}
 	badSort1 := Coins{
-		{"TREE", NewInt(1)},
-		{"GAS", NewInt(1)},
-		{"MINERAL", NewInt(1)},
+		{"TREE", 0},
+		{"GAS", 0},
+		{"MINERAL", 0},
 	}
 	// both are after the first one, but the second and third are in the wrong order
 	badSort2 := Coins{
-		{"GAS", NewInt(1)},
-		{"TREE", NewInt(1)},
-		{"MINERAL", NewInt(1)},
+		{"GAS", 1},
+		{"TREE", 1},
+		{"MINERAL", 1},
 	}
 	badAmt := Coins{
-		{"GAS", NewInt(1)},
-		{"TREE", NewInt(0)},
-		{"MINERAL", NewInt(1)},
+		{"GAS", 1},
+		{"TREE", 1},
+		{"MINERAL", 1},
 	}
 	dup := Coins{
-		{"GAS", NewInt(1)},
-		{"GAS", NewInt(1)},
-		{"MINERAL", NewInt(1)},
+		{"GAS", 1},
+		{"GAS", 1},
+		{"MINERAL", 1},
 	}
 
 	assert.True(t, good.IsValid(), "Coins are valid")
@@ -258,10 +258,10 @@ func TestCoins(t *testing.T) {
 }
 
 func TestPlusCoins(t *testing.T) {
-	one := NewInt(1)
-	zero := NewInt(0)
-	negone := NewInt(-1)
-	two := NewInt(2)
+	one := int64(1)
+	zero := int64(0)
+	negone := int64(-1)
+	two := int64(2)
 
 	cases := []struct {
 		inputOne Coins
@@ -284,7 +284,7 @@ func TestPlusCoins(t *testing.T) {
 
 //Test the parsing of Coin and Coins
 func TestParse(t *testing.T) {
-	one := NewInt(1)
+	one := int64(1)
 
 	cases := []struct {
 		input    string
@@ -293,16 +293,16 @@ func TestParse(t *testing.T) {
 	}{
 		{"", true, nil},
 		{"1:foo", true, Coins{{"foo", one}}},
-		{"10:bar", true, Coins{{"bar", NewInt(10)}}},
-		{"99:bar,1:foo", true, Coins{{"bar", NewInt(99)}, {"foo", one}}},
-		{"98:bar , 1:foo  ", true, Coins{{"bar", NewInt(98)}, {"foo", one}}},
-		{"  55:bling\n", true, Coins{{"bling", NewInt(55)}}},
-		{"2:foo, 97:bar", true, Coins{{"bar", NewInt(97)}, {"foo", NewInt(2)}}},
-		{"5:mycoin,", false, nil},                                                 // no empty coins in a list
-		{"2:3foo, 97:bar", true, Coins{{"3foo", NewInt(2)}, {"bar", NewInt(97)}}}, // 3foo is invalid coin name
-		{"11me:coin, 12you:coin", false, nil},                                     // no spaces in coin names
-		{"1.2:btc", false, nil},                                                   // amount must be integer
-		{"5:foo-bar", false, nil},                                                 // once more, only letters in coin name
+		{"10:bar", true, Coins{{"bar", 10}}},
+		{"99:bar,1:foo", true, Coins{{"bar", 99}, {"foo", one}}},
+		{"98:bar , 1:foo  ", true, Coins{{"bar", 98}, {"foo", one}}},
+		{"  55:bling\n", true, Coins{{"bling", 55}}},
+		{"2:foo, 97:bar", true, Coins{{"bar", 97}, {"foo", 2}}},
+		{"5:mycoin,", false, nil},                                 // no empty coins in a list
+		{"2:3foo, 97:bar", true, Coins{{"3foo", 2}, {"bar", 97}}}, // 3foo is invalid coin name
+		{"11me:coin, 12you:coin", false, nil},                     // no spaces in coin names
+		{"1.2:btc", false, nil},                                   // amount must be integer
+		{"5:foo-bar", false, nil},                                 // once more, only letters in coin name
 	}
 
 	for tcIndex, tc := range cases {
@@ -319,32 +319,32 @@ func TestParse(t *testing.T) {
 func TestSortCoins(t *testing.T) {
 
 	good := Coins{
-		NewInt64Coin("GAS", 1),
-		NewInt64Coin("MINERAL", 1),
-		NewInt64Coin("TREE", 1),
+		NewCoin("GAS", 1),
+		NewCoin("MINERAL", 1),
+		NewCoin("TREE", 1),
 	}
 	empty := Coins{
-		NewInt64Coin("GOLD", 0),
+		NewCoin("GOLD", 0),
 	}
 	badSort1 := Coins{
-		NewInt64Coin("TREE", 1),
-		NewInt64Coin("GAS", 1),
-		NewInt64Coin("MINERAL", 1),
+		NewCoin("TREE", 1),
+		NewCoin("GAS", 1),
+		NewCoin("MINERAL", 1),
 	}
 	badSort2 := Coins{ // both are after the first one, but the second and third are in the wrong order
-		NewInt64Coin("GAS", 1),
-		NewInt64Coin("TREE", 1),
-		NewInt64Coin("MINERAL", 1),
+		NewCoin("GAS", 1),
+		NewCoin("TREE", 1),
+		NewCoin("MINERAL", 1),
 	}
 	badAmt := Coins{
-		NewInt64Coin("GAS", 1),
-		NewInt64Coin("TREE", 0),
-		NewInt64Coin("MINERAL", 1),
+		NewCoin("GAS", 1),
+		NewCoin("TREE", 0),
+		NewCoin("MINERAL", 1),
 	}
 	dup := Coins{
-		NewInt64Coin("GAS", 1),
-		NewInt64Coin("GAS", 1),
-		NewInt64Coin("MINERAL", 1),
+		NewCoin("GAS", 1),
+		NewCoin("GAS", 1),
+		NewCoin("MINERAL", 1),
 	}
 
 	cases := []struct {
@@ -370,31 +370,31 @@ func TestAmountOf(t *testing.T) {
 
 	case0 := Coins{}
 	case1 := Coins{
-		NewInt64Coin("", 0),
+		NewCoin("", 0),
 	}
 	case2 := Coins{
-		NewInt64Coin(" ", 0),
+		NewCoin(" ", 0),
 	}
 	case3 := Coins{
-		NewInt64Coin("GOLD", 0),
+		NewCoin("GOLD", 0),
 	}
 	case4 := Coins{
-		NewInt64Coin("GAS", 1),
-		NewInt64Coin("MINERAL", 1),
-		NewInt64Coin("TREE", 1),
+		NewCoin("GAS", 1),
+		NewCoin("MINERAL", 1),
+		NewCoin("TREE", 1),
 	}
 	case5 := Coins{
-		NewInt64Coin("MINERAL", 1),
-		NewInt64Coin("TREE", 1),
+		NewCoin("MINERAL", 1),
+		NewCoin("TREE", 1),
 	}
 	case6 := Coins{
-		NewInt64Coin("", 6),
+		NewCoin("", 6),
 	}
 	case7 := Coins{
-		NewInt64Coin(" ", 7),
+		NewCoin(" ", 7),
 	}
 	case8 := Coins{
-		NewInt64Coin("GAS", 8),
+		NewCoin("GAS", 8),
 	}
 
 	cases := []struct {
@@ -417,11 +417,11 @@ func TestAmountOf(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		assert.Equal(t, NewInt(tc.amountOf), tc.coins.AmountOf(""))
-		assert.Equal(t, NewInt(tc.amountOfSpace), tc.coins.AmountOf(" "))
-		assert.Equal(t, NewInt(tc.amountOfGAS), tc.coins.AmountOf("GAS"))
-		assert.Equal(t, NewInt(tc.amountOfMINERAL), tc.coins.AmountOf("MINERAL"))
-		assert.Equal(t, NewInt(tc.amountOfTREE), tc.coins.AmountOf("TREE"))
+		assert.Equal(t, tc.amountOf, tc.coins.AmountOf(""))
+		assert.Equal(t, tc.amountOfSpace, tc.coins.AmountOf(" "))
+		assert.Equal(t, tc.amountOfGAS, tc.coins.AmountOf("GAS"))
+		assert.Equal(t, tc.amountOfMINERAL, tc.coins.AmountOf("MINERAL"))
+		assert.Equal(t, tc.amountOfTREE, tc.coins.AmountOf("TREE"))
 	}
 }
 
@@ -431,10 +431,10 @@ func BenchmarkCoinsAdditionIntersect(b *testing.B) {
 			coinsA := Coins(make([]Coin, numCoinsA))
 			coinsB := Coins(make([]Coin, numCoinsB))
 			for i := 0; i < numCoinsA; i++ {
-				coinsA[i] = NewCoin("COINZ_"+string(i), NewInt(int64(i)))
+				coinsA[i] = NewCoin("COINZ_"+string(i), int64(i))
 			}
 			for i := 0; i < numCoinsB; i++ {
-				coinsB[i] = NewCoin("COINZ_"+string(i), NewInt(int64(i)))
+				coinsB[i] = NewCoin("COINZ_"+string(i), int64(i))
 			}
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
@@ -457,10 +457,10 @@ func BenchmarkCoinsAdditionNoIntersect(b *testing.B) {
 			coinsA := Coins(make([]Coin, numCoinsA))
 			coinsB := Coins(make([]Coin, numCoinsB))
 			for i := 0; i < numCoinsA; i++ {
-				coinsA[i] = NewCoin("COINZ_"+string(numCoinsB+i), NewInt(int64(i)))
+				coinsA[i] = NewCoin("COINZ_"+string(numCoinsB+i), int64(i))
 			}
 			for i := 0; i < numCoinsB; i++ {
-				coinsB[i] = NewCoin("COINZ_"+string(i), NewInt(int64(i)))
+				coinsB[i] = NewCoin("COINZ_"+string(i), int64(i))
 			}
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {

--- a/types/decimal.go
+++ b/types/decimal.go
@@ -12,12 +12,12 @@ import (
 // NOTE: never use new(Dec) or else we will panic unmarshalling into the
 // nil embedded big.Int
 type Dec struct {
-	*big.Int `json:"int"`
+	int64 `json:"int"`
 }
 
 // number of decimal places
 const (
-	Precision = 10
+	Precision = 8
 
 	// bytes required to represent the above precision
 	// ceil(log2(9999999999))
@@ -25,9 +25,9 @@ const (
 )
 
 var (
-	precisionReuse       = new(big.Int).Exp(big.NewInt(10), big.NewInt(Precision), nil)
-	fivePrecision        = new(big.Int).Quo(precisionReuse, big.NewInt(2))
-	precisionMultipliers []*big.Int
+	precisionReuse       = new(big.Int).Exp(big.NewInt(10), big.NewInt(Precision), nil).Int64()
+	fivePrecision        = precisionReuse / 2
+	precisionMultipliers []int64
 	zeroInt              = big.NewInt(0)
 	oneInt               = big.NewInt(1)
 	tenInt               = big.NewInt(10)
@@ -35,32 +35,32 @@ var (
 
 // Set precision multipliers
 func init() {
-	precisionMultipliers = make([]*big.Int, Precision+1)
+	precisionMultipliers = make([]int64, Precision+1)
 	for i := 0; i <= Precision; i++ {
 		precisionMultipliers[i] = calcPrecisionMultiplier(int64(i))
 	}
 }
 
-func precisionInt() *big.Int {
-	return new(big.Int).Set(precisionReuse)
+func precisionInt() int64 {
+	return precisionReuse
 }
 
 // nolint - common values
-func ZeroDec() Dec { return Dec{new(big.Int).Set(zeroInt)} }
+func ZeroDec() Dec { return Dec{0} }
 func OneDec() Dec  { return Dec{precisionInt()} }
 
 // calculate the precision multiplier
-func calcPrecisionMultiplier(prec int64) *big.Int {
+func calcPrecisionMultiplier(prec int64) int64 {
 	if prec > Precision {
 		panic(fmt.Sprintf("too much precision, maximum %v, provided %v", Precision, prec))
 	}
 	zerosToAdd := Precision - prec
-	multiplier := new(big.Int).Exp(tenInt, big.NewInt(zerosToAdd), nil)
+	multiplier := new(big.Int).Exp(tenInt, big.NewInt(zerosToAdd), nil).Int64()
 	return multiplier
 }
 
 // get the precision multiplier, do not mutate result
-func precisionMultiplier(prec int64) *big.Int {
+func precisionMultiplier(prec int64) int64 {
 	if prec > Precision {
 		panic(fmt.Sprintf("too much precision, maximum %v, provided %v", Precision, prec))
 	}
@@ -77,37 +77,38 @@ func NewDec(i int64) Dec {
 // create a new Dec from integer with decimal place at prec
 // CONTRACT: prec <= Precision
 func NewDecWithPrec(i, prec int64) Dec {
-	return Dec{
-		new(big.Int).Mul(big.NewInt(i), precisionMultiplier(prec)),
+	if i == 0 {
+		return Dec{0}
 	}
+	c := i * precisionMultiplier(prec)
+	if c/i != precisionMultiplier(prec) {
+		panic("Int overflow")
+	}
+	return Dec{c}
 }
 
 // create a new Dec from big integer assuming whole numbers
 // CONTRACT: prec <= Precision
-func NewDecFromBigInt(i *big.Int) Dec {
+func NewDecFromBigInt(i int64) Dec {
 	return NewDecFromBigIntWithPrec(i, 0)
 }
 
 // create a new Dec from big integer assuming whole numbers
 // CONTRACT: prec <= Precision
-func NewDecFromBigIntWithPrec(i *big.Int, prec int64) Dec {
-	return Dec{
-		new(big.Int).Mul(i, precisionMultiplier(prec)),
-	}
+func NewDecFromBigIntWithPrec(i int64, prec int64) Dec {
+	return NewDecWithPrec(i, prec)
 }
 
 // create a new Dec from big integer assuming whole numbers
 // CONTRACT: prec <= Precision
-func NewDecFromInt(i Int) Dec {
+func NewDecFromInt(i int64) Dec {
 	return NewDecFromIntWithPrec(i, 0)
 }
 
 // create a new Dec from big integer with decimal place at prec
 // CONTRACT: prec <= Precision
-func NewDecFromIntWithPrec(i Int, prec int64) Dec {
-	return Dec{
-		new(big.Int).Mul(i.BigInt(), precisionMultiplier(prec)),
-	}
+func NewDecFromIntWithPrec(i int64, prec int64) Dec {
+	return NewDecWithPrec(i, prec)
 }
 
 // create a decimal from an input decimal string.
@@ -162,122 +163,130 @@ func NewDecFromStr(str string) (d Dec, err Error) {
 	zeros := fmt.Sprintf(`%0`+strconv.Itoa(zerosToAdd)+`s`, "")
 	combinedStr = combinedStr + zeros
 
-	combined, ok := new(big.Int).SetString(combinedStr, 10)
-	if !ok {
-		return d, ErrUnknownRequest(fmt.Sprintf("bad string to integer conversion, combinedStr: %v", combinedStr))
+	combined, parseErr := strconv.ParseInt(combinedStr, 10, 64)
+	if parseErr != nil {
+		return d, ErrUnknownRequest(fmt.Sprintf("bad string to integer conversion, combinedStr: %v, error: %v", combinedStr, err))
 	}
 	if neg {
-		combined = new(big.Int).Neg(combined)
+		combined = -combined
 	}
 	return Dec{combined}, nil
 }
 
 //______________________________________________________________________________________________
 //nolint
-func (d Dec) IsNil() bool       { return d.Int == nil }                 // is decimal nil
-func (d Dec) IsZero() bool      { return (d.Int).Sign() == 0 }          // is equal to zero
-func (d Dec) Equal(d2 Dec) bool { return (d.Int).Cmp(d2.Int) == 0 }     // equal decimals
-func (d Dec) GT(d2 Dec) bool    { return (d.Int).Cmp(d2.Int) > 0 }      // greater than
-func (d Dec) GTE(d2 Dec) bool   { return (d.Int).Cmp(d2.Int) >= 0 }     // greater than or equal
-func (d Dec) LT(d2 Dec) bool    { return (d.Int).Cmp(d2.Int) < 0 }      // less than
-func (d Dec) LTE(d2 Dec) bool   { return (d.Int).Cmp(d2.Int) <= 0 }     // less than or equal
-func (d Dec) Neg() Dec          { return Dec{new(big.Int).Neg(d.Int)} } // reverse the decimal sign
-func (d Dec) Abs() Dec          { return Dec{new(big.Int).Abs(d.Int)} } // absolute value
+func (d Dec) IsNil() bool       { return false }               // is decimal nil
+func (d Dec) IsZero() bool      { return d.int64 == 0 }        // is equal to zero
+func (d Dec) Equal(d2 Dec) bool { return d.int64 == d2.int64 } // equal decimals
+func (d Dec) GT(d2 Dec) bool    { return d.int64 > d2.int64 }  // greater than
+func (d Dec) GTE(d2 Dec) bool   { return d.int64 >= d2.int64 } // greater than or equal
+func (d Dec) LT(d2 Dec) bool    { return d.int64 < d2.int64 }  // less than
+func (d Dec) LTE(d2 Dec) bool   { return d.int64 <= d2.int64 } // less than or equal
+func (d Dec) Neg() Dec          { return Dec{-d.int64} }       // reverse the decimal sign
+func (d Dec) Abs() Dec {
+	if d.int64 < 0 {
+		return d.Neg()
+	}
+	return d
+}
+
+func (d Dec) Set(v int64) Dec {
+	d.int64 = v
+	return d
+}
 
 // addition
 func (d Dec) Add(d2 Dec) Dec {
-	res := new(big.Int).Add(d.Int, d2.Int)
-
-	if res.BitLen() > 255+DecimalPrecisionBits {
+	c := d.int64 + d2.int64
+	if (c > d.int64) != (d2.int64 > 0) {
 		panic("Int overflow")
 	}
-	return Dec{res}
+	return Dec{c}
 }
 
 // subtraction
 func (d Dec) Sub(d2 Dec) Dec {
-	res := new(big.Int).Sub(d.Int, d2.Int)
-
-	if res.BitLen() > 255+DecimalPrecisionBits {
+	c := d.int64 - d2.int64
+	if (c < d.int64) != (d2.int64 > 0) {
 		panic("Int overflow")
 	}
-	return Dec{res}
+	return Dec{c}
 }
 
 // multiplication
 func (d Dec) Mul(d2 Dec) Dec {
-	mul := new(big.Int).Mul(d.Int, d2.Int)
+	mul := new(big.Int).Mul(big.NewInt(d.int64), big.NewInt(d2.int64))
 	chopped := chopPrecisionAndRound(mul)
 
-	if chopped.BitLen() > 255+DecimalPrecisionBits {
+	if !chopped.IsInt64() {
 		panic("Int overflow")
 	}
-	return Dec{chopped}
+	return Dec{chopped.Int64()}
 }
 
 // multiplication
-func (d Dec) MulInt(i Int) Dec {
-	mul := new(big.Int).Mul(d.Int, i.i)
+func (d Dec) MulInt(i int64) Dec {
+	mul := new(big.Int).Mul(big.NewInt(d.int64), big.NewInt(i))
 
-	if mul.BitLen() > 255+DecimalPrecisionBits {
+	if !mul.IsInt64() {
 		panic("Int overflow")
 	}
-	return Dec{mul}
+	return Dec{mul.Int64()}
 }
 
 // quotient
 func (d Dec) Quo(d2 Dec) Dec {
-
+	if d2.IsZero() {
+		panic("Dived can not be zero")
+	}
 	// multiply precision twice
-	mul := new(big.Int).Mul(d.Int, precisionReuse)
-	mul.Mul(mul, precisionReuse)
+	mul := new(big.Int).Mul(big.NewInt(d.int64), big.NewInt(precisionReuse))
+	mul.Mul(mul, big.NewInt(precisionReuse))
 
-	quo := new(big.Int).Quo(mul, d2.Int)
+	quo := new(big.Int).Quo(mul, big.NewInt(d2.int64))
 	chopped := chopPrecisionAndRound(quo)
 
-	if chopped.BitLen() > 255+DecimalPrecisionBits {
+	if !chopped.IsInt64() {
 		panic("Int overflow")
 	}
-	return Dec{chopped}
+	return Dec{chopped.Int64()}
 }
 
 // quotient
-func (d Dec) QuoInt(i Int) Dec {
-	mul := new(big.Int).Quo(d.Int, i.i)
+func (d Dec) QuoInt(i int64) Dec {
+	mul := d.int64 / i
 	return Dec{mul}
 }
 
 // is integer, e.g. decimals are zero
 func (d Dec) IsInteger() bool {
-	return new(big.Int).Rem(d.Int, precisionReuse).Sign() == 0
+	return d.int64%precisionReuse == 0
 }
 
 func (d Dec) String() string {
-	bz, err := d.Int.MarshalText()
-	if err != nil {
-		return ""
-	}
+	s := strconv.FormatInt(d.int64, 10)
+	bz := []byte(s)
 	var bzWDec []byte
 	inputSize := len(bz)
 	// TODO: Remove trailing zeros
 	// case 1, purely decimal
-	if inputSize <= 10 {
-		bzWDec = make([]byte, 12)
+	if inputSize <= 8 {
+		bzWDec = make([]byte, 10)
 		// 0. prefix
 		bzWDec[0] = byte('0')
 		bzWDec[1] = byte('.')
 		// set relevant digits to 0
-		for i := 0; i < 10-inputSize; i++ {
+		for i := 0; i < 8-inputSize; i++ {
 			bzWDec[i+2] = byte('0')
 		}
 		// set last few digits
-		copy(bzWDec[2+(10-inputSize):], bz)
+		copy(bzWDec[2+(8-inputSize):], bz)
 	} else {
 		// inputSize + 1 to account for the decimal point that is being added
 		bzWDec = make([]byte, inputSize+1)
-		copy(bzWDec, bz[:inputSize-10])
-		bzWDec[inputSize-10] = byte('.')
-		copy(bzWDec[inputSize-9:], bz[inputSize-10:])
+		copy(bzWDec, bz[:inputSize-8])
+		bzWDec[inputSize-8] = byte('.')
+		copy(bzWDec[inputSize-7:], bz[inputSize-8:])
 	}
 	return string(bzWDec)
 }
@@ -309,13 +318,13 @@ func chopPrecisionAndRound(d *big.Int) *big.Int {
 
 	// get the trucated quotient and remainder
 	quo, rem := d, big.NewInt(0)
-	quo, rem = quo.QuoRem(d, precisionReuse, rem)
+	quo, rem = quo.QuoRem(d, big.NewInt(precisionReuse), rem)
 
 	if rem.Sign() == 0 { // remainder is zero
 		return quo
 	}
 
-	switch rem.Cmp(fivePrecision) {
+	switch rem.Cmp(big.NewInt(fivePrecision)) {
 	case -1:
 		return quo
 	case 1:
@@ -336,7 +345,7 @@ func chopPrecisionAndRoundNonMutative(d *big.Int) *big.Int {
 
 // RoundInt64 rounds the decimal using bankers rounding
 func (d Dec) RoundInt64() int64 {
-	chopped := chopPrecisionAndRoundNonMutative(d.Int)
+	chopped := chopPrecisionAndRoundNonMutative(big.NewInt(d.int64))
 	if !chopped.IsInt64() {
 		panic("Int64() out of bound")
 	}
@@ -344,93 +353,61 @@ func (d Dec) RoundInt64() int64 {
 }
 
 // RoundInt round the decimal using bankers rounding
-func (d Dec) RoundInt() Int {
-	return NewIntFromBigInt(chopPrecisionAndRoundNonMutative(d.Int))
+func (d Dec) RoundInt() int64 {
+	return d.RoundInt64()
 }
 
 //___________________________________________________________________________________
 
 // similar to chopPrecisionAndRound, but always rounds down
-func chopPrecisionAndTruncate(d *big.Int) *big.Int {
-	return d.Quo(d, precisionReuse)
+func chopPrecisionAndTruncate(d int64) int64 {
+	return d / precisionReuse
 }
 
-func chopPrecisionAndTruncateNonMutative(d *big.Int) *big.Int {
-	tmp := new(big.Int).Set(d)
-	return chopPrecisionAndTruncate(tmp)
+func chopPrecisionAndTruncateNonMutative(d int64) int64 {
+	return chopPrecisionAndTruncate(d)
 }
 
 // TruncateInt64 truncates the decimals from the number and returns an int64
 func (d Dec) TruncateInt64() int64 {
-	chopped := chopPrecisionAndTruncateNonMutative(d.Int)
-	if !chopped.IsInt64() {
-		panic("Int64() out of bound")
-	}
-	return chopped.Int64()
+	return chopPrecisionAndTruncateNonMutative(d.int64)
 }
 
 // TruncateInt truncates the decimals from the number and returns an Int
-func (d Dec) TruncateInt() Int {
-	return NewIntFromBigInt(chopPrecisionAndTruncateNonMutative(d.Int))
+func (d Dec) TruncateInt() int64 {
+	return chopPrecisionAndTruncateNonMutative(d.int64)
 }
 
 //___________________________________________________________________________________
 
-// reuse nil values
-var (
-	nilAmino string
-	nilJSON  []byte
-)
-
-func init() {
-	empty := new(big.Int)
-	bz, err := empty.MarshalText()
-	if err != nil {
-		panic("bad nil amino init")
-	}
-	nilAmino = string(bz)
-
-	nilJSON, err = json.Marshal(string(bz))
-	if err != nil {
-		panic("bad nil json init")
-	}
+// wraps d.MarshalText()
+func (d Dec) MarshalAmino() (int64, error) {
+	return d.int64, nil
 }
 
-// wraps d.MarshalText()
-func (d Dec) MarshalAmino() (string, error) {
-	if d.Int == nil {
-		return nilAmino, nil
-	}
-	bz, err := d.Int.MarshalText()
-	return string(bz), err
+func (d Dec) MarshalText() ([]byte, error) {
+	return []byte(strconv.FormatInt(d.int64, 10)), nil
+}
+
+func (d *Dec) UnmarshalText(text []byte) error {
+	v, err := strconv.ParseInt(string(text), 10, 64)
+	d.int64 = v
+	return err
 }
 
 // requires a valid JSON string - strings quotes and calls UnmarshalText
-func (d *Dec) UnmarshalAmino(text string) (err error) {
-	tempInt := new(big.Int)
-	err = tempInt.UnmarshalText([]byte(text))
-	if err != nil {
-		return err
-	}
-	d.Int = tempInt
+func (d *Dec) UnmarshalAmino(v int64) (err error) {
+	d.int64 = v
 	return nil
 }
 
 // MarshalJSON marshals the decimal
 func (d Dec) MarshalJSON() ([]byte, error) {
-	if d.Int == nil {
-		return nilJSON, nil
-	}
-
 	return json.Marshal(d.String())
 }
 
 // UnmarshalJSON defines custom decoding scheme
 func (d *Dec) UnmarshalJSON(bz []byte) error {
-	if d.Int == nil {
-		d.Int = new(big.Int)
-	}
-
 	var text string
 	err := json.Unmarshal(bz, &text)
 	if err != nil {
@@ -441,7 +418,7 @@ func (d *Dec) UnmarshalJSON(bz []byte) error {
 	if err != nil {
 		return err
 	}
-	d.Int = newDec.Int
+	d.int64 = newDec.int64
 	return nil
 }
 

--- a/types/int.go
+++ b/types/int.go
@@ -533,3 +533,11 @@ func (i *Uint) UnmarshalJSON(bz []byte) error {
 func IntEq(t *testing.T, exp, got Int) (*testing.T, bool, string, string, string) {
 	return t, exp.Equal(got), "expected:\t%v\ngot:\t\t%v", exp.String(), got.String()
 }
+
+func MinInt64(i1, i2 int64) int64 {
+	if i1 < i2 {
+		return i1
+	} else {
+		return i2
+	}
+}

--- a/x/auth/account_test.go
+++ b/x/auth/account_test.go
@@ -56,7 +56,7 @@ func TestBaseAccountCoins(t *testing.T) {
 	_, _, addr := keyPubAddr()
 	acc := NewBaseAccountWithAddress(addr)
 
-	someCoins := sdk.Coins{sdk.NewInt64Coin("atom", 123), sdk.NewInt64Coin("eth", 246)}
+	someCoins := sdk.Coins{sdk.NewCoin("atom", 123), sdk.NewCoin("eth", 246)}
 
 	err := acc.SetCoins(someCoins)
 	require.Nil(t, err)
@@ -78,7 +78,7 @@ func TestBaseAccountMarshal(t *testing.T) {
 	_, pub, addr := keyPubAddr()
 	acc := NewBaseAccountWithAddress(addr)
 
-	someCoins := sdk.Coins{sdk.NewInt64Coin("atom", 123), sdk.NewInt64Coin("eth", 246)}
+	someCoins := sdk.Coins{sdk.NewCoin("atom", 123), sdk.NewCoin("eth", 246)}
 	seq := int64(7)
 
 	// set everything on the account

--- a/x/auth/ante_test.go
+++ b/x/auth/ante_test.go
@@ -19,7 +19,7 @@ func newTestMsg(addrs ...sdk.AccAddress) *sdk.TestMsg {
 
 func newCoins() sdk.Coins {
 	return sdk.Coins{
-		sdk.NewInt64Coin("atom", 10000000),
+		sdk.NewCoin("atom", 10000000),
 	}
 }
 

--- a/x/bank/app_test.go
+++ b/x/bank/app_test.go
@@ -40,9 +40,9 @@ var (
 	priv4 = ed25519.GenPrivKey()
 	addr4 = sdk.AccAddress(priv4.PubKey().Address())
 
-	coins     = sdk.Coins{sdk.NewInt64Coin("foocoin", 10)}
-	halfCoins = sdk.Coins{sdk.NewInt64Coin("foocoin", 5)}
-	manyCoins = sdk.Coins{sdk.NewInt64Coin("foocoin", 1), sdk.NewInt64Coin("barcoin", 1)}
+	coins     = sdk.Coins{sdk.NewCoin("foocoin", 10)}
+	halfCoins = sdk.Coins{sdk.NewCoin("foocoin", 5)}
+	manyCoins = sdk.Coins{sdk.NewCoin("foocoin", 1), sdk.NewCoin("barcoin", 1)}
 
 	sendMsg1 = MsgSend{
 		Inputs:  []Input{NewInput(addr1, coins)},
@@ -94,7 +94,7 @@ func TestMsgSendWithAccounts(t *testing.T) {
 	mapp := getMockApp(t)
 	acc := &auth.BaseAccount{
 		Address: addr1,
-		Coins:   sdk.Coins{sdk.NewInt64Coin("foocoin", 67)},
+		Coins:   sdk.Coins{sdk.NewCoin("foocoin", 67)},
 	}
 
 	mock.SetGenesis(mapp, []auth.Account{acc})
@@ -114,8 +114,8 @@ func TestMsgSendWithAccounts(t *testing.T) {
 			expPass:    true,
 			privKeys:   []crypto.PrivKey{priv1},
 			expectedBalances: []expectedBalance{
-				{addr1, sdk.Coins{sdk.NewInt64Coin("foocoin", 57)}},
-				{addr2, sdk.Coins{sdk.NewInt64Coin("foocoin", 10)}},
+				{addr1, sdk.Coins{sdk.NewCoin("foocoin", 57)}},
+				{addr2, sdk.Coins{sdk.NewCoin("foocoin", 10)}},
 			},
 		},
 		{
@@ -154,11 +154,11 @@ func TestMsgSendMultipleOut(t *testing.T) {
 
 	acc1 := &auth.BaseAccount{
 		Address: addr1,
-		Coins:   sdk.Coins{sdk.NewInt64Coin("foocoin", 42)},
+		Coins:   sdk.Coins{sdk.NewCoin("foocoin", 42)},
 	}
 	acc2 := &auth.BaseAccount{
 		Address: addr2,
-		Coins:   sdk.Coins{sdk.NewInt64Coin("foocoin", 42)},
+		Coins:   sdk.Coins{sdk.NewCoin("foocoin", 42)},
 	}
 
 	mock.SetGenesis(mapp, []auth.Account{acc1, acc2})
@@ -172,9 +172,9 @@ func TestMsgSendMultipleOut(t *testing.T) {
 			expPass:    true,
 			privKeys:   []crypto.PrivKey{priv1},
 			expectedBalances: []expectedBalance{
-				{addr1, sdk.Coins{sdk.NewInt64Coin("foocoin", 32)}},
-				{addr2, sdk.Coins{sdk.NewInt64Coin("foocoin", 47)}},
-				{addr3, sdk.Coins{sdk.NewInt64Coin("foocoin", 5)}},
+				{addr1, sdk.Coins{sdk.NewCoin("foocoin", 32)}},
+				{addr2, sdk.Coins{sdk.NewCoin("foocoin", 47)}},
+				{addr3, sdk.Coins{sdk.NewCoin("foocoin", 5)}},
 			},
 		},
 	}
@@ -193,15 +193,15 @@ func TestSengMsgMultipleInOut(t *testing.T) {
 
 	acc1 := &auth.BaseAccount{
 		Address: addr1,
-		Coins:   sdk.Coins{sdk.NewInt64Coin("foocoin", 42)},
+		Coins:   sdk.Coins{sdk.NewCoin("foocoin", 42)},
 	}
 	acc2 := &auth.BaseAccount{
 		Address: addr2,
-		Coins:   sdk.Coins{sdk.NewInt64Coin("foocoin", 42)},
+		Coins:   sdk.Coins{sdk.NewCoin("foocoin", 42)},
 	}
 	acc4 := &auth.BaseAccount{
 		Address: addr4,
-		Coins:   sdk.Coins{sdk.NewInt64Coin("foocoin", 42)},
+		Coins:   sdk.Coins{sdk.NewCoin("foocoin", 42)},
 	}
 
 	mock.SetGenesis(mapp, []auth.Account{acc1, acc2, acc4})
@@ -215,10 +215,10 @@ func TestSengMsgMultipleInOut(t *testing.T) {
 			expPass:    true,
 			privKeys:   []crypto.PrivKey{priv1, priv4},
 			expectedBalances: []expectedBalance{
-				{addr1, sdk.Coins{sdk.NewInt64Coin("foocoin", 32)}},
-				{addr4, sdk.Coins{sdk.NewInt64Coin("foocoin", 32)}},
-				{addr2, sdk.Coins{sdk.NewInt64Coin("foocoin", 52)}},
-				{addr3, sdk.Coins{sdk.NewInt64Coin("foocoin", 10)}},
+				{addr1, sdk.Coins{sdk.NewCoin("foocoin", 32)}},
+				{addr4, sdk.Coins{sdk.NewCoin("foocoin", 32)}},
+				{addr2, sdk.Coins{sdk.NewCoin("foocoin", 52)}},
+				{addr3, sdk.Coins{sdk.NewCoin("foocoin", 10)}},
 			},
 		},
 	}
@@ -237,7 +237,7 @@ func TestMsgSendDependent(t *testing.T) {
 
 	acc1 := &auth.BaseAccount{
 		Address: addr1,
-		Coins:   sdk.Coins{sdk.NewInt64Coin("foocoin", 42)},
+		Coins:   sdk.Coins{sdk.NewCoin("foocoin", 42)},
 	}
 
 	mock.SetGenesis(mapp, []auth.Account{acc1})
@@ -251,8 +251,8 @@ func TestMsgSendDependent(t *testing.T) {
 			expPass:    true,
 			privKeys:   []crypto.PrivKey{priv1},
 			expectedBalances: []expectedBalance{
-				{addr1, sdk.Coins{sdk.NewInt64Coin("foocoin", 32)}},
-				{addr2, sdk.Coins{sdk.NewInt64Coin("foocoin", 10)}},
+				{addr1, sdk.Coins{sdk.NewCoin("foocoin", 32)}},
+				{addr2, sdk.Coins{sdk.NewCoin("foocoin", 10)}},
 			},
 		},
 		{
@@ -263,7 +263,7 @@ func TestMsgSendDependent(t *testing.T) {
 			expPass:    true,
 			privKeys:   []crypto.PrivKey{priv2},
 			expectedBalances: []expectedBalance{
-				{addr1, sdk.Coins{sdk.NewInt64Coin("foocoin", 42)}},
+				{addr1, sdk.Coins{sdk.NewCoin("foocoin", 42)}},
 			},
 		},
 	}

--- a/x/bank/bench_test.go
+++ b/x/bank/bench_test.go
@@ -30,7 +30,7 @@ func BenchmarkOneBankSendTxPerBlock(b *testing.B) {
 	acc := &auth.BaseAccount{
 		Address: addr1,
 		// Some value conceivably higher than the benchmarks would ever go
-		Coins: sdk.Coins{sdk.NewInt64Coin("foocoin", 100000000000)},
+		Coins: sdk.Coins{sdk.NewCoin("foocoin", 100000000000)},
 	}
 	accs := []auth.Account{acc}
 

--- a/x/bank/keeper_test.go
+++ b/x/bank/keeper_test.go
@@ -45,69 +45,69 @@ func TestKeeper(t *testing.T) {
 	accountKeeper.SetAccount(ctx, acc)
 	require.True(t, bankKeeper.GetCoins(ctx, addr).IsEqual(sdk.Coins{}))
 
-	bankKeeper.SetCoins(ctx, addr, sdk.Coins{sdk.NewInt64Coin("foocoin", 10)})
-	require.True(t, bankKeeper.GetCoins(ctx, addr).IsEqual(sdk.Coins{sdk.NewInt64Coin("foocoin", 10)}))
+	bankKeeper.SetCoins(ctx, addr, sdk.Coins{sdk.NewCoin("foocoin", 10)})
+	require.True(t, bankKeeper.GetCoins(ctx, addr).IsEqual(sdk.Coins{sdk.NewCoin("foocoin", 10)}))
 
 	// Test HasCoins
-	require.True(t, bankKeeper.HasCoins(ctx, addr, sdk.Coins{sdk.NewInt64Coin("foocoin", 10)}))
-	require.True(t, bankKeeper.HasCoins(ctx, addr, sdk.Coins{sdk.NewInt64Coin("foocoin", 5)}))
-	require.False(t, bankKeeper.HasCoins(ctx, addr, sdk.Coins{sdk.NewInt64Coin("foocoin", 15)}))
-	require.False(t, bankKeeper.HasCoins(ctx, addr, sdk.Coins{sdk.NewInt64Coin("barcoin", 5)}))
+	require.True(t, bankKeeper.HasCoins(ctx, addr, sdk.Coins{sdk.NewCoin("foocoin", 10)}))
+	require.True(t, bankKeeper.HasCoins(ctx, addr, sdk.Coins{sdk.NewCoin("foocoin", 5)}))
+	require.False(t, bankKeeper.HasCoins(ctx, addr, sdk.Coins{sdk.NewCoin("foocoin", 15)}))
+	require.False(t, bankKeeper.HasCoins(ctx, addr, sdk.Coins{sdk.NewCoin("barcoin", 5)}))
 
 	// Test AddCoins
-	bankKeeper.AddCoins(ctx, addr, sdk.Coins{sdk.NewInt64Coin("foocoin", 15)})
-	require.True(t, bankKeeper.GetCoins(ctx, addr).IsEqual(sdk.Coins{sdk.NewInt64Coin("foocoin", 25)}))
+	bankKeeper.AddCoins(ctx, addr, sdk.Coins{sdk.NewCoin("foocoin", 15)})
+	require.True(t, bankKeeper.GetCoins(ctx, addr).IsEqual(sdk.Coins{sdk.NewCoin("foocoin", 25)}))
 
-	bankKeeper.AddCoins(ctx, addr, sdk.Coins{sdk.NewInt64Coin("barcoin", 15)})
-	require.True(t, bankKeeper.GetCoins(ctx, addr).IsEqual(sdk.Coins{sdk.NewInt64Coin("barcoin", 15), sdk.NewInt64Coin("foocoin", 25)}))
+	bankKeeper.AddCoins(ctx, addr, sdk.Coins{sdk.NewCoin("barcoin", 15)})
+	require.True(t, bankKeeper.GetCoins(ctx, addr).IsEqual(sdk.Coins{sdk.NewCoin("barcoin", 15), sdk.NewCoin("foocoin", 25)}))
 
 	// Test SubtractCoins
-	bankKeeper.SubtractCoins(ctx, addr, sdk.Coins{sdk.NewInt64Coin("foocoin", 10)})
-	bankKeeper.SubtractCoins(ctx, addr, sdk.Coins{sdk.NewInt64Coin("barcoin", 5)})
-	require.True(t, bankKeeper.GetCoins(ctx, addr).IsEqual(sdk.Coins{sdk.NewInt64Coin("barcoin", 10), sdk.NewInt64Coin("foocoin", 15)}))
+	bankKeeper.SubtractCoins(ctx, addr, sdk.Coins{sdk.NewCoin("foocoin", 10)})
+	bankKeeper.SubtractCoins(ctx, addr, sdk.Coins{sdk.NewCoin("barcoin", 5)})
+	require.True(t, bankKeeper.GetCoins(ctx, addr).IsEqual(sdk.Coins{sdk.NewCoin("barcoin", 10), sdk.NewCoin("foocoin", 15)}))
 
-	bankKeeper.SubtractCoins(ctx, addr, sdk.Coins{sdk.NewInt64Coin("barcoin", 11)})
-	require.True(t, bankKeeper.GetCoins(ctx, addr).IsEqual(sdk.Coins{sdk.NewInt64Coin("barcoin", 10), sdk.NewInt64Coin("foocoin", 15)}))
+	bankKeeper.SubtractCoins(ctx, addr, sdk.Coins{sdk.NewCoin("barcoin", 11)})
+	require.True(t, bankKeeper.GetCoins(ctx, addr).IsEqual(sdk.Coins{sdk.NewCoin("barcoin", 10), sdk.NewCoin("foocoin", 15)}))
 
-	bankKeeper.SubtractCoins(ctx, addr, sdk.Coins{sdk.NewInt64Coin("barcoin", 10)})
-	require.True(t, bankKeeper.GetCoins(ctx, addr).IsEqual(sdk.Coins{sdk.NewInt64Coin("foocoin", 15)}))
-	require.False(t, bankKeeper.HasCoins(ctx, addr, sdk.Coins{sdk.NewInt64Coin("barcoin", 1)}))
+	bankKeeper.SubtractCoins(ctx, addr, sdk.Coins{sdk.NewCoin("barcoin", 10)})
+	require.True(t, bankKeeper.GetCoins(ctx, addr).IsEqual(sdk.Coins{sdk.NewCoin("foocoin", 15)}))
+	require.False(t, bankKeeper.HasCoins(ctx, addr, sdk.Coins{sdk.NewCoin("barcoin", 1)}))
 
 	// Test SendCoins
-	bankKeeper.SendCoins(ctx, addr, addr2, sdk.Coins{sdk.NewInt64Coin("foocoin", 5)})
-	require.True(t, bankKeeper.GetCoins(ctx, addr).IsEqual(sdk.Coins{sdk.NewInt64Coin("foocoin", 10)}))
-	require.True(t, bankKeeper.GetCoins(ctx, addr2).IsEqual(sdk.Coins{sdk.NewInt64Coin("foocoin", 5)}))
+	bankKeeper.SendCoins(ctx, addr, addr2, sdk.Coins{sdk.NewCoin("foocoin", 5)})
+	require.True(t, bankKeeper.GetCoins(ctx, addr).IsEqual(sdk.Coins{sdk.NewCoin("foocoin", 10)}))
+	require.True(t, bankKeeper.GetCoins(ctx, addr2).IsEqual(sdk.Coins{sdk.NewCoin("foocoin", 5)}))
 
-	_, err2 := bankKeeper.SendCoins(ctx, addr, addr2, sdk.Coins{sdk.NewInt64Coin("foocoin", 50)})
+	_, err2 := bankKeeper.SendCoins(ctx, addr, addr2, sdk.Coins{sdk.NewCoin("foocoin", 50)})
 	assert.Implements(t, (*sdk.Error)(nil), err2)
-	require.True(t, bankKeeper.GetCoins(ctx, addr).IsEqual(sdk.Coins{sdk.NewInt64Coin("foocoin", 10)}))
-	require.True(t, bankKeeper.GetCoins(ctx, addr2).IsEqual(sdk.Coins{sdk.NewInt64Coin("foocoin", 5)}))
+	require.True(t, bankKeeper.GetCoins(ctx, addr).IsEqual(sdk.Coins{sdk.NewCoin("foocoin", 10)}))
+	require.True(t, bankKeeper.GetCoins(ctx, addr2).IsEqual(sdk.Coins{sdk.NewCoin("foocoin", 5)}))
 
-	bankKeeper.AddCoins(ctx, addr, sdk.Coins{sdk.NewInt64Coin("barcoin", 30)})
-	bankKeeper.SendCoins(ctx, addr, addr2, sdk.Coins{sdk.NewInt64Coin("barcoin", 10), sdk.NewInt64Coin("foocoin", 5)})
-	require.True(t, bankKeeper.GetCoins(ctx, addr).IsEqual(sdk.Coins{sdk.NewInt64Coin("barcoin", 20), sdk.NewInt64Coin("foocoin", 5)}))
-	require.True(t, bankKeeper.GetCoins(ctx, addr2).IsEqual(sdk.Coins{sdk.NewInt64Coin("barcoin", 10), sdk.NewInt64Coin("foocoin", 10)}))
+	bankKeeper.AddCoins(ctx, addr, sdk.Coins{sdk.NewCoin("barcoin", 30)})
+	bankKeeper.SendCoins(ctx, addr, addr2, sdk.Coins{sdk.NewCoin("barcoin", 10), sdk.NewCoin("foocoin", 5)})
+	require.True(t, bankKeeper.GetCoins(ctx, addr).IsEqual(sdk.Coins{sdk.NewCoin("barcoin", 20), sdk.NewCoin("foocoin", 5)}))
+	require.True(t, bankKeeper.GetCoins(ctx, addr2).IsEqual(sdk.Coins{sdk.NewCoin("barcoin", 10), sdk.NewCoin("foocoin", 10)}))
 
 	// Test InputOutputCoins
-	input1 := NewInput(addr2, sdk.Coins{sdk.NewInt64Coin("foocoin", 2)})
-	output1 := NewOutput(addr, sdk.Coins{sdk.NewInt64Coin("foocoin", 2)})
+	input1 := NewInput(addr2, sdk.Coins{sdk.NewCoin("foocoin", 2)})
+	output1 := NewOutput(addr, sdk.Coins{sdk.NewCoin("foocoin", 2)})
 	bankKeeper.InputOutputCoins(ctx, []Input{input1}, []Output{output1})
-	require.True(t, bankKeeper.GetCoins(ctx, addr).IsEqual(sdk.Coins{sdk.NewInt64Coin("barcoin", 20), sdk.NewInt64Coin("foocoin", 7)}))
-	require.True(t, bankKeeper.GetCoins(ctx, addr2).IsEqual(sdk.Coins{sdk.NewInt64Coin("barcoin", 10), sdk.NewInt64Coin("foocoin", 8)}))
+	require.True(t, bankKeeper.GetCoins(ctx, addr).IsEqual(sdk.Coins{sdk.NewCoin("barcoin", 20), sdk.NewCoin("foocoin", 7)}))
+	require.True(t, bankKeeper.GetCoins(ctx, addr2).IsEqual(sdk.Coins{sdk.NewCoin("barcoin", 10), sdk.NewCoin("foocoin", 8)}))
 
 	inputs := []Input{
-		NewInput(addr, sdk.Coins{sdk.NewInt64Coin("foocoin", 3)}),
-		NewInput(addr2, sdk.Coins{sdk.NewInt64Coin("barcoin", 3), sdk.NewInt64Coin("foocoin", 2)}),
+		NewInput(addr, sdk.Coins{sdk.NewCoin("foocoin", 3)}),
+		NewInput(addr2, sdk.Coins{sdk.NewCoin("barcoin", 3), sdk.NewCoin("foocoin", 2)}),
 	}
 
 	outputs := []Output{
-		NewOutput(addr, sdk.Coins{sdk.NewInt64Coin("barcoin", 1)}),
-		NewOutput(addr3, sdk.Coins{sdk.NewInt64Coin("barcoin", 2), sdk.NewInt64Coin("foocoin", 5)}),
+		NewOutput(addr, sdk.Coins{sdk.NewCoin("barcoin", 1)}),
+		NewOutput(addr3, sdk.Coins{sdk.NewCoin("barcoin", 2), sdk.NewCoin("foocoin", 5)}),
 	}
 	bankKeeper.InputOutputCoins(ctx, inputs, outputs)
-	require.True(t, bankKeeper.GetCoins(ctx, addr).IsEqual(sdk.Coins{sdk.NewInt64Coin("barcoin", 21), sdk.NewInt64Coin("foocoin", 4)}))
-	require.True(t, bankKeeper.GetCoins(ctx, addr2).IsEqual(sdk.Coins{sdk.NewInt64Coin("barcoin", 7), sdk.NewInt64Coin("foocoin", 6)}))
-	require.True(t, bankKeeper.GetCoins(ctx, addr3).IsEqual(sdk.Coins{sdk.NewInt64Coin("barcoin", 2), sdk.NewInt64Coin("foocoin", 5)}))
+	require.True(t, bankKeeper.GetCoins(ctx, addr).IsEqual(sdk.Coins{sdk.NewCoin("barcoin", 21), sdk.NewCoin("foocoin", 4)}))
+	require.True(t, bankKeeper.GetCoins(ctx, addr2).IsEqual(sdk.Coins{sdk.NewCoin("barcoin", 7), sdk.NewCoin("foocoin", 6)}))
+	require.True(t, bankKeeper.GetCoins(ctx, addr3).IsEqual(sdk.Coins{sdk.NewCoin("barcoin", 2), sdk.NewCoin("foocoin", 5)}))
 
 }
 
@@ -131,52 +131,52 @@ func TestSendKeeper(t *testing.T) {
 	accountKeeper.SetAccount(ctx, acc)
 	require.True(t, sendKeeper.GetCoins(ctx, addr).IsEqual(sdk.Coins{}))
 
-	bankKeeper.SetCoins(ctx, addr, sdk.Coins{sdk.NewInt64Coin("foocoin", 10)})
-	require.True(t, sendKeeper.GetCoins(ctx, addr).IsEqual(sdk.Coins{sdk.NewInt64Coin("foocoin", 10)}))
+	bankKeeper.SetCoins(ctx, addr, sdk.Coins{sdk.NewCoin("foocoin", 10)})
+	require.True(t, sendKeeper.GetCoins(ctx, addr).IsEqual(sdk.Coins{sdk.NewCoin("foocoin", 10)}))
 
 	// Test HasCoins
-	require.True(t, sendKeeper.HasCoins(ctx, addr, sdk.Coins{sdk.NewInt64Coin("foocoin", 10)}))
-	require.True(t, sendKeeper.HasCoins(ctx, addr, sdk.Coins{sdk.NewInt64Coin("foocoin", 5)}))
-	require.False(t, sendKeeper.HasCoins(ctx, addr, sdk.Coins{sdk.NewInt64Coin("foocoin", 15)}))
-	require.False(t, sendKeeper.HasCoins(ctx, addr, sdk.Coins{sdk.NewInt64Coin("barcoin", 5)}))
+	require.True(t, sendKeeper.HasCoins(ctx, addr, sdk.Coins{sdk.NewCoin("foocoin", 10)}))
+	require.True(t, sendKeeper.HasCoins(ctx, addr, sdk.Coins{sdk.NewCoin("foocoin", 5)}))
+	require.False(t, sendKeeper.HasCoins(ctx, addr, sdk.Coins{sdk.NewCoin("foocoin", 15)}))
+	require.False(t, sendKeeper.HasCoins(ctx, addr, sdk.Coins{sdk.NewCoin("barcoin", 5)}))
 
-	bankKeeper.SetCoins(ctx, addr, sdk.Coins{sdk.NewInt64Coin("foocoin", 15)})
+	bankKeeper.SetCoins(ctx, addr, sdk.Coins{sdk.NewCoin("foocoin", 15)})
 
 	// Test SendCoins
-	sendKeeper.SendCoins(ctx, addr, addr2, sdk.Coins{sdk.NewInt64Coin("foocoin", 5)})
-	require.True(t, sendKeeper.GetCoins(ctx, addr).IsEqual(sdk.Coins{sdk.NewInt64Coin("foocoin", 10)}))
-	require.True(t, sendKeeper.GetCoins(ctx, addr2).IsEqual(sdk.Coins{sdk.NewInt64Coin("foocoin", 5)}))
+	sendKeeper.SendCoins(ctx, addr, addr2, sdk.Coins{sdk.NewCoin("foocoin", 5)})
+	require.True(t, sendKeeper.GetCoins(ctx, addr).IsEqual(sdk.Coins{sdk.NewCoin("foocoin", 10)}))
+	require.True(t, sendKeeper.GetCoins(ctx, addr2).IsEqual(sdk.Coins{sdk.NewCoin("foocoin", 5)}))
 
-	_, err2 := sendKeeper.SendCoins(ctx, addr, addr2, sdk.Coins{sdk.NewInt64Coin("foocoin", 50)})
+	_, err2 := sendKeeper.SendCoins(ctx, addr, addr2, sdk.Coins{sdk.NewCoin("foocoin", 50)})
 	assert.Implements(t, (*sdk.Error)(nil), err2)
-	require.True(t, sendKeeper.GetCoins(ctx, addr).IsEqual(sdk.Coins{sdk.NewInt64Coin("foocoin", 10)}))
-	require.True(t, sendKeeper.GetCoins(ctx, addr2).IsEqual(sdk.Coins{sdk.NewInt64Coin("foocoin", 5)}))
+	require.True(t, sendKeeper.GetCoins(ctx, addr).IsEqual(sdk.Coins{sdk.NewCoin("foocoin", 10)}))
+	require.True(t, sendKeeper.GetCoins(ctx, addr2).IsEqual(sdk.Coins{sdk.NewCoin("foocoin", 5)}))
 
-	bankKeeper.AddCoins(ctx, addr, sdk.Coins{sdk.NewInt64Coin("barcoin", 30)})
-	sendKeeper.SendCoins(ctx, addr, addr2, sdk.Coins{sdk.NewInt64Coin("barcoin", 10), sdk.NewInt64Coin("foocoin", 5)})
-	require.True(t, sendKeeper.GetCoins(ctx, addr).IsEqual(sdk.Coins{sdk.NewInt64Coin("barcoin", 20), sdk.NewInt64Coin("foocoin", 5)}))
-	require.True(t, sendKeeper.GetCoins(ctx, addr2).IsEqual(sdk.Coins{sdk.NewInt64Coin("barcoin", 10), sdk.NewInt64Coin("foocoin", 10)}))
+	bankKeeper.AddCoins(ctx, addr, sdk.Coins{sdk.NewCoin("barcoin", 30)})
+	sendKeeper.SendCoins(ctx, addr, addr2, sdk.Coins{sdk.NewCoin("barcoin", 10), sdk.NewCoin("foocoin", 5)})
+	require.True(t, sendKeeper.GetCoins(ctx, addr).IsEqual(sdk.Coins{sdk.NewCoin("barcoin", 20), sdk.NewCoin("foocoin", 5)}))
+	require.True(t, sendKeeper.GetCoins(ctx, addr2).IsEqual(sdk.Coins{sdk.NewCoin("barcoin", 10), sdk.NewCoin("foocoin", 10)}))
 
 	// Test InputOutputCoins
-	input1 := NewInput(addr2, sdk.Coins{sdk.NewInt64Coin("foocoin", 2)})
-	output1 := NewOutput(addr, sdk.Coins{sdk.NewInt64Coin("foocoin", 2)})
+	input1 := NewInput(addr2, sdk.Coins{sdk.NewCoin("foocoin", 2)})
+	output1 := NewOutput(addr, sdk.Coins{sdk.NewCoin("foocoin", 2)})
 	sendKeeper.InputOutputCoins(ctx, []Input{input1}, []Output{output1})
-	require.True(t, sendKeeper.GetCoins(ctx, addr).IsEqual(sdk.Coins{sdk.NewInt64Coin("barcoin", 20), sdk.NewInt64Coin("foocoin", 7)}))
-	require.True(t, sendKeeper.GetCoins(ctx, addr2).IsEqual(sdk.Coins{sdk.NewInt64Coin("barcoin", 10), sdk.NewInt64Coin("foocoin", 8)}))
+	require.True(t, sendKeeper.GetCoins(ctx, addr).IsEqual(sdk.Coins{sdk.NewCoin("barcoin", 20), sdk.NewCoin("foocoin", 7)}))
+	require.True(t, sendKeeper.GetCoins(ctx, addr2).IsEqual(sdk.Coins{sdk.NewCoin("barcoin", 10), sdk.NewCoin("foocoin", 8)}))
 
 	inputs := []Input{
-		NewInput(addr, sdk.Coins{sdk.NewInt64Coin("foocoin", 3)}),
-		NewInput(addr2, sdk.Coins{sdk.NewInt64Coin("barcoin", 3), sdk.NewInt64Coin("foocoin", 2)}),
+		NewInput(addr, sdk.Coins{sdk.NewCoin("foocoin", 3)}),
+		NewInput(addr2, sdk.Coins{sdk.NewCoin("barcoin", 3), sdk.NewCoin("foocoin", 2)}),
 	}
 
 	outputs := []Output{
-		NewOutput(addr, sdk.Coins{sdk.NewInt64Coin("barcoin", 1)}),
-		NewOutput(addr3, sdk.Coins{sdk.NewInt64Coin("barcoin", 2), sdk.NewInt64Coin("foocoin", 5)}),
+		NewOutput(addr, sdk.Coins{sdk.NewCoin("barcoin", 1)}),
+		NewOutput(addr3, sdk.Coins{sdk.NewCoin("barcoin", 2), sdk.NewCoin("foocoin", 5)}),
 	}
 	sendKeeper.InputOutputCoins(ctx, inputs, outputs)
-	require.True(t, sendKeeper.GetCoins(ctx, addr).IsEqual(sdk.Coins{sdk.NewInt64Coin("barcoin", 21), sdk.NewInt64Coin("foocoin", 4)}))
-	require.True(t, sendKeeper.GetCoins(ctx, addr2).IsEqual(sdk.Coins{sdk.NewInt64Coin("barcoin", 7), sdk.NewInt64Coin("foocoin", 6)}))
-	require.True(t, sendKeeper.GetCoins(ctx, addr3).IsEqual(sdk.Coins{sdk.NewInt64Coin("barcoin", 2), sdk.NewInt64Coin("foocoin", 5)}))
+	require.True(t, sendKeeper.GetCoins(ctx, addr).IsEqual(sdk.Coins{sdk.NewCoin("barcoin", 21), sdk.NewCoin("foocoin", 4)}))
+	require.True(t, sendKeeper.GetCoins(ctx, addr2).IsEqual(sdk.Coins{sdk.NewCoin("barcoin", 7), sdk.NewCoin("foocoin", 6)}))
+	require.True(t, sendKeeper.GetCoins(ctx, addr3).IsEqual(sdk.Coins{sdk.NewCoin("barcoin", 2), sdk.NewCoin("foocoin", 5)}))
 
 }
 
@@ -198,12 +198,12 @@ func TestViewKeeper(t *testing.T) {
 	accountKeeper.SetAccount(ctx, acc)
 	require.True(t, viewKeeper.GetCoins(ctx, addr).IsEqual(sdk.Coins{}))
 
-	bankKeeper.SetCoins(ctx, addr, sdk.Coins{sdk.NewInt64Coin("foocoin", 10)})
-	require.True(t, viewKeeper.GetCoins(ctx, addr).IsEqual(sdk.Coins{sdk.NewInt64Coin("foocoin", 10)}))
+	bankKeeper.SetCoins(ctx, addr, sdk.Coins{sdk.NewCoin("foocoin", 10)})
+	require.True(t, viewKeeper.GetCoins(ctx, addr).IsEqual(sdk.Coins{sdk.NewCoin("foocoin", 10)}))
 
 	// Test HasCoins
-	require.True(t, viewKeeper.HasCoins(ctx, addr, sdk.Coins{sdk.NewInt64Coin("foocoin", 10)}))
-	require.True(t, viewKeeper.HasCoins(ctx, addr, sdk.Coins{sdk.NewInt64Coin("foocoin", 5)}))
-	require.False(t, viewKeeper.HasCoins(ctx, addr, sdk.Coins{sdk.NewInt64Coin("foocoin", 15)}))
-	require.False(t, viewKeeper.HasCoins(ctx, addr, sdk.Coins{sdk.NewInt64Coin("barcoin", 5)}))
+	require.True(t, viewKeeper.HasCoins(ctx, addr, sdk.Coins{sdk.NewCoin("foocoin", 10)}))
+	require.True(t, viewKeeper.HasCoins(ctx, addr, sdk.Coins{sdk.NewCoin("foocoin", 5)}))
+	require.False(t, viewKeeper.HasCoins(ctx, addr, sdk.Coins{sdk.NewCoin("foocoin", 15)}))
+	require.False(t, viewKeeper.HasCoins(ctx, addr, sdk.Coins{sdk.NewCoin("barcoin", 5)}))
 }

--- a/x/bank/msgs_test.go
+++ b/x/bank/msgs_test.go
@@ -15,7 +15,7 @@ func TestMsgSendRoute(t *testing.T) {
 	// Construct a MsgSend
 	addr1 := sdk.AccAddress([]byte("input"))
 	addr2 := sdk.AccAddress([]byte("output"))
-	coins := sdk.Coins{sdk.NewInt64Coin("atom", 10)}
+	coins := sdk.Coins{sdk.NewCoin("atom", 10)}
 	var msg = MsgSend{
 		Inputs:  []Input{NewInput(addr1, coins)},
 		Outputs: []Output{NewOutput(addr2, coins)},
@@ -28,16 +28,16 @@ func TestMsgSendRoute(t *testing.T) {
 func TestInputValidation(t *testing.T) {
 	addr1 := sdk.AccAddress([]byte{1, 2})
 	addr2 := sdk.AccAddress([]byte{7, 8})
-	someCoins := sdk.Coins{sdk.NewInt64Coin("atom", 123)}
-	multiCoins := sdk.Coins{sdk.NewInt64Coin("atom", 123), sdk.NewInt64Coin("eth", 20)}
+	someCoins := sdk.Coins{sdk.NewCoin("atom", 123)}
+	multiCoins := sdk.Coins{sdk.NewCoin("atom", 123), sdk.NewCoin("eth", 20)}
 
 	var emptyAddr sdk.AccAddress
 	emptyCoins := sdk.Coins{}
-	emptyCoins2 := sdk.Coins{sdk.NewInt64Coin("eth", 0)}
-	someEmptyCoins := sdk.Coins{sdk.NewInt64Coin("eth", 10), sdk.NewInt64Coin("atom", 0)}
-	minusCoins := sdk.Coins{sdk.NewInt64Coin("eth", -34)}
-	someMinusCoins := sdk.Coins{sdk.NewInt64Coin("atom", 20), sdk.NewInt64Coin("eth", -34)}
-	unsortedCoins := sdk.Coins{sdk.NewInt64Coin("eth", 1), sdk.NewInt64Coin("atom", 1)}
+	emptyCoins2 := sdk.Coins{sdk.NewCoin("eth", 0)}
+	someEmptyCoins := sdk.Coins{sdk.NewCoin("eth", 10), sdk.NewCoin("atom", 0)}
+	minusCoins := sdk.Coins{sdk.NewCoin("eth", -34)}
+	someMinusCoins := sdk.Coins{sdk.NewCoin("atom", 20), sdk.NewCoin("eth", -34)}
+	unsortedCoins := sdk.Coins{sdk.NewCoin("eth", 1), sdk.NewCoin("atom", 1)}
 
 	cases := []struct {
 		valid bool
@@ -70,16 +70,16 @@ func TestInputValidation(t *testing.T) {
 func TestOutputValidation(t *testing.T) {
 	addr1 := sdk.AccAddress([]byte{1, 2})
 	addr2 := sdk.AccAddress([]byte{7, 8})
-	someCoins := sdk.Coins{sdk.NewInt64Coin("atom", 123)}
-	multiCoins := sdk.Coins{sdk.NewInt64Coin("atom", 123), sdk.NewInt64Coin("eth", 20)}
+	someCoins := sdk.Coins{sdk.NewCoin("atom", 123)}
+	multiCoins := sdk.Coins{sdk.NewCoin("atom", 123), sdk.NewCoin("eth", 20)}
 
 	var emptyAddr sdk.AccAddress
 	emptyCoins := sdk.Coins{}
-	emptyCoins2 := sdk.Coins{sdk.NewInt64Coin("eth", 0)}
-	someEmptyCoins := sdk.Coins{sdk.NewInt64Coin("eth", 10), sdk.NewInt64Coin("atom", 0)}
-	minusCoins := sdk.Coins{sdk.NewInt64Coin("eth", -34)}
-	someMinusCoins := sdk.Coins{sdk.NewInt64Coin("atom", 20), sdk.NewInt64Coin("eth", -34)}
-	unsortedCoins := sdk.Coins{sdk.NewInt64Coin("eth", 1), sdk.NewInt64Coin("atom", 1)}
+	emptyCoins2 := sdk.Coins{sdk.NewCoin("eth", 0)}
+	someEmptyCoins := sdk.Coins{sdk.NewCoin("eth", 10), sdk.NewCoin("atom", 0)}
+	minusCoins := sdk.Coins{sdk.NewCoin("eth", -34)}
+	someMinusCoins := sdk.Coins{sdk.NewCoin("atom", 20), sdk.NewCoin("eth", -34)}
+	unsortedCoins := sdk.Coins{sdk.NewCoin("eth", 1), sdk.NewCoin("atom", 1)}
 
 	cases := []struct {
 		valid bool
@@ -112,10 +112,10 @@ func TestOutputValidation(t *testing.T) {
 func TestMsgSendValidation(t *testing.T) {
 	addr1 := sdk.AccAddress([]byte{1, 2})
 	addr2 := sdk.AccAddress([]byte{7, 8})
-	atom123 := sdk.Coins{sdk.NewInt64Coin("atom", 123)}
-	atom124 := sdk.Coins{sdk.NewInt64Coin("atom", 124)}
-	eth123 := sdk.Coins{sdk.NewInt64Coin("eth", 123)}
-	atom123eth123 := sdk.Coins{sdk.NewInt64Coin("atom", 123), sdk.NewInt64Coin("eth", 123)}
+	atom123 := sdk.Coins{sdk.NewCoin("atom", 123)}
+	atom124 := sdk.Coins{sdk.NewCoin("atom", 124)}
+	eth123 := sdk.Coins{sdk.NewCoin("eth", 123)}
+	atom123eth123 := sdk.Coins{sdk.NewCoin("atom", 123), sdk.NewCoin("eth", 123)}
 
 	input1 := NewInput(addr1, atom123)
 	input2 := NewInput(addr1, eth123)
@@ -180,7 +180,7 @@ func TestMsgSendValidation(t *testing.T) {
 func TestMsgSendGetSignBytes(t *testing.T) {
 	addr1 := sdk.AccAddress([]byte("input"))
 	addr2 := sdk.AccAddress([]byte("output"))
-	coins := sdk.Coins{sdk.NewInt64Coin("atom", 10)}
+	coins := sdk.Coins{sdk.NewCoin("atom", 10)}
 	var msg = MsgSend{
 		Inputs:  []Input{NewInput(addr1, coins)},
 		Outputs: []Output{NewOutput(addr2, coins)},
@@ -213,7 +213,7 @@ func TestMsgSendSigners(t *testing.T) {
 		{7, 8, 9},
 	}
 
-	someCoins := sdk.Coins{sdk.NewInt64Coin("atom", 123)}
+	someCoins := sdk.Coins{sdk.NewCoin("atom", 123)}
 	inputs := make([]Input, len(signers))
 	for i, signer := range signers {
 		inputs[i] = NewInput(signer, someCoins)
@@ -234,7 +234,7 @@ func TestNewMsgIssue(t *testing.T) {
 func TestMsgIssueRoute(t *testing.T) {
 	// Construct an MsgIssue
 	addr := sdk.AccAddress([]byte("loan-from-bank"))
-	coins := sdk.Coins{sdk.NewInt64Coin("atom", 10)}
+	coins := sdk.Coins{sdk.NewCoin("atom", 10)}
 	var msg = MsgIssue{
 		Banker:  sdk.AccAddress([]byte("input")),
 		Outputs: []Output{NewOutput(addr, coins)},
@@ -250,7 +250,7 @@ func TestMsgIssueValidation(t *testing.T) {
 
 func TestMsgIssueGetSignBytes(t *testing.T) {
 	addr := sdk.AccAddress([]byte("loan-from-bank"))
-	coins := sdk.Coins{sdk.NewInt64Coin("atom", 10)}
+	coins := sdk.Coins{sdk.NewCoin("atom", 10)}
 	var msg = MsgIssue{
 		Banker:  sdk.AccAddress([]byte("input")),
 		Outputs: []Output{NewOutput(addr, coins)},

--- a/x/bank/simulation/msgs.go
+++ b/x/bank/simulation/msgs.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/big"
 	"math/rand"
+	"strconv"
 
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -77,7 +78,7 @@ func createSingleInputSendMsg(r *rand.Rand, ctx sdk.Context, accs []simulation.A
 
 	action = fmt.Sprintf("%s is sending %s %s to %s",
 		fromAcc.Address.String(),
-		amt.String(),
+		strconv.FormatInt(amt, 10),
 		initFromCoins[denomIndex].Denom,
 		toAddr.String(),
 	)
@@ -141,7 +142,16 @@ func sendAndVerifyMsgSend(app *baseapp.BaseApp, mapper auth.AccountKeeper, msg b
 	return nil
 }
 
-func randPositiveInt(r *rand.Rand, max sdk.Int) (sdk.Int, error) {
+func randPositiveInt(r *rand.Rand, max int64) (int64, error) {
+	if max <= 1 {
+		return 0, errors.New("max too small")
+	}
+	max = max - 1
+	r.Int63n(max)
+	return r.Int63n(max) + 1, nil
+}
+
+func randPositiveInt1(r *rand.Rand, max sdk.Int) (sdk.Int, error) {
 	if !max.GT(sdk.OneInt()) {
 		return sdk.Int{}, errors.New("max too small")
 	}

--- a/x/distribution/keeper/allocation_test.go
+++ b/x/distribution/keeper/allocation_test.go
@@ -38,7 +38,7 @@ func TestAllocateTokensBasic(t *testing.T) {
 	require.Nil(t, feePool.Pool)
 
 	// allocate 100 denom of fees
-	feeInputs := sdk.NewInt(100)
+	feeInputs := int64(100)
 	fck.SetCollectedFees(sdk.Coins{sdk.NewCoin(denom, feeInputs)})
 	require.Equal(t, feeInputs, fck.GetCollectedFees(ctx).AmountOf(denom))
 	keeper.AllocateTokens(ctx, sdk.OneDec(), valConsAddr1)
@@ -66,7 +66,7 @@ func TestAllocateTokensWithCommunityTax(t *testing.T) {
 	_ = sk.ApplyAndReturnValidatorSetUpdates(ctx)
 
 	// allocate 100 denom of fees
-	feeInputs := sdk.NewInt(100)
+	feeInputs := int64(100)
 	fck.SetCollectedFees(sdk.Coins{sdk.NewCoin(denom, feeInputs)})
 	keeper.AllocateTokens(ctx, sdk.OneDec(), valConsAddr1)
 
@@ -94,7 +94,7 @@ func TestAllocateTokensWithPartialPrecommitPower(t *testing.T) {
 	_ = sk.ApplyAndReturnValidatorSetUpdates(ctx)
 
 	// allocate 100 denom of fees
-	feeInputs := sdk.NewInt(100)
+	feeInputs := int64(100)
 	fck.SetCollectedFees(sdk.Coins{sdk.NewCoin(denom, feeInputs)})
 	percentPrecommitVotes := sdk.NewDecWithPrec(25, 2)
 	keeper.AllocateTokens(ctx, percentPrecommitVotes, valConsAddr1)

--- a/x/distribution/keeper/delegation_test.go
+++ b/x/distribution/keeper/delegation_test.go
@@ -24,23 +24,23 @@ func TestWithdrawDelegationRewardBasic(t *testing.T) {
 	got = stakeHandler(ctx, msgDelegate)
 	require.True(t, got.IsOK())
 	amt := accMapper.GetAccount(ctx, delAddr1).GetCoins().AmountOf(denom)
-	require.Equal(t, int64(90), amt.Int64())
+	require.Equal(t, int64(90), amt)
 
 	// allocate 100 denom of fees
-	feeInputs := sdk.NewInt(100)
+	feeInputs := int64(100)
 	fck.SetCollectedFees(sdk.Coins{sdk.NewCoin(denom, feeInputs)})
 	require.Equal(t, feeInputs, fck.GetCollectedFees(ctx).AmountOf(denom))
 	keeper.AllocateTokens(ctx, sdk.OneDec(), valConsAddr1)
 
 	// withdraw delegation
 	ctx = ctx.WithBlockHeight(1)
-	sk.SetLastTotalPower(ctx, sdk.NewInt(10))
-	sk.SetLastValidatorPower(ctx, valOpAddr1, sdk.NewInt(10))
+	sk.SetLastTotalPower(ctx, 10)
+	sk.SetLastValidatorPower(ctx, valOpAddr1, int64(10))
 	keeper.WithdrawDelegationReward(ctx, delAddr1, valOpAddr1)
 	amt = accMapper.GetAccount(ctx, delAddr1).GetCoins().AmountOf(denom)
 
 	expRes := sdk.NewDec(90).Add(sdk.NewDec(100).Quo(sdk.NewDec(2))).TruncateInt() // 90 + 100 tokens * 10/20
-	require.True(sdk.IntEq(t, expRes, amt))
+	require.True(t, expRes == amt)
 }
 
 func TestWithdrawDelegationRewardWithCommission(t *testing.T) {
@@ -60,10 +60,10 @@ func TestWithdrawDelegationRewardWithCommission(t *testing.T) {
 	got = stakeHandler(ctx, msgDelegate)
 	require.True(t, got.IsOK())
 	amt := accMapper.GetAccount(ctx, delAddr1).GetCoins().AmountOf(denom)
-	require.Equal(t, int64(90), amt.Int64())
+	require.Equal(t, int64(90), amt)
 
 	// allocate 100 denom of fees
-	feeInputs := sdk.NewInt(100)
+	feeInputs := int64(100)
 	fck.SetCollectedFees(sdk.Coins{sdk.NewCoin(denom, feeInputs)})
 	require.Equal(t, feeInputs, fck.GetCollectedFees(ctx).AmountOf(denom))
 	keeper.AllocateTokens(ctx, sdk.OneDec(), valConsAddr1)
@@ -74,7 +74,7 @@ func TestWithdrawDelegationRewardWithCommission(t *testing.T) {
 	amt = accMapper.GetAccount(ctx, delAddr1).GetCoins().AmountOf(denom)
 
 	expRes := sdk.NewDec(90).Add(sdk.NewDec(90).Quo(sdk.NewDec(2))).TruncateInt() // 90 + 100*90% tokens * 10/20
-	require.True(sdk.IntEq(t, expRes, amt))
+	require.True(t, expRes == amt)
 }
 
 func TestWithdrawDelegationRewardTwoDelegators(t *testing.T) {
@@ -94,16 +94,16 @@ func TestWithdrawDelegationRewardTwoDelegators(t *testing.T) {
 	got = stakeHandler(ctx, msgDelegate)
 	require.True(t, got.IsOK())
 	amt := accMapper.GetAccount(ctx, delAddr1).GetCoins().AmountOf(denom)
-	require.Equal(t, int64(90), amt.Int64())
+	require.Equal(t, int64(90), amt)
 
 	msgDelegate = stake.NewTestMsgDelegate(delAddr2, valOpAddr1, 20)
 	got = stakeHandler(ctx, msgDelegate)
 	require.True(t, got.IsOK())
 	amt = accMapper.GetAccount(ctx, delAddr2).GetCoins().AmountOf(denom)
-	require.Equal(t, int64(80), amt.Int64())
+	require.Equal(t, int64(80), amt)
 
 	// allocate 100 denom of fees
-	feeInputs := sdk.NewInt(100)
+	feeInputs := int64(100)
 	fck.SetCollectedFees(sdk.Coins{sdk.NewCoin(denom, feeInputs)})
 	require.Equal(t, feeInputs, fck.GetCollectedFees(ctx).AmountOf(denom))
 	keeper.AllocateTokens(ctx, sdk.OneDec(), valConsAddr1)
@@ -114,7 +114,7 @@ func TestWithdrawDelegationRewardTwoDelegators(t *testing.T) {
 	amt = accMapper.GetAccount(ctx, delAddr1).GetCoins().AmountOf(denom)
 
 	expRes := sdk.NewDec(90).Add(sdk.NewDec(90).Quo(sdk.NewDec(4))).TruncateInt() // 90 + 100*90% tokens * 10/40
-	require.True(sdk.IntEq(t, expRes, amt))
+	require.True(t, expRes == amt)
 }
 
 // this test demonstrates how two delegators with the same power can end up
@@ -136,16 +136,16 @@ func TestWithdrawDelegationRewardTwoDelegatorsUneven(t *testing.T) {
 	got = stakeHandler(ctx, msgDelegate)
 	require.True(t, got.IsOK())
 	amt := accMapper.GetAccount(ctx, delAddr1).GetCoins().AmountOf(denom)
-	require.Equal(t, int64(90), amt.Int64())
+	require.Equal(t, int64(90), amt)
 
 	msgDelegate = stake.NewTestMsgDelegate(delAddr2, valOpAddr1, 10)
 	got = stakeHandler(ctx, msgDelegate)
 	require.True(t, got.IsOK())
 	amt = accMapper.GetAccount(ctx, delAddr2).GetCoins().AmountOf(denom)
-	require.Equal(t, int64(90), amt.Int64())
+	require.Equal(t, int64(90), amt)
 
 	// allocate 100 denom of fees
-	feeInputs := sdk.NewInt(90)
+	feeInputs := int64(90)
 	fck.SetCollectedFees(sdk.Coins{sdk.NewCoin(denom, feeInputs)})
 	require.Equal(t, feeInputs, fck.GetCollectedFees(ctx).AmountOf(denom))
 	keeper.AllocateTokens(ctx, sdk.OneDec(), valConsAddr1)
@@ -156,10 +156,10 @@ func TestWithdrawDelegationRewardTwoDelegatorsUneven(t *testing.T) {
 	amt = accMapper.GetAccount(ctx, delAddr1).GetCoins().AmountOf(denom)
 
 	expRes1 := sdk.NewDec(90).Add(sdk.NewDec(90).Quo(sdk.NewDec(3))).TruncateInt() // 90 + 100 * 10/30
-	require.True(sdk.IntEq(t, expRes1, amt))
+	require.True(t, expRes1 == amt)
 
 	// allocate 200 denom of fees
-	feeInputs = sdk.NewInt(180)
+	feeInputs = int64(180)
 	fck.SetCollectedFees(sdk.Coins{sdk.NewCoin(denom, feeInputs)})
 	require.Equal(t, feeInputs, fck.GetCollectedFees(ctx).AmountOf(denom))
 	keeper.AllocateTokens(ctx, sdk.OneDec(), valConsAddr1)
@@ -171,7 +171,7 @@ func TestWithdrawDelegationRewardTwoDelegatorsUneven(t *testing.T) {
 	// existingTokens + (100+200 * (10/(20+30))
 	withdrawnFromVal := sdk.NewDec(60 + 180).Mul(sdk.NewDec(2)).Quo(sdk.NewDec(5))
 	expRes2 := sdk.NewDec(90).Add(withdrawnFromVal).TruncateInt()
-	require.True(sdk.IntEq(t, expRes2, amt))
+	require.True(t, expRes2 == amt)
 
 	// finally delegator 1 withdraws the remainder of its reward
 	keeper.WithdrawDelegationReward(ctx, delAddr1, valOpAddr1)
@@ -179,10 +179,10 @@ func TestWithdrawDelegationRewardTwoDelegatorsUneven(t *testing.T) {
 
 	remainingInVal := sdk.NewDec(60 + 180).Sub(withdrawnFromVal)
 	expRes3 := sdk.NewDecFromInt(expRes1).Add(remainingInVal.Mul(sdk.NewDec(1)).Quo(sdk.NewDec(3))).TruncateInt()
-	require.True(sdk.IntEq(t, expRes3, amt))
+	require.True(t, expRes3 == amt)
 
 	// verify the final withdraw amounts are different
-	require.True(t, expRes2.GT(expRes3))
+	require.True(t, expRes2 > expRes3)
 }
 
 func TestWithdrawDelegationRewardsAll(t *testing.T) {
@@ -219,7 +219,7 @@ func TestWithdrawDelegationRewardsAll(t *testing.T) {
 
 	// 40 tokens left after delegating 60 of them
 	amt := accMapper.GetAccount(ctx, delAddr1).GetCoins().AmountOf(denom)
-	require.Equal(t, int64(40), amt.Int64())
+	require.Equal(t, int64(40), amt)
 
 	// total power of each validator:
 	// validator 1: 10 (self) + 10 (delegator) = 20
@@ -228,7 +228,7 @@ func TestWithdrawDelegationRewardsAll(t *testing.T) {
 	// grand total: 160
 
 	// allocate 100 denom of fees
-	feeInputs := sdk.NewInt(1000)
+	feeInputs := int64(1000)
 	fck.SetCollectedFees(sdk.Coins{sdk.NewCoin(denom, feeInputs)})
 	require.Equal(t, feeInputs, fck.GetCollectedFees(ctx).AmountOf(denom))
 	keeper.AllocateTokens(ctx, sdk.OneDec(), valConsAddr1)
@@ -249,5 +249,5 @@ func TestWithdrawDelegationRewardsAll(t *testing.T) {
 	feesInVal3 := feesInNonProposer.Mul(sdk.NewDec(30).Quo(sdk.NewDec(160))).Mul(sdk.NewDecWithPrec(7, 1))
 	feesInVal1Proposer := feesInProposer.Mul(sdk.NewDec(10).Quo(sdk.NewDec(20))).Mul(sdk.NewDecWithPrec(9, 1))
 	expRes := sdk.NewDec(40).Add(feesInVal1).Add(feesInVal2).Add(feesInVal3).Add(feesInVal1Proposer).TruncateInt()
-	require.True(sdk.IntEq(t, expRes, amt))
+	require.True(t, expRes == amt)
 }

--- a/x/distribution/keeper/test_common.go
+++ b/x/distribution/keeper/test_common.go
@@ -123,7 +123,7 @@ func CreateTestInputAdvanced(t *testing.T, isCheckTx bool, initCoins int64,
 	for _, addr := range addrs {
 		pool := sk.GetPool(ctx)
 		_, _, err := ck.AddCoins(ctx, addr, sdk.Coins{
-			{sk.GetParams(ctx).BondDenom, sdk.NewInt(initCoins)},
+			{sk.GetParams(ctx).BondDenom, initCoins},
 		})
 		require.Nil(t, err)
 		pool.LooseTokens = pool.LooseTokens.Add(sdk.NewDec(initCoins))

--- a/x/distribution/keeper/validator_test.go
+++ b/x/distribution/keeper/validator_test.go
@@ -20,7 +20,7 @@ func TestWithdrawValidatorRewardsAllNoDelegator(t *testing.T) {
 	_ = sk.ApplyAndReturnValidatorSetUpdates(ctx)
 
 	// allocate 100 denom of fees
-	feeInputs := sdk.NewInt(100)
+	feeInputs := int64(100)
 	fck.SetCollectedFees(sdk.Coins{sdk.NewCoin(denom, feeInputs)})
 	require.Equal(t, feeInputs, fck.GetCollectedFees(ctx).AmountOf(denom))
 	keeper.AllocateTokens(ctx, sdk.OneDec(), valConsAddr1)
@@ -30,7 +30,7 @@ func TestWithdrawValidatorRewardsAllNoDelegator(t *testing.T) {
 	keeper.WithdrawValidatorRewardsAll(ctx, valOpAddr1)
 	amt := accMapper.GetAccount(ctx, valAccAddr1).GetCoins().AmountOf(denom)
 	expRes := sdk.NewDec(90).Add(sdk.NewDec(100)).TruncateInt()
-	require.True(sdk.IntEq(t, expRes, amt))
+	require.True(t, expRes == amt)
 }
 
 func TestWithdrawValidatorRewardsAllDelegatorNoCommission(t *testing.T) {
@@ -49,10 +49,10 @@ func TestWithdrawValidatorRewardsAllDelegatorNoCommission(t *testing.T) {
 	got = stakeHandler(ctx, msgDelegate)
 	require.True(t, got.IsOK())
 	amt := accMapper.GetAccount(ctx, delAddr1).GetCoins().AmountOf(denom)
-	require.Equal(t, int64(90), amt.Int64())
+	require.Equal(t, int64(90), amt)
 
 	// allocate 100 denom of fees
-	feeInputs := sdk.NewInt(100)
+	feeInputs := int64(100)
 	fck.SetCollectedFees(sdk.Coins{sdk.NewCoin(denom, feeInputs)})
 	require.Equal(t, feeInputs, fck.GetCollectedFees(ctx).AmountOf(denom))
 	keeper.AllocateTokens(ctx, sdk.OneDec(), valConsAddr1)
@@ -62,7 +62,7 @@ func TestWithdrawValidatorRewardsAllDelegatorNoCommission(t *testing.T) {
 	keeper.WithdrawValidatorRewardsAll(ctx, valOpAddr1)
 	amt = accMapper.GetAccount(ctx, valAccAddr1).GetCoins().AmountOf(denom)
 	expRes := sdk.NewDec(90).Add(sdk.NewDec(100).Quo(sdk.NewDec(2))).TruncateInt() // 90 + 100 tokens * 10/20
-	require.True(sdk.IntEq(t, expRes, amt))
+	require.True(t, expRes == amt)
 }
 
 func TestWithdrawValidatorRewardsAllDelegatorWithCommission(t *testing.T) {
@@ -83,10 +83,10 @@ func TestWithdrawValidatorRewardsAllDelegatorWithCommission(t *testing.T) {
 	got = stakeHandler(ctx, msgDelegate)
 	require.True(t, got.IsOK())
 	amt := accMapper.GetAccount(ctx, delAddr1).GetCoins().AmountOf(denom)
-	require.Equal(t, int64(90), amt.Int64())
+	require.Equal(t, int64(90), amt)
 
 	// allocate 100 denom of fees
-	feeInputs := sdk.NewInt(100)
+	feeInputs := int64(100)
 	fck.SetCollectedFees(sdk.Coins{sdk.NewCoin(denom, feeInputs)})
 	require.Equal(t, feeInputs, fck.GetCollectedFees(ctx).AmountOf(denom))
 	keeper.AllocateTokens(ctx, sdk.OneDec(), valConsAddr1)
@@ -99,7 +99,7 @@ func TestWithdrawValidatorRewardsAllDelegatorWithCommission(t *testing.T) {
 	afterCommission := sdk.NewDec(100).Sub(commissionTaken)
 	selfDelegationReward := afterCommission.Quo(sdk.NewDec(2))
 	expRes := sdk.NewDec(90).Add(commissionTaken).Add(selfDelegationReward).TruncateInt() // 90 + 100 tokens * 10/20
-	require.True(sdk.IntEq(t, expRes, amt))
+	require.True(t, expRes == amt)
 }
 
 func TestWithdrawValidatorRewardsAllMultipleValidator(t *testing.T) {
@@ -126,7 +126,7 @@ func TestWithdrawValidatorRewardsAllMultipleValidator(t *testing.T) {
 	_ = sk.ApplyAndReturnValidatorSetUpdates(ctx)
 
 	// allocate 100 denom of fees
-	feeInputs := sdk.NewInt(1000)
+	feeInputs := int64(1000)
 	fck.SetCollectedFees(sdk.Coins{sdk.NewCoin(denom, feeInputs)})
 	require.Equal(t, feeInputs, fck.GetCollectedFees(ctx).AmountOf(denom))
 	keeper.AllocateTokens(ctx, sdk.OneDec(), valConsAddr1)
@@ -142,7 +142,7 @@ func TestWithdrawValidatorRewardsAllMultipleValidator(t *testing.T) {
 					Add(feesInNonProposer.Quo(sdk.NewDec(10))). // validator 1 has 1/10 total power
 					Add(feesInProposer).
 					TruncateInt()
-	require.True(sdk.IntEq(t, expRes, amt))
+	require.True(t, expRes == amt)
 }
 
 func TestWithdrawValidatorRewardsAllMultipleDelegator(t *testing.T) {
@@ -163,16 +163,16 @@ func TestWithdrawValidatorRewardsAllMultipleDelegator(t *testing.T) {
 	got = stakeHandler(ctx, msgDelegate)
 	require.True(t, got.IsOK())
 	amt := accMapper.GetAccount(ctx, delAddr1).GetCoins().AmountOf(denom)
-	require.Equal(t, int64(90), amt.Int64())
+	require.Equal(t, int64(90), amt)
 
 	msgDelegate = stake.NewTestMsgDelegate(delAddr2, valOpAddr1, 20)
 	got = stakeHandler(ctx, msgDelegate)
 	require.True(t, got.IsOK())
 	amt = accMapper.GetAccount(ctx, delAddr2).GetCoins().AmountOf(denom)
-	require.Equal(t, int64(80), amt.Int64())
+	require.Equal(t, int64(80), amt)
 
 	// allocate 100 denom of fees
-	feeInputs := sdk.NewInt(100)
+	feeInputs := int64(100)
 	fck.SetCollectedFees(sdk.Coins{sdk.NewCoin(denom, feeInputs)})
 	require.Equal(t, feeInputs, fck.GetCollectedFees(ctx).AmountOf(denom))
 	keeper.AllocateTokens(ctx, sdk.OneDec(), valConsAddr1)
@@ -188,5 +188,5 @@ func TestWithdrawValidatorRewardsAllMultipleDelegator(t *testing.T) {
 		Add(afterCommission.Quo(sdk.NewDec(4))).
 		Add(commissionTaken).
 		TruncateInt() // 90 + 100*90% tokens * 10/40
-	require.True(sdk.IntEq(t, expRes, amt))
+	require.True(t, expRes == amt)
 }

--- a/x/distribution/types/delegator_info.go
+++ b/x/distribution/types/delegator_info.go
@@ -42,7 +42,7 @@ func (di DelegationDistInfo) WithdrawRewards(fp FeePool, vi ValidatorDistInfo,
 
 	blocks := height - di.WithdrawalHeight
 	di.WithdrawalHeight = height
-	accum := delegatorShares.MulInt(sdk.NewInt(blocks))
+	accum := delegatorShares.MulInt(blocks)
 	withdrawalTokens := vi.Pool.MulDec(accum).QuoDec(vi.DelAccum.Accum)
 	remainingTokens := vi.Pool.Minus(withdrawalTokens)
 

--- a/x/distribution/types/fee_pool.go
+++ b/x/distribution/types/fee_pool.go
@@ -24,7 +24,7 @@ func (ta TotalAccum) UpdateForNewHeight(height int64, accumCreatedPerBlock sdk.D
 	if blocks < 0 {
 		panic("reverse updated for new height")
 	}
-	ta.Accum = ta.Accum.Add(accumCreatedPerBlock.MulInt(sdk.NewInt(blocks)))
+	ta.Accum = ta.Accum.Add(accumCreatedPerBlock.MulInt(blocks))
 	ta.UpdateHeight = height
 	return ta
 }

--- a/x/distribution/types/keepers.go
+++ b/x/distribution/types/keepers.go
@@ -10,8 +10,8 @@ type StakeKeeper interface {
 	Validator(ctx sdk.Context, valAddr sdk.ValAddress) sdk.Validator
 	ValidatorByConsAddr(ctx sdk.Context, consAddr sdk.ConsAddress) sdk.Validator
 	TotalPower(ctx sdk.Context) sdk.Dec
-	GetLastTotalPower(ctx sdk.Context) sdk.Int
-	GetLastValidatorPower(ctx sdk.Context, valAddr sdk.ValAddress) sdk.Int
+	GetLastTotalPower(ctx sdk.Context) int64
+	GetLastValidatorPower(ctx sdk.Context, valAddr sdk.ValAddress) int64
 }
 
 // expected coin keeper

--- a/x/distribution/types/validator_info.go
+++ b/x/distribution/types/validator_info.go
@@ -52,7 +52,7 @@ func (vi ValidatorDistInfo) TakeFeePoolRewards(fp FeePool, height int64, totalBo
 	// update the validators pool
 	blocks := height - vi.FeePoolWithdrawalHeight
 	vi.FeePoolWithdrawalHeight = height
-	accum := vdTokens.MulInt(sdk.NewInt(blocks))
+	accum := vdTokens.MulInt(blocks)
 
 	if accum.GT(fp.TotalValAccum.Accum) {
 		panic("individual accum should never be greater than the total")

--- a/x/gov/endblocker_test.go
+++ b/x/gov/endblocker_test.go
@@ -19,7 +19,7 @@ func TestTickExpiredDepositPeriod(t *testing.T) {
 	require.Nil(t, keeper.InactiveProposalQueuePeek(ctx))
 	require.False(t, shouldPopInactiveProposalQueue(ctx, keeper))
 
-	newProposalMsg := NewMsgSubmitProposal("Test", "test", ProposalTypeText, addrs[0], sdk.Coins{sdk.NewInt64Coin("steak", 5)})
+	newProposalMsg := NewMsgSubmitProposal("Test", "test", ProposalTypeText, addrs[0], sdk.Coins{sdk.NewCoin("steak", 5)})
 
 	res := govHandler(ctx, newProposalMsg)
 	require.True(t, res.IsOK())
@@ -56,7 +56,7 @@ func TestTickMultipleExpiredDepositPeriod(t *testing.T) {
 	require.Nil(t, keeper.InactiveProposalQueuePeek(ctx))
 	require.False(t, shouldPopInactiveProposalQueue(ctx, keeper))
 
-	newProposalMsg := NewMsgSubmitProposal("Test", "test", ProposalTypeText, addrs[0], sdk.Coins{sdk.NewInt64Coin("steak", 5)})
+	newProposalMsg := NewMsgSubmitProposal("Test", "test", ProposalTypeText, addrs[0], sdk.Coins{sdk.NewCoin("steak", 5)})
 
 	res := govHandler(ctx, newProposalMsg)
 	require.True(t, res.IsOK())
@@ -73,7 +73,7 @@ func TestTickMultipleExpiredDepositPeriod(t *testing.T) {
 	require.NotNil(t, keeper.InactiveProposalQueuePeek(ctx))
 	require.False(t, shouldPopInactiveProposalQueue(ctx, keeper))
 
-	newProposalMsg2 := NewMsgSubmitProposal("Test2", "test2", ProposalTypeText, addrs[1], sdk.Coins{sdk.NewInt64Coin("steak", 5)})
+	newProposalMsg2 := NewMsgSubmitProposal("Test2", "test2", ProposalTypeText, addrs[1], sdk.Coins{sdk.NewCoin("steak", 5)})
 	res = govHandler(ctx, newProposalMsg2)
 	require.True(t, res.IsOK())
 
@@ -109,7 +109,7 @@ func TestTickPassedDepositPeriod(t *testing.T) {
 	require.Nil(t, keeper.ActiveProposalQueuePeek(ctx))
 	require.False(t, shouldPopActiveProposalQueue(ctx, keeper))
 
-	newProposalMsg := NewMsgSubmitProposal("Test", "test", ProposalTypeText, addrs[0], sdk.Coins{sdk.NewInt64Coin("steak", 5)})
+	newProposalMsg := NewMsgSubmitProposal("Test", "test", ProposalTypeText, addrs[0], sdk.Coins{sdk.NewCoin("steak", 5)})
 
 	res := govHandler(ctx, newProposalMsg)
 	require.True(t, res.IsOK())
@@ -128,7 +128,7 @@ func TestTickPassedDepositPeriod(t *testing.T) {
 	require.NotNil(t, keeper.InactiveProposalQueuePeek(ctx))
 	require.False(t, shouldPopInactiveProposalQueue(ctx, keeper))
 
-	newDepositMsg := NewMsgDeposit(addrs[1], proposalID, sdk.Coins{sdk.NewInt64Coin("steak", 5)})
+	newDepositMsg := NewMsgDeposit(addrs[1], proposalID, sdk.Coins{sdk.NewCoin("steak", 5)})
 	res = govHandler(ctx, newDepositMsg)
 	require.True(t, res.IsOK())
 
@@ -157,7 +157,7 @@ func TestTickPassedVotingPeriod(t *testing.T) {
 	require.Nil(t, keeper.ActiveProposalQueuePeek(ctx))
 	require.False(t, shouldPopActiveProposalQueue(ctx, keeper))
 
-	newProposalMsg := NewMsgSubmitProposal("Test", "test", ProposalTypeText, addrs[0], sdk.Coins{sdk.NewInt64Coin("steak", 5)})
+	newProposalMsg := NewMsgSubmitProposal("Test", "test", ProposalTypeText, addrs[0], sdk.Coins{sdk.NewCoin("steak", 5)})
 
 	res := govHandler(ctx, newProposalMsg)
 	require.True(t, res.IsOK())
@@ -168,7 +168,7 @@ func TestTickPassedVotingPeriod(t *testing.T) {
 	newHeader.Time = ctx.BlockHeader().Time.Add(time.Duration(1) * time.Second)
 	ctx = ctx.WithBlockHeader(newHeader)
 
-	newDepositMsg := NewMsgDeposit(addrs[1], proposalID, sdk.Coins{sdk.NewInt64Coin("steak", 5)})
+	newDepositMsg := NewMsgDeposit(addrs[1], proposalID, sdk.Coins{sdk.NewCoin("steak", 5)})
 	res = govHandler(ctx, newDepositMsg)
 	require.True(t, res.IsOK())
 

--- a/x/gov/genesis.go
+++ b/x/gov/genesis.go
@@ -28,7 +28,7 @@ func DefaultGenesisState() GenesisState {
 	return GenesisState{
 		StartingProposalID: 1,
 		DepositProcedure: DepositProcedure{
-			MinDeposit:       sdk.Coins{sdk.NewInt64Coin("steak", 10)},
+			MinDeposit:       sdk.Coins{sdk.NewCoin("steak", 10)},
 			MaxDepositPeriod: time.Duration(172800) * time.Second,
 		},
 		VotingProcedure: VotingProcedure{

--- a/x/gov/keeper_test.go
+++ b/x/gov/keeper_test.go
@@ -64,14 +64,14 @@ func TestDeposits(t *testing.T) {
 	proposal := keeper.NewTextProposal(ctx, "Test", "description", ProposalTypeText)
 	proposalID := proposal.GetProposalID()
 
-	fourSteak := sdk.Coins{sdk.NewInt64Coin("steak", 4)}
-	fiveSteak := sdk.Coins{sdk.NewInt64Coin("steak", 5)}
+	fourSteak := sdk.Coins{sdk.NewCoin("steak", 4)}
+	fiveSteak := sdk.Coins{sdk.NewCoin("steak", 5)}
 
 	addr0Initial := keeper.ck.GetCoins(ctx, addrs[0])
 	addr1Initial := keeper.ck.GetCoins(ctx, addrs[1])
 
-	// require.True(t, addr0Initial.IsEqual(sdk.Coins{sdk.NewInt64Coin("steak", 42)}))
-	require.Equal(t, sdk.Coins{sdk.NewInt64Coin("steak", 42)}, addr0Initial)
+	// require.True(t, addr0Initial.IsEqual(sdk.Coins{sdk.NewCoin("steak", 42)}))
+	require.Equal(t, sdk.Coins{sdk.NewCoin("steak", 42)}, addr0Initial)
 
 	require.True(t, proposal.GetTotalDeposit().IsEqual(sdk.Coins{}))
 

--- a/x/gov/msgs_test.go
+++ b/x/gov/msgs_test.go
@@ -10,11 +10,11 @@ import (
 )
 
 var (
-	coinsPos         = sdk.Coins{sdk.NewInt64Coin("steak", 1000)}
+	coinsPos         = sdk.Coins{sdk.NewCoin("steak", 1000)}
 	coinsZero        = sdk.Coins{}
-	coinsNeg         = sdk.Coins{sdk.NewInt64Coin("steak", -10000)}
-	coinsPosNotAtoms = sdk.Coins{sdk.NewInt64Coin("foo", 10000)}
-	coinsMulti       = sdk.Coins{sdk.NewInt64Coin("foo", 10000), sdk.NewInt64Coin("steak", 1000)}
+	coinsNeg         = sdk.Coins{sdk.NewCoin("steak", -10000)}
+	coinsPosNotAtoms = sdk.Coins{sdk.NewCoin("foo", 10000)}
+	coinsMulti       = sdk.Coins{sdk.NewCoin("foo", 10000), sdk.NewCoin("steak", 1000)}
 )
 
 // test ValidateBasic for MsgCreateValidator

--- a/x/gov/simulation/msgs.go
+++ b/x/gov/simulation/msgs.go
@@ -196,7 +196,7 @@ func operationSimulateMsgVote(k gov.Keeper, sk stake.Keeper, acc simulation.Acco
 func randomDeposit(r *rand.Rand) sdk.Coins {
 	// TODO Choose based on account balance and min deposit
 	amount := int64(r.Intn(20)) + 1
-	return sdk.Coins{sdk.NewInt64Coin(denom, amount)}
+	return sdk.Coins{sdk.NewCoin(denom, amount)}
 }
 
 // Pick a random proposal ID

--- a/x/gov/simulation/sim_test.go
+++ b/x/gov/simulation/sim_test.go
@@ -50,7 +50,7 @@ func TestGovWithRandomMessages(t *testing.T) {
 	}
 
 	setup := func(r *rand.Rand, accs []simulation.Account) {
-		ctx := mapp.NewContext(false, abci.Header{})
+		ctx := mapp.NewContext(sdk.RunTxModeDeliver, abci.Header{})
 		stake.InitGenesis(ctx, stakeKeeper, stake.DefaultGenesisState())
 		gov.InitGenesis(ctx, govKeeper, gov.DefaultGenesisState())
 	}

--- a/x/gov/tally_test.go
+++ b/x/gov/tally_test.go
@@ -25,7 +25,7 @@ func createValidators(t *testing.T, stakeHandler sdk.Handler, ctx sdk.Context, a
 
 	for i := 0; i < len(addrs); i++ {
 		valCreateMsg := stake.NewMsgCreateValidator(
-			addrs[i], pubkeys[i], sdk.NewInt64Coin("steak", coinAmt[i]), testDescription, testCommissionMsg,
+			addrs[i], pubkeys[i], sdk.NewCoin("steak", coinAmt[i]), testDescription, testCommissionMsg,
 		)
 
 		res := stakeHandler(ctx, valCreateMsg)
@@ -289,7 +289,7 @@ func TestTallyDelgatorOverride(t *testing.T) {
 	createValidators(t, stakeHandler, ctx, valAddrs, []int64{5, 6, 7})
 	stake.EndBlocker(ctx, sk)
 
-	delegator1Msg := stake.NewMsgDelegate(addrs[3], sdk.ValAddress(addrs[2]), sdk.NewInt64Coin("steak", 30))
+	delegator1Msg := stake.NewMsgDelegate(addrs[3], sdk.ValAddress(addrs[2]), sdk.NewCoin("steak", 30))
 	stakeHandler(ctx, delegator1Msg)
 
 	proposal := keeper.NewTextProposal(ctx, "Test", "description", ProposalTypeText)
@@ -326,7 +326,7 @@ func TestTallyDelgatorInherit(t *testing.T) {
 	createValidators(t, stakeHandler, ctx, valAddrs, []int64{5, 6, 7})
 	stake.EndBlocker(ctx, sk)
 
-	delegator1Msg := stake.NewMsgDelegate(addrs[3], sdk.ValAddress(addrs[2]), sdk.NewInt64Coin("steak", 30))
+	delegator1Msg := stake.NewMsgDelegate(addrs[3], sdk.ValAddress(addrs[2]), sdk.NewCoin("steak", 30))
 	stakeHandler(ctx, delegator1Msg)
 
 	proposal := keeper.NewTextProposal(ctx, "Test", "description", ProposalTypeText)
@@ -361,9 +361,9 @@ func TestTallyDelgatorMultipleOverride(t *testing.T) {
 	createValidators(t, stakeHandler, ctx, valAddrs, []int64{5, 6, 7})
 	stake.EndBlocker(ctx, sk)
 
-	delegator1Msg := stake.NewMsgDelegate(addrs[3], sdk.ValAddress(addrs[2]), sdk.NewInt64Coin("steak", 10))
+	delegator1Msg := stake.NewMsgDelegate(addrs[3], sdk.ValAddress(addrs[2]), sdk.NewCoin("steak", 10))
 	stakeHandler(ctx, delegator1Msg)
-	delegator1Msg2 := stake.NewMsgDelegate(addrs[3], sdk.ValAddress(addrs[1]), sdk.NewInt64Coin("steak", 10))
+	delegator1Msg2 := stake.NewMsgDelegate(addrs[3], sdk.ValAddress(addrs[1]), sdk.NewCoin("steak", 10))
 	stakeHandler(ctx, delegator1Msg2)
 
 	proposal := keeper.NewTextProposal(ctx, "Test", "description", ProposalTypeText)
@@ -393,24 +393,24 @@ func TestTallyDelgatorMultipleInherit(t *testing.T) {
 	stakeHandler := stake.NewHandler(sk)
 
 	val1CreateMsg := stake.NewMsgCreateValidator(
-		sdk.ValAddress(addrs[0]), ed25519.GenPrivKey().PubKey(), sdk.NewInt64Coin("steak", 25), testDescription, testCommissionMsg,
+		sdk.ValAddress(addrs[0]), ed25519.GenPrivKey().PubKey(), sdk.NewCoin("steak", 25), testDescription, testCommissionMsg,
 	)
 	stakeHandler(ctx, val1CreateMsg)
 
 	val2CreateMsg := stake.NewMsgCreateValidator(
-		sdk.ValAddress(addrs[1]), ed25519.GenPrivKey().PubKey(), sdk.NewInt64Coin("steak", 6), testDescription, testCommissionMsg,
+		sdk.ValAddress(addrs[1]), ed25519.GenPrivKey().PubKey(), sdk.NewCoin("steak", 6), testDescription, testCommissionMsg,
 	)
 	stakeHandler(ctx, val2CreateMsg)
 
 	val3CreateMsg := stake.NewMsgCreateValidator(
-		sdk.ValAddress(addrs[2]), ed25519.GenPrivKey().PubKey(), sdk.NewInt64Coin("steak", 7), testDescription, testCommissionMsg,
+		sdk.ValAddress(addrs[2]), ed25519.GenPrivKey().PubKey(), sdk.NewCoin("steak", 7), testDescription, testCommissionMsg,
 	)
 	stakeHandler(ctx, val3CreateMsg)
 
-	delegator1Msg := stake.NewMsgDelegate(addrs[3], sdk.ValAddress(addrs[2]), sdk.NewInt64Coin("steak", 10))
+	delegator1Msg := stake.NewMsgDelegate(addrs[3], sdk.ValAddress(addrs[2]), sdk.NewCoin("steak", 10))
 	stakeHandler(ctx, delegator1Msg)
 
-	delegator1Msg2 := stake.NewMsgDelegate(addrs[3], sdk.ValAddress(addrs[1]), sdk.NewInt64Coin("steak", 10))
+	delegator1Msg2 := stake.NewMsgDelegate(addrs[3], sdk.ValAddress(addrs[1]), sdk.NewCoin("steak", 10))
 	stakeHandler(ctx, delegator1Msg2)
 
 	stake.EndBlocker(ctx, sk)
@@ -447,10 +447,10 @@ func TestTallyJailedValidator(t *testing.T) {
 	createValidators(t, stakeHandler, ctx, valAddrs, []int64{25, 6, 7})
 	stake.EndBlocker(ctx, sk)
 
-	delegator1Msg := stake.NewMsgDelegate(addrs[3], sdk.ValAddress(addrs[2]), sdk.NewInt64Coin("steak", 10))
+	delegator1Msg := stake.NewMsgDelegate(addrs[3], sdk.ValAddress(addrs[2]), sdk.NewCoin("steak", 10))
 	stakeHandler(ctx, delegator1Msg)
 
-	delegator1Msg2 := stake.NewMsgDelegate(addrs[3], sdk.ValAddress(addrs[1]), sdk.NewInt64Coin("steak", 10))
+	delegator1Msg2 := stake.NewMsgDelegate(addrs[3], sdk.ValAddress(addrs[1]), sdk.NewCoin("steak", 10))
 	stakeHandler(ctx, delegator1Msg2)
 
 	val2, found := sk.GetValidator(ctx, sdk.ValAddress(addrs[1]))

--- a/x/gov/test_common.go
+++ b/x/gov/test_common.go
@@ -44,7 +44,7 @@ func getMockApp(t *testing.T, numGenAccs int) (*mock.App, Keeper, stake.Keeper, 
 
 	require.NoError(t, mapp.CompleteSetup(keyStake, tkeyStake, keyGov, keyGlobalParams, tkeyGlobalParams))
 
-	genAccs, addrs, pubKeys, privKeys := mock.CreateGenAccounts(numGenAccs, sdk.Coins{sdk.NewInt64Coin("steak", 42)})
+	genAccs, addrs, pubKeys, privKeys := mock.CreateGenAccounts(numGenAccs, sdk.Coins{sdk.NewCoin("steak", 42)})
 
 	mock.SetGenesis(mapp, genAccs)
 

--- a/x/ibc/app_test.go
+++ b/x/ibc/app_test.go
@@ -36,7 +36,7 @@ func TestIBCMsgs(t *testing.T) {
 
 	priv1 := ed25519.GenPrivKey()
 	addr1 := sdk.AccAddress(priv1.PubKey().Address())
-	coins := sdk.Coins{sdk.NewInt64Coin("foocoin", 10)}
+	coins := sdk.Coins{sdk.NewCoin("foocoin", 10)}
 	var emptyCoins sdk.Coins
 
 	acc := &auth.BaseAccount{

--- a/x/ibc/ibc_test.go
+++ b/x/ibc/ibc_test.go
@@ -71,7 +71,7 @@ func TestIBC(t *testing.T) {
 	dest := newAddress()
 	chainid := "ibcchain"
 	zero := sdk.Coins(nil)
-	mycoins := sdk.Coins{sdk.NewInt64Coin("mycoin", 10)}
+	mycoins := sdk.Coins{sdk.NewCoin("mycoin", 10)}
 
 	coins, _, err := ck.AddCoins(ctx, src, mycoins)
 	require.Nil(t, err)

--- a/x/ibc/types_test.go
+++ b/x/ibc/types_test.go
@@ -100,7 +100,7 @@ func TestIBCReceiveMsgValidation(t *testing.T) {
 func constructIBCPacket(valid bool) IBCPacket {
 	srcAddr := sdk.AccAddress([]byte("source"))
 	destAddr := sdk.AccAddress([]byte("destination"))
-	coins := sdk.Coins{sdk.NewInt64Coin("atom", 10)}
+	coins := sdk.Coins{sdk.NewCoin("atom", 10)}
 	srcChain := "source-chain"
 	destChain := "dest-chain"
 

--- a/x/mock/app.go
+++ b/x/mock/app.go
@@ -219,7 +219,7 @@ func RandomSetGenesis(r *rand.Rand, app *App, addrs []sdk.AccAddress, denoms []s
 	randCoinIntervals := []BigInterval{
 		{sdk.NewIntWithDecimal(1, 0), sdk.NewIntWithDecimal(1, 1)},
 		{sdk.NewIntWithDecimal(1, 2), sdk.NewIntWithDecimal(1, 3)},
-		{sdk.NewIntWithDecimal(1, 40), sdk.NewIntWithDecimal(1, 50)},
+		{sdk.NewIntWithDecimal(1, 8), sdk.NewIntWithDecimal(1, 8)},
 	}
 
 	for i := 0; i < len(accts); i++ {
@@ -228,7 +228,7 @@ func RandomSetGenesis(r *rand.Rand, app *App, addrs []sdk.AccAddress, denoms []s
 		// generate a random coin for each denomination
 		for j := 0; j < len(denoms); j++ {
 			coins[j] = sdk.Coin{Denom: denoms[j],
-				Amount: RandFromBigInterval(r, randCoinIntervals),
+				Amount: RandFromBigInterval(r, randCoinIntervals).Int64(),
 			}
 		}
 

--- a/x/mock/app_test.go
+++ b/x/mock/app_test.go
@@ -13,7 +13,7 @@ const msgRoute = "testMsg"
 
 var (
 	numAccts                       = 2
-	genCoins                       = sdk.Coins{sdk.NewInt64Coin("foocoin", 77)}
+	genCoins                       = sdk.Coins{sdk.NewCoin("foocoin", 77)}
 	accs, addrs, pubKeys, privKeys = CreateGenAccounts(numAccts, genCoins)
 )
 

--- a/x/mock/simulation/util.go
+++ b/x/mock/simulation/util.go
@@ -66,8 +66,8 @@ func RandomAcc(r *rand.Rand, accs []Account) Account {
 }
 
 // Generate a random amount
-func RandomAmount(r *rand.Rand, max sdk.Int) sdk.Int {
-	return sdk.NewInt(int64(r.Intn(int(max.Int64()))))
+func RandomAmount(r *rand.Rand, max int64) int64 {
+	return r.Int63n(max)
 }
 
 // RandomAccounts generates n random accounts

--- a/x/slashing/app_test.go
+++ b/x/slashing/app_test.go
@@ -17,7 +17,7 @@ import (
 var (
 	priv1 = ed25519.GenPrivKey()
 	addr1 = sdk.AccAddress(priv1.PubKey().Address())
-	coins = sdk.Coins{sdk.NewInt64Coin("foocoin", 10)}
+	coins = sdk.Coins{sdk.NewCoin("foocoin", 10)}
 )
 
 // initialize the mock application for this module
@@ -93,8 +93,8 @@ func checkValidatorSigningInfo(t *testing.T, mapp *mock.App, keeper Keeper,
 func TestSlashingMsgs(t *testing.T) {
 	mapp, stakeKeeper, keeper := getMockApp(t)
 
-	genCoin := sdk.NewInt64Coin("steak", 42)
-	bondCoin := sdk.NewInt64Coin("steak", 10)
+	genCoin := sdk.NewCoin("steak", 42)
+	bondCoin := sdk.NewCoin("steak", 10)
 
 	acc1 := &auth.BaseAccount{
 		Address: addr1,

--- a/x/slashing/handler_test.go
+++ b/x/slashing/handler_test.go
@@ -15,12 +15,13 @@ func TestCannotUnjailUnlessJailed(t *testing.T) {
 	ctx, ck, sk, _, keeper := createTestInput(t, DefaultParams())
 	slh := NewHandler(keeper)
 	amtInt := int64(100)
-	addr, val, amt := addrs[0], pks[0], sdk.NewInt(amtInt)
+	addr, val, amt := addrs[0], pks[0], amtInt
 	msg := NewTestMsgCreateValidator(addr, val, amt)
 	got := stake.NewHandler(sk)(ctx, msg)
+
 	require.True(t, got.IsOK())
 	stake.EndBlocker(ctx, sk)
-	require.Equal(t, ck.GetCoins(ctx, sdk.AccAddress(addr)), sdk.Coins{{sk.GetParams(ctx).BondDenom, initCoins.Sub(amt)}})
+	require.Equal(t, ck.GetCoins(ctx, sdk.AccAddress(addr)), sdk.Coins{{sk.GetParams(ctx).BondDenom, initCoins - amt}})
 	require.True(t, sdk.NewDecFromInt(amt).Equal(sk.Validator(ctx, addr).GetPower()))
 
 	// assert non-jailed validator can't be unjailed
@@ -38,7 +39,7 @@ func TestJailedValidatorDelegations(t *testing.T) {
 
 	// create a validator
 	amount := int64(10)
-	valPubKey, bondAmount := pks[0], sdk.NewInt(amount)
+	valPubKey, bondAmount := pks[0], amount
 	valAddr, consAddr := addrs[1], sdk.ConsAddress(addrs[0])
 
 	msgCreateVal := NewTestMsgCreateValidator(valAddr, valPubKey, bondAmount)

--- a/x/slashing/keeper_test.go
+++ b/x/slashing/keeper_test.go
@@ -31,12 +31,12 @@ func TestHandleDoubleSign(t *testing.T) {
 	// validator added pre-genesis
 	ctx = ctx.WithBlockHeight(-1)
 	amtInt := int64(100)
-	operatorAddr, val, amt := addrs[0], pks[0], sdk.NewInt(amtInt)
+	operatorAddr, val, amt := addrs[0], pks[0], amtInt
 	got := stake.NewHandler(sk)(ctx, NewTestMsgCreateValidator(operatorAddr, val, amt))
 	require.True(t, got.IsOK())
 	validatorUpdates := stake.EndBlocker(ctx, sk)
 	keeper.AddValidators(ctx, validatorUpdates)
-	require.Equal(t, ck.GetCoins(ctx, sdk.AccAddress(operatorAddr)), sdk.Coins{{sk.GetParams(ctx).BondDenom, initCoins.Sub(amt)}})
+	require.Equal(t, ck.GetCoins(ctx, sdk.AccAddress(operatorAddr)), sdk.Coins{{sk.GetParams(ctx).BondDenom, initCoins - amt}})
 	require.True(t, sdk.NewDecFromInt(amt).Equal(sk.Validator(ctx, operatorAddr).GetPower()))
 
 	// handle a signature to set signing info
@@ -71,14 +71,14 @@ func TestSlashingPeriodCap(t *testing.T) {
 	// initial setup
 	ctx, ck, sk, _, keeper := createTestInput(t, DefaultParams())
 	amtInt := int64(100)
-	operatorAddr, amt := addrs[0], sdk.NewInt(amtInt)
+	operatorAddr, amt := addrs[0], amtInt
 	valConsPubKey, valConsAddr := pks[0], pks[0].Address()
 	got := stake.NewHandler(sk)(ctx, NewTestMsgCreateValidator(operatorAddr, valConsPubKey, amt))
 	require.True(t, got.IsOK())
 	validatorUpdates := stake.EndBlocker(ctx, sk)
 	ctx = ctx.WithBlockHeight(ctx.BlockHeight() + 1)
 	keeper.AddValidators(ctx, validatorUpdates)
-	require.Equal(t, ck.GetCoins(ctx, sdk.AccAddress(operatorAddr)), sdk.Coins{{sk.GetParams(ctx).BondDenom, initCoins.Sub(amt)}})
+	require.Equal(t, ck.GetCoins(ctx, sdk.AccAddress(operatorAddr)), sdk.Coins{{sk.GetParams(ctx).BondDenom, initCoins - amt}})
 	require.True(t, sdk.NewDecFromInt(amt).Equal(sk.Validator(ctx, operatorAddr).GetPower()))
 
 	// handle a signature to set signing info
@@ -136,14 +136,14 @@ func TestHandleAbsentValidator(t *testing.T) {
 	// initial setup
 	ctx, ck, sk, _, keeper := createTestInput(t, keeperTestParams())
 	amtInt := int64(100)
-	addr, val, amt := addrs[0], pks[0], sdk.NewInt(amtInt)
+	addr, val, amt := addrs[0], pks[0], amtInt
 	sh := stake.NewHandler(sk)
 	slh := NewHandler(keeper)
 	got := sh(ctx, NewTestMsgCreateValidator(addr, val, amt))
 	require.True(t, got.IsOK())
 	validatorUpdates := stake.EndBlocker(ctx, sk)
 	keeper.AddValidators(ctx, validatorUpdates)
-	require.Equal(t, ck.GetCoins(ctx, sdk.AccAddress(addr)), sdk.Coins{{sk.GetParams(ctx).BondDenom, initCoins.Sub(amt)}})
+	require.Equal(t, ck.GetCoins(ctx, sdk.AccAddress(addr)), sdk.Coins{{sk.GetParams(ctx).BondDenom, initCoins - amt}})
 	require.True(t, sdk.NewDecFromInt(amt).Equal(sk.Validator(ctx, addr).GetPower()))
 	// will exist since the validator has been bonded
 	info, found := keeper.getValidatorSigningInfo(ctx, sdk.ConsAddress(val.Address()))
@@ -296,11 +296,11 @@ func TestHandleNewValidator(t *testing.T) {
 	ctx = ctx.WithBlockHeight(keeper.SignedBlocksWindow(ctx) + 1)
 
 	// Validator created
-	got := sh(ctx, NewTestMsgCreateValidator(addr, val, sdk.NewInt(amt)))
+	got := sh(ctx, NewTestMsgCreateValidator(addr, val, amt))
 	require.True(t, got.IsOK())
 	validatorUpdates := stake.EndBlocker(ctx, sk)
 	keeper.AddValidators(ctx, validatorUpdates)
-	require.Equal(t, ck.GetCoins(ctx, sdk.AccAddress(addr)), sdk.Coins{{sk.GetParams(ctx).BondDenom, initCoins.SubRaw(amt)}})
+	require.Equal(t, ck.GetCoins(ctx, sdk.AccAddress(addr)), sdk.Coins{{sk.GetParams(ctx).BondDenom, initCoins - amt}})
 	require.Equal(t, sdk.NewDec(amt), sk.Validator(ctx, addr).GetPower())
 
 	// Now a validator, for two blocks
@@ -329,7 +329,7 @@ func TestHandleAlreadyJailed(t *testing.T) {
 	// initial setup
 	ctx, _, sk, _, keeper := createTestInput(t, DefaultParams())
 	amtInt := int64(100)
-	addr, val, amt := addrs[0], pks[0], sdk.NewInt(amtInt)
+	addr, val, amt := addrs[0], pks[0], amtInt
 	sh := stake.NewHandler(sk)
 	got := sh(ctx, NewTestMsgCreateValidator(addr, val, amt))
 	require.True(t, got.IsOK())
@@ -381,7 +381,7 @@ func TestValidatorDippingInAndOut(t *testing.T) {
 	params.MaxValidators = 1
 	sk.SetParams(ctx, params)
 	amtInt := int64(100)
-	addr, val, amt := addrs[0], pks[0], sdk.NewInt(amtInt)
+	addr, val, amt := addrs[0], pks[0], amtInt
 	consAddr := sdk.ConsAddress(addr)
 	sh := stake.NewHandler(sk)
 	got := sh(ctx, NewTestMsgCreateValidator(addr, val, amt))
@@ -398,7 +398,7 @@ func TestValidatorDippingInAndOut(t *testing.T) {
 
 	// validator kicked out of validator set
 	newAmt := int64(101)
-	got = sh(ctx, NewTestMsgCreateValidator(addrs[1], pks[1], sdk.NewInt(newAmt)))
+	got = sh(ctx, NewTestMsgCreateValidator(addrs[1], pks[1], newAmt))
 	require.True(t, got.IsOK())
 	validatorUpdates = stake.EndBlocker(ctx, sk)
 	require.Equal(t, 2, len(validatorUpdates))
@@ -411,7 +411,7 @@ func TestValidatorDippingInAndOut(t *testing.T) {
 	ctx = ctx.WithBlockHeight(height)
 
 	// validator added back in
-	got = sh(ctx, newTestMsgDelegate(sdk.AccAddress(addrs[2]), addrs[0], sdk.NewInt(2)))
+	got = sh(ctx, newTestMsgDelegate(sdk.AccAddress(addrs[2]), addrs[0], 2))
 	require.True(t, got.IsOK())
 	validatorUpdates = stake.EndBlocker(ctx, sk)
 	require.Equal(t, 2, len(validatorUpdates))

--- a/x/slashing/test_common.go
+++ b/x/slashing/test_common.go
@@ -36,7 +36,7 @@ var (
 		sdk.ValAddress(pks[1].Address()),
 		sdk.ValAddress(pks[2].Address()),
 	}
-	initCoins = sdk.NewInt(200)
+	initCoins = int64(200)
 )
 
 func createTestCodec() *codec.Codec {
@@ -75,7 +75,7 @@ func createTestInput(t *testing.T, defaults Params) (sdk.Context, bank.Keeper, s
 	sk := stake.NewKeeper(cdc, keyStake, tkeyStake, ck, paramsKeeper.Subspace(stake.DefaultParamspace), stake.DefaultCodespace)
 	genesis := stake.DefaultGenesisState()
 
-	genesis.Pool.LooseTokens = sdk.NewDec(initCoins.MulRaw(int64(len(addrs))).Int64())
+	genesis.Pool.LooseTokens = sdk.NewDec(initCoins * (int64(len(addrs))))
 
 	_, err = stake.InitGenesis(ctx, sk, genesis)
 	require.Nil(t, err)
@@ -112,7 +112,7 @@ func testAddr(addr string) sdk.AccAddress {
 	return res
 }
 
-func NewTestMsgCreateValidator(address sdk.ValAddress, pubKey crypto.PubKey, amt sdk.Int) stake.MsgCreateValidator {
+func NewTestMsgCreateValidator(address sdk.ValAddress, pubKey crypto.PubKey, amt int64) stake.MsgCreateValidator {
 	commission := stake.NewCommissionMsg(sdk.ZeroDec(), sdk.ZeroDec(), sdk.ZeroDec())
 	return stake.MsgCreateValidator{
 		Description:   stake.Description{},
@@ -124,7 +124,7 @@ func NewTestMsgCreateValidator(address sdk.ValAddress, pubKey crypto.PubKey, amt
 	}
 }
 
-func newTestMsgDelegate(delAddr sdk.AccAddress, valAddr sdk.ValAddress, delAmount sdk.Int) stake.MsgDelegate {
+func newTestMsgDelegate(delAddr sdk.AccAddress, valAddr sdk.ValAddress, delAmount int64) stake.MsgDelegate {
 	return stake.MsgDelegate{
 		DelegatorAddr: delAddr,
 		ValidatorAddr: valAddr,

--- a/x/slashing/tick_test.go
+++ b/x/slashing/tick_test.go
@@ -14,19 +14,19 @@ import (
 
 func TestBeginBlocker(t *testing.T) {
 	ctx, ck, sk, _, keeper := createTestInput(t, DefaultParams())
-	addr, pk, amt := addrs[2], pks[2], sdk.NewInt(100)
+	addr, pk, amt := addrs[2], pks[2], int64(100)
 
 	// bond the validator
 	got := stake.NewHandler(sk)(ctx, NewTestMsgCreateValidator(addr, pk, amt))
 	require.True(t, got.IsOK())
 	validatorUpdates := stake.EndBlocker(ctx, sk)
 	keeper.AddValidators(ctx, validatorUpdates)
-	require.Equal(t, ck.GetCoins(ctx, sdk.AccAddress(addr)), sdk.Coins{{sk.GetParams(ctx).BondDenom, initCoins.Sub(amt)}})
+	require.Equal(t, ck.GetCoins(ctx, sdk.AccAddress(addr)), sdk.Coins{{sk.GetParams(ctx).BondDenom, initCoins - amt}})
 	require.True(t, sdk.NewDecFromInt(amt).Equal(sk.Validator(ctx, addr).GetPower()))
 
 	val := abci.Validator{
 		Address: pk.Address(),
-		Power:   amt.Int64(),
+		Power:   amt,
 	}
 
 	// mark the validator as having signed

--- a/x/stake/app_test.go
+++ b/x/stake/app_test.go
@@ -100,8 +100,8 @@ func checkDelegation(
 func TestStakeMsgs(t *testing.T) {
 	mApp, keeper := getMockApp(t)
 
-	genCoin := sdk.NewInt64Coin("steak", 42)
-	bondCoin := sdk.NewInt64Coin("steak", 10)
+	genCoin := sdk.NewCoin("steak", 42)
+	bondCoin := sdk.NewCoin("steak", 10)
 
 	acc1 := &auth.BaseAccount{
 		Address: addr1,

--- a/x/stake/keeper/delegation_test.go
+++ b/x/stake/keeper/delegation_test.go
@@ -18,7 +18,7 @@ func TestDelegation(t *testing.T) {
 	pool := keeper.GetPool(ctx)
 
 	//construct the validators
-	amts := []sdk.Int{sdk.NewInt(9), sdk.NewInt(8), sdk.NewInt(7)}
+	amts := []int64{9, 8, 7}
 	var validators [3]types.Validator
 	for i, amt := range amts {
 		validators[i] = types.NewValidator(addrVals[i], PKs[i], types.Description{})
@@ -139,7 +139,7 @@ func TestUnbondingDelegation(t *testing.T) {
 		ValidatorAddr:  addrVals[0],
 		CreationHeight: 0,
 		MinTime:        time.Unix(0, 0),
-		Balance:        sdk.NewInt64Coin("steak", 5),
+		Balance:        sdk.NewCoin("steak", 5),
 	}
 
 	// set and retrieve a record
@@ -149,7 +149,7 @@ func TestUnbondingDelegation(t *testing.T) {
 	require.True(t, ubd.Equal(resUnbond))
 
 	// modify a records, save, and retrieve
-	ubd.Balance = sdk.NewInt64Coin("steak", 21)
+	ubd.Balance = sdk.NewCoin("steak", 21)
 	keeper.SetUnbondingDelegation(ctx, ubd)
 
 	resUnbonds := keeper.GetUnbondingDelegations(ctx, addrDels[0], 5)
@@ -182,7 +182,7 @@ func TestUnbondDelegation(t *testing.T) {
 
 	//create a validator and a delegator to that validator
 	validator := types.NewValidator(addrVals[0], PKs[0], types.Description{})
-	validator, pool, issuedShares := validator.AddTokensFromDel(pool, sdk.NewInt(10))
+	validator, pool, issuedShares := validator.AddTokensFromDel(pool, 10)
 	require.Equal(t, int64(10), issuedShares.RoundInt64())
 	keeper.SetPool(ctx, pool)
 	validator = TestingUpdateValidator(keeper, ctx, validator)
@@ -224,7 +224,7 @@ func TestUndelegateSelfDelegation(t *testing.T) {
 
 	//create a validator with a self-delegation
 	validator := types.NewValidator(addrVals[0], PKs[0], types.Description{})
-	validator, pool, issuedShares := validator.AddTokensFromDel(pool, sdk.NewInt(10))
+	validator, pool, issuedShares := validator.AddTokensFromDel(pool, 10)
 	require.Equal(t, int64(10), issuedShares.RoundInt64())
 	keeper.SetPool(ctx, pool)
 	validator = TestingUpdateValidator(keeper, ctx, validator)
@@ -238,7 +238,7 @@ func TestUndelegateSelfDelegation(t *testing.T) {
 
 	// create a second delegation to this validator
 	keeper.DeleteValidatorByPowerIndex(ctx, validator, pool)
-	validator, pool, issuedShares = validator.AddTokensFromDel(pool, sdk.NewInt(10))
+	validator, pool, issuedShares = validator.AddTokensFromDel(pool, 10)
 	require.Equal(t, int64(10), issuedShares.RoundInt64())
 	keeper.SetPool(ctx, pool)
 	validator = TestingUpdateValidator(keeper, ctx, validator)
@@ -272,7 +272,7 @@ func TestUndelegateFromUnbondingValidator(t *testing.T) {
 	//create a validator with a self-delegation
 	validator := types.NewValidator(addrVals[0], PKs[0], types.Description{})
 
-	validator, pool, issuedShares := validator.AddTokensFromDel(pool, sdk.NewInt(10))
+	validator, pool, issuedShares := validator.AddTokensFromDel(pool, 10)
 	require.Equal(t, int64(10), issuedShares.RoundInt64())
 	keeper.SetPool(ctx, pool)
 	validator = TestingUpdateValidator(keeper, ctx, validator)
@@ -286,7 +286,7 @@ func TestUndelegateFromUnbondingValidator(t *testing.T) {
 
 	// create a second delegation to this validator
 	keeper.DeleteValidatorByPowerIndex(ctx, validator, pool)
-	validator, pool, issuedShares = validator.AddTokensFromDel(pool, sdk.NewInt(10))
+	validator, pool, issuedShares = validator.AddTokensFromDel(pool, 10)
 	require.Equal(t, int64(10), issuedShares.RoundInt64())
 	keeper.SetPool(ctx, pool)
 	validator = TestingUpdateValidator(keeper, ctx, validator)
@@ -335,7 +335,7 @@ func TestUndelegateFromUnbondingValidator(t *testing.T) {
 	// retrieve the unbonding delegation
 	ubd, found := keeper.GetUnbondingDelegation(ctx, addrDels[0], addrVals[0])
 	require.True(t, found)
-	require.True(t, ubd.Balance.IsEqual(sdk.NewInt64Coin(params.BondDenom, 6)))
+	require.True(t, ubd.Balance.IsEqual(sdk.NewCoin(params.BondDenom, 6)))
 	assert.Equal(t, blockHeight, ubd.CreationHeight)
 	assert.True(t, blockTime.Add(params.UnbondingTime).Equal(ubd.MinTime))
 }
@@ -348,7 +348,7 @@ func TestUndelegateFromUnbondedValidator(t *testing.T) {
 	//create a validator with a self-delegation
 	validator := types.NewValidator(addrVals[0], PKs[0], types.Description{})
 
-	validator, pool, issuedShares := validator.AddTokensFromDel(pool, sdk.NewInt(10))
+	validator, pool, issuedShares := validator.AddTokensFromDel(pool, 10)
 	require.Equal(t, int64(10), issuedShares.RoundInt64())
 	keeper.SetPool(ctx, pool)
 	validator = TestingUpdateValidator(keeper, ctx, validator)
@@ -363,7 +363,7 @@ func TestUndelegateFromUnbondedValidator(t *testing.T) {
 
 	// create a second delegation to this validator
 	keeper.DeleteValidatorByPowerIndex(ctx, validator, pool)
-	validator, pool, issuedShares = validator.AddTokensFromDel(pool, sdk.NewInt(10))
+	validator, pool, issuedShares = validator.AddTokensFromDel(pool, 10)
 	require.Equal(t, int64(10), issuedShares.RoundInt64())
 	keeper.SetPool(ctx, pool)
 	validator = TestingUpdateValidator(keeper, ctx, validator)
@@ -427,7 +427,7 @@ func TestUnbondingAllDelegationFromValidator(t *testing.T) {
 	//create a validator with a self-delegation
 	validator := types.NewValidator(addrVals[0], PKs[0], types.Description{})
 
-	validator, pool, issuedShares := validator.AddTokensFromDel(pool, sdk.NewInt(10))
+	validator, pool, issuedShares := validator.AddTokensFromDel(pool, 10)
 	require.Equal(t, int64(10), issuedShares.RoundInt64())
 	keeper.SetPool(ctx, pool)
 	validator = TestingUpdateValidator(keeper, ctx, validator)
@@ -442,7 +442,7 @@ func TestUnbondingAllDelegationFromValidator(t *testing.T) {
 
 	// create a second delegation to this validator
 	keeper.DeleteValidatorByPowerIndex(ctx, validator, pool)
-	validator, pool, issuedShares = validator.AddTokensFromDel(pool, sdk.NewInt(10))
+	validator, pool, issuedShares = validator.AddTokensFromDel(pool, 10)
 	require.Equal(t, int64(10), issuedShares.RoundInt64())
 	keeper.SetPool(ctx, pool)
 	validator = TestingUpdateValidator(keeper, ctx, validator)
@@ -589,7 +589,7 @@ func TestRedelegateSelfDelegation(t *testing.T) {
 
 	//create a validator with a self-delegation
 	validator := types.NewValidator(addrVals[0], PKs[0], types.Description{})
-	validator, pool, issuedShares := validator.AddTokensFromDel(pool, sdk.NewInt(10))
+	validator, pool, issuedShares := validator.AddTokensFromDel(pool, 10)
 	require.Equal(t, int64(10), issuedShares.RoundInt64())
 	keeper.SetPool(ctx, pool)
 	validator = TestingUpdateValidator(keeper, ctx, validator)
@@ -604,7 +604,7 @@ func TestRedelegateSelfDelegation(t *testing.T) {
 
 	// create a second validator
 	validator2 := types.NewValidator(addrVals[1], PKs[1], types.Description{})
-	validator2, pool, issuedShares = validator2.AddTokensFromDel(pool, sdk.NewInt(10))
+	validator2, pool, issuedShares = validator2.AddTokensFromDel(pool, 10)
 	require.Equal(t, int64(10), issuedShares.RoundInt64())
 	pool.BondedTokens = pool.BondedTokens.Add(sdk.NewDec(10))
 	keeper.SetPool(ctx, pool)
@@ -612,7 +612,7 @@ func TestRedelegateSelfDelegation(t *testing.T) {
 	require.Equal(t, sdk.Bonded, validator2.Status)
 
 	// create a second delegation to this validator
-	validator, pool, issuedShares = validator.AddTokensFromDel(pool, sdk.NewInt(10))
+	validator, pool, issuedShares = validator.AddTokensFromDel(pool, 10)
 	require.Equal(t, int64(10), issuedShares.RoundInt64())
 	keeper.SetPool(ctx, pool)
 	validator = TestingUpdateValidator(keeper, ctx, validator)
@@ -646,7 +646,7 @@ func TestRedelegateFromUnbondingValidator(t *testing.T) {
 	validator := types.NewValidator(addrVals[0], PKs[0], types.Description{})
 	validator.BondIntraTxCounter = 1
 
-	validator, pool, issuedShares := validator.AddTokensFromDel(pool, sdk.NewInt(10))
+	validator, pool, issuedShares := validator.AddTokensFromDel(pool, 10)
 	require.Equal(t, int64(10), issuedShares.RoundInt64())
 	keeper.SetPool(ctx, pool)
 	validator = TestingUpdateValidator(keeper, ctx, validator)
@@ -661,7 +661,7 @@ func TestRedelegateFromUnbondingValidator(t *testing.T) {
 
 	// create a second delegation to this validator
 	keeper.DeleteValidatorByPowerIndex(ctx, validator, pool)
-	validator, pool, issuedShares = validator.AddTokensFromDel(pool, sdk.NewInt(10))
+	validator, pool, issuedShares = validator.AddTokensFromDel(pool, 10)
 	require.Equal(t, int64(10), issuedShares.RoundInt64())
 	keeper.SetPool(ctx, pool)
 	validator = TestingUpdateValidator(keeper, ctx, validator)
@@ -676,7 +676,7 @@ func TestRedelegateFromUnbondingValidator(t *testing.T) {
 	// create a second validator
 	validator2 := types.NewValidator(addrVals[1], PKs[1], types.Description{})
 	validator2.BondIntraTxCounter = 2
-	validator2, pool, issuedShares = validator2.AddTokensFromDel(pool, sdk.NewInt(10))
+	validator2, pool, issuedShares = validator2.AddTokensFromDel(pool, 10)
 	require.Equal(t, int64(10), issuedShares.RoundInt64())
 	keeper.SetPool(ctx, pool)
 	validator2 = TestingUpdateValidator(keeper, ctx, validator2)
@@ -717,7 +717,7 @@ func TestRedelegateFromUnbondingValidator(t *testing.T) {
 	// retrieve the unbonding delegation
 	ubd, found := keeper.GetRedelegation(ctx, addrDels[0], addrVals[0], addrVals[1])
 	require.True(t, found)
-	require.True(t, ubd.Balance.IsEqual(sdk.NewInt64Coin(params.BondDenom, 6)))
+	require.True(t, ubd.Balance.IsEqual(sdk.NewCoin(params.BondDenom, 6)))
 	assert.Equal(t, blockHeight, ubd.CreationHeight)
 	assert.True(t, blockTime.Add(params.UnbondingTime).Equal(ubd.MinTime))
 }
@@ -730,7 +730,7 @@ func TestRedelegateFromUnbondedValidator(t *testing.T) {
 	//create a validator with a self-delegation
 	validator := types.NewValidator(addrVals[0], PKs[0], types.Description{})
 
-	validator, pool, issuedShares := validator.AddTokensFromDel(pool, sdk.NewInt(10))
+	validator, pool, issuedShares := validator.AddTokensFromDel(pool, 10)
 	require.Equal(t, int64(10), issuedShares.RoundInt64())
 	keeper.SetPool(ctx, pool)
 	validator = TestingUpdateValidator(keeper, ctx, validator)
@@ -745,7 +745,7 @@ func TestRedelegateFromUnbondedValidator(t *testing.T) {
 
 	// create a second delegation to this validator
 	keeper.DeleteValidatorByPowerIndex(ctx, validator, pool)
-	validator, pool, issuedShares = validator.AddTokensFromDel(pool, sdk.NewInt(10))
+	validator, pool, issuedShares = validator.AddTokensFromDel(pool, 10)
 	validator.BondIntraTxCounter = 1
 	require.Equal(t, int64(10), issuedShares.RoundInt64())
 	keeper.SetPool(ctx, pool)
@@ -761,7 +761,7 @@ func TestRedelegateFromUnbondedValidator(t *testing.T) {
 	// create a second validator
 	validator2 := types.NewValidator(addrVals[1], PKs[1], types.Description{})
 	validator2.BondIntraTxCounter = 2
-	validator2, pool, issuedShares = validator2.AddTokensFromDel(pool, sdk.NewInt(10))
+	validator2, pool, issuedShares = validator2.AddTokensFromDel(pool, 10)
 	require.Equal(t, int64(10), issuedShares.RoundInt64())
 	keeper.SetPool(ctx, pool)
 	validator2 = TestingUpdateValidator(keeper, ctx, validator2)

--- a/x/stake/keeper/keeper.go
+++ b/x/stake/keeper/keeper.go
@@ -74,18 +74,18 @@ func (k Keeper) SetPool(ctx sdk.Context, pool types.Pool) {
 //_______________________________________________________________________
 
 // Load the last total validator power.
-func (k Keeper) GetLastTotalPower(ctx sdk.Context) (power sdk.Int) {
+func (k Keeper) GetLastTotalPower(ctx sdk.Context) (power int64) {
 	store := ctx.KVStore(k.storeKey)
 	b := store.Get(LastTotalPowerKey)
 	if b == nil {
-		return sdk.ZeroInt()
+		return 0
 	}
 	k.cdc.MustUnmarshalBinary(b, &power)
 	return
 }
 
 // Set the last total validator power.
-func (k Keeper) SetLastTotalPower(ctx sdk.Context, power sdk.Int) {
+func (k Keeper) SetLastTotalPower(ctx sdk.Context, power int64) {
 	store := ctx.KVStore(k.storeKey)
 	b := k.cdc.MustMarshalBinary(power)
 	store.Set(LastTotalPowerKey, b)
@@ -95,18 +95,18 @@ func (k Keeper) SetLastTotalPower(ctx sdk.Context, power sdk.Int) {
 
 // Load the last validator power.
 // Returns zero if the operator was not a validator last block.
-func (k Keeper) GetLastValidatorPower(ctx sdk.Context, operator sdk.ValAddress) (power sdk.Int) {
+func (k Keeper) GetLastValidatorPower(ctx sdk.Context, operator sdk.ValAddress) (power int64) {
 	store := ctx.KVStore(k.storeKey)
 	bz := store.Get(GetLastValidatorPowerKey(operator))
 	if bz == nil {
-		return sdk.ZeroInt()
+		return 0
 	}
 	k.cdc.MustUnmarshalBinary(bz, &power)
 	return
 }
 
 // Set the last validator power.
-func (k Keeper) SetLastValidatorPower(ctx sdk.Context, operator sdk.ValAddress, power sdk.Int) {
+func (k Keeper) SetLastValidatorPower(ctx sdk.Context, operator sdk.ValAddress, power int64) {
 	store := ctx.KVStore(k.storeKey)
 	bz := k.cdc.MustMarshalBinary(power)
 	store.Set(GetLastValidatorPowerKey(operator), bz)

--- a/x/stake/keeper/key_test.go
+++ b/x/stake/keeper/key_test.go
@@ -28,8 +28,8 @@ func TestGetValidatorPowerRank(t *testing.T) {
 	val2, val3, val4 := val1, val1, val1
 	val2.Tokens = sdk.NewDec(1)
 	val3.Tokens = sdk.NewDec(10)
-	x := new(big.Int).Exp(big.NewInt(2), big.NewInt(40), big.NewInt(0))
-	val4.Tokens = sdk.NewDecFromBigInt(x)
+	x := new(big.Int).Exp(big.NewInt(2), big.NewInt(20), big.NewInt(0))
+	val4.Tokens = sdk.NewDecFromBigInt(x.Int64())
 
 	tests := []struct {
 		validator types.Validator
@@ -38,7 +38,7 @@ func TestGetValidatorPowerRank(t *testing.T) {
 		{val1, "230000000000000000ffffffffffffffffffff"},
 		{val2, "230000000000000001ffffffffffffffffffff"},
 		{val3, "23000000000000000affffffffffffffffffff"},
-		{val4, "230000010000000000ffffffffffffffffffff"},
+		{val4, "230000000000100000ffffffffffffffffffff"},
 	}
 	for i, tt := range tests {
 		got := hex.EncodeToString(getValidatorPowerRank(tt.validator))

--- a/x/stake/keeper/slash.go
+++ b/x/stake/keeper/slash.go
@@ -171,11 +171,11 @@ func (k Keeper) slashUnbondingDelegation(ctx sdk.Context, unbondingDelegation ty
 	// Possible since the unbonding delegation may already
 	// have been slashed, and slash amounts are calculated
 	// according to stake held at time of infraction
-	unbondingSlashAmount := sdk.MinInt(slashAmount.RoundInt(), unbondingDelegation.Balance.Amount)
+	unbondingSlashAmount := sdk.MinInt64(slashAmount.RoundInt(), unbondingDelegation.Balance.Amount)
 
 	// Update unbonding delegation if necessary
-	if !unbondingSlashAmount.IsZero() {
-		unbondingDelegation.Balance.Amount = unbondingDelegation.Balance.Amount.Sub(unbondingSlashAmount)
+	if unbondingSlashAmount != 0 {
+		unbondingDelegation.Balance.Amount = unbondingDelegation.Balance.Amount - unbondingSlashAmount
 		k.SetUnbondingDelegation(ctx, unbondingDelegation)
 		pool := k.GetPool(ctx)
 
@@ -217,11 +217,11 @@ func (k Keeper) slashRedelegation(ctx sdk.Context, validator types.Validator, re
 	// Possible since the redelegation may already
 	// have been slashed, and slash amounts are calculated
 	// according to stake held at time of infraction
-	redelegationSlashAmount := sdk.MinInt(slashAmount.RoundInt(), redelegation.Balance.Amount)
+	redelegationSlashAmount := sdk.MinInt64(slashAmount.RoundInt(), redelegation.Balance.Amount)
 
 	// Update redelegation if necessary
-	if !redelegationSlashAmount.IsZero() {
-		redelegation.Balance.Amount = redelegation.Balance.Amount.Sub(redelegationSlashAmount)
+	if redelegationSlashAmount != 0 {
+		redelegation.Balance.Amount = redelegation.Balance.Amount - redelegationSlashAmount
 		k.SetRedelegation(ctx, redelegation)
 	}
 

--- a/x/stake/keeper/slash_test.go
+++ b/x/stake/keeper/slash_test.go
@@ -25,7 +25,7 @@ func setupHelper(t *testing.T, amt int64) (sdk.Context, Keeper, types.Params) {
 	// add numVals validators
 	for i := 0; i < numVals; i++ {
 		validator := types.NewValidator(addrVals[i], PKs[i], types.Description{})
-		validator, pool, _ = validator.AddTokensFromDel(pool, sdk.NewInt(amt))
+		validator, pool, _ = validator.AddTokensFromDel(pool, amt)
 		validator.BondIntraTxCounter = int16(i)
 		pool.BondedTokens = pool.BondedTokens.Add(sdk.NewDec(amt))
 		keeper.SetPool(ctx, pool)
@@ -77,8 +77,8 @@ func TestSlashUnbondingDelegation(t *testing.T) {
 		CreationHeight: 0,
 		// expiration timestamp (beyond which the unbonding delegation shouldn't be slashed)
 		MinTime:        time.Unix(0, 0),
-		InitialBalance: sdk.NewInt64Coin(params.BondDenom, 10),
-		Balance:        sdk.NewInt64Coin(params.BondDenom, 10),
+		InitialBalance: sdk.NewCoin(params.BondDenom, 10),
+		Balance:        sdk.NewCoin(params.BondDenom, 10),
 	}
 	keeper.SetUnbondingDelegation(ctx, ubd)
 
@@ -102,10 +102,10 @@ func TestSlashUnbondingDelegation(t *testing.T) {
 	require.True(t, found)
 
 	// initialbalance unchanged
-	require.Equal(t, sdk.NewInt64Coin(params.BondDenom, 10), ubd.InitialBalance)
+	require.Equal(t, sdk.NewCoin(params.BondDenom, 10), ubd.InitialBalance)
 
 	// balance decreased
-	require.Equal(t, sdk.NewInt64Coin(params.BondDenom, 5), ubd.Balance)
+	require.Equal(t, sdk.NewCoin(params.BondDenom, 5), ubd.Balance)
 	newPool := keeper.GetPool(ctx)
 	require.Equal(t, int64(5), oldPool.LooseTokens.Sub(newPool.LooseTokens).RoundInt64())
 }
@@ -125,8 +125,8 @@ func TestSlashRedelegation(t *testing.T) {
 		MinTime:        time.Unix(0, 0),
 		SharesSrc:      sdk.NewDec(10),
 		SharesDst:      sdk.NewDec(10),
-		InitialBalance: sdk.NewInt64Coin(params.BondDenom, 10),
-		Balance:        sdk.NewInt64Coin(params.BondDenom, 10),
+		InitialBalance: sdk.NewCoin(params.BondDenom, 10),
+		Balance:        sdk.NewCoin(params.BondDenom, 10),
 	}
 	keeper.SetRedelegation(ctx, rd)
 
@@ -168,10 +168,10 @@ func TestSlashRedelegation(t *testing.T) {
 	require.Equal(t, 1, len(updates))
 
 	// initialbalance unchanged
-	require.Equal(t, sdk.NewInt64Coin(params.BondDenom, 10), rd.InitialBalance)
+	require.Equal(t, sdk.NewCoin(params.BondDenom, 10), rd.InitialBalance)
 
 	// balance decreased
-	require.Equal(t, sdk.NewInt64Coin(params.BondDenom, 5), rd.Balance)
+	require.Equal(t, sdk.NewCoin(params.BondDenom, 5), rd.Balance)
 
 	// shares decreased
 	del, found = keeper.GetDelegation(ctx, addrDels[0], addrVals[1])
@@ -259,8 +259,8 @@ func TestSlashWithUnbondingDelegation(t *testing.T) {
 		CreationHeight: 11,
 		// expiration timestamp (beyond which the unbonding delegation shouldn't be slashed)
 		MinTime:        time.Unix(0, 0),
-		InitialBalance: sdk.NewInt64Coin(params.BondDenom, 4),
-		Balance:        sdk.NewInt64Coin(params.BondDenom, 4),
+		InitialBalance: sdk.NewCoin(params.BondDenom, 4),
+		Balance:        sdk.NewCoin(params.BondDenom, 4),
 	}
 	keeper.SetUnbondingDelegation(ctx, ubd)
 
@@ -279,7 +279,7 @@ func TestSlashWithUnbondingDelegation(t *testing.T) {
 	ubd, found = keeper.GetUnbondingDelegation(ctx, addrDels[0], addrVals[0])
 	require.True(t, found)
 	// balance decreased
-	require.Equal(t, sdk.NewInt(2), ubd.Balance.Amount)
+	require.Equal(t, int64(2), ubd.Balance.Amount)
 	// read updated pool
 	newPool := keeper.GetPool(ctx)
 	// bonded tokens burned
@@ -299,7 +299,7 @@ func TestSlashWithUnbondingDelegation(t *testing.T) {
 	ubd, found = keeper.GetUnbondingDelegation(ctx, addrDels[0], addrVals[0])
 	require.True(t, found)
 	// balance decreased again
-	require.Equal(t, sdk.NewInt(0), ubd.Balance.Amount)
+	require.Equal(t, int64(0), ubd.Balance.Amount)
 	// read updated pool
 	newPool = keeper.GetPool(ctx)
 	// bonded tokens burned again
@@ -319,7 +319,7 @@ func TestSlashWithUnbondingDelegation(t *testing.T) {
 	ubd, found = keeper.GetUnbondingDelegation(ctx, addrDels[0], addrVals[0])
 	require.True(t, found)
 	// balance unchanged
-	require.Equal(t, sdk.NewInt(0), ubd.Balance.Amount)
+	require.Equal(t, int64(0), ubd.Balance.Amount)
 	// read updated pool
 	newPool = keeper.GetPool(ctx)
 	// bonded tokens burned again
@@ -339,7 +339,7 @@ func TestSlashWithUnbondingDelegation(t *testing.T) {
 	ubd, found = keeper.GetUnbondingDelegation(ctx, addrDels[0], addrVals[0])
 	require.True(t, found)
 	// balance unchanged
-	require.Equal(t, sdk.NewInt(0), ubd.Balance.Amount)
+	require.Equal(t, int64(0), ubd.Balance.Amount)
 	// read updated pool
 	newPool = keeper.GetPool(ctx)
 	// just 1 bonded token burned again since that's all the validator now has
@@ -368,8 +368,8 @@ func TestSlashWithRedelegation(t *testing.T) {
 		MinTime:          time.Unix(0, 0),
 		SharesSrc:        sdk.NewDec(6),
 		SharesDst:        sdk.NewDec(6),
-		InitialBalance:   sdk.NewInt64Coin(params.BondDenom, 6),
-		Balance:          sdk.NewInt64Coin(params.BondDenom, 6),
+		InitialBalance:   sdk.NewCoin(params.BondDenom, 6),
+		Balance:          sdk.NewCoin(params.BondDenom, 6),
 	}
 	keeper.SetRedelegation(ctx, rd)
 
@@ -397,7 +397,7 @@ func TestSlashWithRedelegation(t *testing.T) {
 	rd, found = keeper.GetRedelegation(ctx, addrDels[0], addrVals[0], addrVals[1])
 	require.True(t, found)
 	// balance decreased
-	require.Equal(t, sdk.NewInt(3), rd.Balance.Amount)
+	require.Equal(t, int64(3), rd.Balance.Amount)
 	// read updated pool
 	newPool := keeper.GetPool(ctx)
 	// bonded tokens burned
@@ -421,7 +421,7 @@ func TestSlashWithRedelegation(t *testing.T) {
 	rd, found = keeper.GetRedelegation(ctx, addrDels[0], addrVals[0], addrVals[1])
 	require.True(t, found)
 	// balance decreased, now zero
-	require.Equal(t, sdk.NewInt(0), rd.Balance.Amount)
+	require.Equal(t, int64(0), rd.Balance.Amount)
 	// read updated pool
 	newPool = keeper.GetPool(ctx)
 	// seven bonded tokens burned
@@ -442,7 +442,7 @@ func TestSlashWithRedelegation(t *testing.T) {
 	rd, found = keeper.GetRedelegation(ctx, addrDels[0], addrVals[0], addrVals[1])
 	require.True(t, found)
 	// balance still zero
-	require.Equal(t, sdk.NewInt(0), rd.Balance.Amount)
+	require.Equal(t, int64(0), rd.Balance.Amount)
 	// read updated pool
 	newPool = keeper.GetPool(ctx)
 	// four more bonded tokens burned
@@ -466,7 +466,7 @@ func TestSlashWithRedelegation(t *testing.T) {
 	rd, found = keeper.GetRedelegation(ctx, addrDels[0], addrVals[0], addrVals[1])
 	require.True(t, found)
 	// balance still zero
-	require.Equal(t, sdk.NewInt(0), rd.Balance.Amount)
+	require.Equal(t, int64(0), rd.Balance.Amount)
 	// read updated pool
 	newPool = keeper.GetPool(ctx)
 	// no more bonded tokens burned
@@ -492,8 +492,8 @@ func TestSlashBoth(t *testing.T) {
 		MinTime:        time.Unix(0, 0),
 		SharesSrc:      sdk.NewDec(6),
 		SharesDst:      sdk.NewDec(6),
-		InitialBalance: sdk.NewInt64Coin(params.BondDenom, 6),
-		Balance:        sdk.NewInt64Coin(params.BondDenom, 6),
+		InitialBalance: sdk.NewCoin(params.BondDenom, 6),
+		Balance:        sdk.NewCoin(params.BondDenom, 6),
 	}
 	keeper.SetRedelegation(ctx, rdA)
 
@@ -512,8 +512,8 @@ func TestSlashBoth(t *testing.T) {
 		CreationHeight: 11,
 		// expiration timestamp (beyond which the unbonding delegation shouldn't be slashed)
 		MinTime:        time.Unix(0, 0),
-		InitialBalance: sdk.NewInt64Coin(params.BondDenom, 4),
-		Balance:        sdk.NewInt64Coin(params.BondDenom, 4),
+		InitialBalance: sdk.NewCoin(params.BondDenom, 4),
+		Balance:        sdk.NewCoin(params.BondDenom, 4),
 	}
 	keeper.SetUnbondingDelegation(ctx, ubdA)
 
@@ -529,7 +529,7 @@ func TestSlashBoth(t *testing.T) {
 	rdA, found = keeper.GetRedelegation(ctx, addrDels[0], addrVals[0], addrVals[1])
 	require.True(t, found)
 	// balance decreased
-	require.Equal(t, sdk.NewInt(3), rdA.Balance.Amount)
+	require.Equal(t, int64(3), rdA.Balance.Amount)
 	// read updated pool
 	newPool := keeper.GetPool(ctx)
 	// loose tokens burned

--- a/x/stake/keeper/test_common.go
+++ b/x/stake/keeper/test_common.go
@@ -116,7 +116,7 @@ func CreateTestInput(t *testing.T, isCheckTx bool, initCoins int64) (sdk.Context
 	for _, addr := range Addrs {
 		pool := keeper.GetPool(ctx)
 		_, _, err := ck.AddCoins(ctx, addr, sdk.Coins{
-			{keeper.BondDenom(ctx), sdk.NewInt(initCoins)},
+			{keeper.BondDenom(ctx), initCoins},
 		})
 		require.Nil(t, err)
 		pool.LooseTokens = pool.LooseTokens.Add(sdk.NewDec(initCoins))

--- a/x/stake/keeper/val_state_change.go
+++ b/x/stake/keeper/val_state_change.go
@@ -27,7 +27,7 @@ func (k Keeper) ApplyAndReturnValidatorSetUpdates(ctx sdk.Context) (updates []ab
 
 	store := ctx.KVStore(k.storeKey)
 	maxValidators := k.GetParams(ctx).MaxValidators
-	totalPower := sdk.ZeroInt()
+	var totalPower int64
 
 	// Retrieve the last validator set.
 	// The persistent set is updated later in this function.
@@ -73,13 +73,13 @@ func (k Keeper) ApplyAndReturnValidatorSetUpdates(ctx sdk.Context) (updates []ab
 
 		// calculate the new power bytes
 		newPower := validator.BondedTokens().RoundInt64()
-		newPowerBytes := k.cdc.MustMarshalBinary(sdk.NewInt(newPower))
+		newPowerBytes := k.cdc.MustMarshalBinary(newPower)
 		// update the validator set if power has changed
 		if !found || !bytes.Equal(oldPowerBytes, newPowerBytes) {
 			updates = append(updates, validator.ABCIValidatorUpdate())
 
 			// set validator power on lookup index.
-			k.SetLastValidatorPower(ctx, operator, sdk.NewInt(newPower))
+			k.SetLastValidatorPower(ctx, operator, newPower)
 		}
 
 		// validator still in the validator set, so delete from the copy
@@ -87,7 +87,7 @@ func (k Keeper) ApplyAndReturnValidatorSetUpdates(ctx sdk.Context) (updates []ab
 
 		// keep count
 		count++
-		totalPower = totalPower.Add(sdk.NewInt(newPower))
+		totalPower = totalPower + newPower
 	}
 
 	// sort the no-longer-bonded validators

--- a/x/stake/keeper/validator.go
+++ b/x/stake/keeper/validator.go
@@ -124,7 +124,7 @@ func (k Keeper) SetNewValidatorByPowerIndex(ctx sdk.Context, validator types.Val
 
 // Update the tokens of an existing validator, update the validators power index key
 func (k Keeper) AddValidatorTokensAndShares(ctx sdk.Context, validator types.Validator,
-	tokensToAdd sdk.Int) (valOut types.Validator, addedShares sdk.Dec) {
+	tokensToAdd int64) (valOut types.Validator, addedShares sdk.Dec) {
 
 	pool := k.GetPool(ctx)
 	k.DeleteValidatorByPowerIndex(ctx, validator, pool)

--- a/x/stake/keeper/validator_test.go
+++ b/x/stake/keeper/validator_test.go
@@ -24,7 +24,7 @@ func TestSetValidator(t *testing.T) {
 
 	// test how the validator is set from a purely unbonbed pool
 	validator := types.NewValidator(valAddr, valPubKey, types.Description{})
-	validator, pool, _ = validator.AddTokensFromDel(pool, sdk.NewInt(10))
+	validator, pool, _ = validator.AddTokensFromDel(pool, 10)
 	require.Equal(t, sdk.Unbonded, validator.Status)
 	assert.True(sdk.DecEq(t, sdk.NewDec(10), validator.Tokens))
 	assert.True(sdk.DecEq(t, sdk.NewDec(10), validator.DelegatorShares))
@@ -80,7 +80,7 @@ func TestUpdateValidatorByPowerIndex(t *testing.T) {
 
 	// add a validator
 	validator := types.NewValidator(addrVals[0], PKs[0], types.Description{})
-	validator, pool, delSharesCreated := validator.AddTokensFromDel(pool, sdk.NewInt(100))
+	validator, pool, delSharesCreated := validator.AddTokensFromDel(pool, 100)
 	require.Equal(t, sdk.Unbonded, validator.Status)
 	require.Equal(t, int64(100), validator.Tokens.RoundInt64())
 	keeper.SetPool(ctx, pool)
@@ -132,7 +132,7 @@ func TestUpdateBondedValidatorsDecreaseCliff(t *testing.T) {
 		val := types.NewValidator(sdk.ValAddress(Addrs[i]), PKs[i], types.Description{Moniker: moniker})
 		val.BondHeight = int64(i)
 		val.BondIntraTxCounter = int16(i)
-		val, pool, _ = val.AddTokensFromDel(pool, sdk.NewInt(int64((i+1)*10)))
+		val, pool, _ = val.AddTokensFromDel(pool, int64((i+1)*10))
 
 		keeper.SetPool(ctx, pool)
 		val = TestingUpdateValidator(keeper, ctx, val)
@@ -173,7 +173,7 @@ func TestSlashToZeroPowerRemoved(t *testing.T) {
 
 	// add a validator
 	validator := types.NewValidator(addrVals[0], PKs[0], types.Description{})
-	validator, pool, _ = validator.AddTokensFromDel(pool, sdk.NewInt(100))
+	validator, pool, _ = validator.AddTokensFromDel(pool, 100)
 	require.Equal(t, sdk.Unbonded, validator.Status)
 	require.Equal(t, int64(100), validator.Tokens.RoundInt64())
 	keeper.SetPool(ctx, pool)
@@ -203,7 +203,7 @@ func TestValidatorBasics(t *testing.T) {
 		validators[i] = types.NewValidator(addrVals[i], PKs[i], types.Description{})
 		validators[i].Status = sdk.Unbonded
 		validators[i].Tokens = sdk.ZeroDec()
-		validators[i], pool, _ = validators[i].AddTokensFromDel(pool, sdk.NewInt(amt))
+		validators[i], pool, _ = validators[i].AddTokensFromDel(pool, amt)
 		keeper.SetPool(ctx, pool)
 	}
 	assert.True(sdk.DecEq(t, sdk.NewDec(9), validators[0].Tokens))
@@ -441,7 +441,7 @@ func TestGetValidatorsEdgeCases(t *testing.T) {
 		pool := keeper.GetPool(ctx)
 		moniker := fmt.Sprintf("val#%d", int64(i))
 		validators[i] = types.NewValidator(sdk.ValAddress(Addrs[i]), PKs[i], types.Description{Moniker: moniker})
-		validators[i], pool, _ = validators[i].AddTokensFromDel(pool, sdk.NewInt(amt))
+		validators[i], pool, _ = validators[i].AddTokensFromDel(pool, amt)
 		validators[i].BondIntraTxCounter = int16(i)
 		keeper.SetPool(ctx, pool)
 		validators[i] = TestingUpdateValidator(keeper, ctx, validators[i])
@@ -458,7 +458,7 @@ func TestGetValidatorsEdgeCases(t *testing.T) {
 
 	pool := keeper.GetPool(ctx)
 	keeper.DeleteValidatorByPowerIndex(ctx, validators[0], pool)
-	validators[0], pool, _ = validators[0].AddTokensFromDel(pool, sdk.NewInt(500))
+	validators[0], pool, _ = validators[0].AddTokensFromDel(pool, 500)
 	keeper.SetPool(ctx, pool)
 	validators[0] = TestingUpdateValidator(keeper, ctx, validators[0])
 	resValidators = keeper.GetBondedValidatorsByPower(ctx)
@@ -476,7 +476,7 @@ func TestGetValidatorsEdgeCases(t *testing.T) {
 	validators[3], found = keeper.GetValidator(ctx, validators[3].OperatorAddr)
 	require.True(t, found)
 	keeper.DeleteValidatorByPowerIndex(ctx, validators[3], pool)
-	validators[3], pool, _ = validators[3].AddTokensFromDel(pool, sdk.NewInt(1))
+	validators[3], pool, _ = validators[3].AddTokensFromDel(pool, 1)
 	keeper.SetPool(ctx, pool)
 	validators[3] = TestingUpdateValidator(keeper, ctx, validators[3])
 	resValidators = keeper.GetBondedValidatorsByPower(ctx)
@@ -496,7 +496,7 @@ func TestGetValidatorsEdgeCases(t *testing.T) {
 
 	// validator 4 does not get spot back
 	keeper.DeleteValidatorByPowerIndex(ctx, validators[3], pool)
-	validators[3], pool, _ = validators[3].AddTokensFromDel(pool, sdk.NewInt(200))
+	validators[3], pool, _ = validators[3].AddTokensFromDel(pool, 200)
 	keeper.SetPool(ctx, pool)
 	validators[3] = TestingUpdateValidator(keeper, ctx, validators[3])
 	resValidators = keeper.GetBondedValidatorsByPower(ctx)
@@ -526,9 +526,9 @@ func TestValidatorBondHeight(t *testing.T) {
 	validators[1].BondIntraTxCounter = 1
 	validators[2].BondIntraTxCounter = 2
 
-	validators[0], pool, _ = validators[0].AddTokensFromDel(pool, sdk.NewInt(200))
-	validators[1], pool, _ = validators[1].AddTokensFromDel(pool, sdk.NewInt(100))
-	validators[2], pool, _ = validators[2].AddTokensFromDel(pool, sdk.NewInt(100))
+	validators[0], pool, _ = validators[0].AddTokensFromDel(pool, 200)
+	validators[1], pool, _ = validators[1].AddTokensFromDel(pool, 100)
+	validators[2], pool, _ = validators[2].AddTokensFromDel(pool, 100)
 	keeper.SetPool(ctx, pool)
 
 	validators[0] = TestingUpdateValidator(keeper, ctx, validators[0])
@@ -548,8 +548,8 @@ func TestValidatorBondHeight(t *testing.T) {
 	assert.True(ValEq(t, validators[1], resValidators[1]))
 	keeper.DeleteValidatorByPowerIndex(ctx, validators[1], pool)
 	keeper.DeleteValidatorByPowerIndex(ctx, validators[2], pool)
-	validators[1], pool, _ = validators[1].AddTokensFromDel(pool, sdk.NewInt(50))
-	validators[2], pool, _ = validators[2].AddTokensFromDel(pool, sdk.NewInt(50))
+	validators[1], pool, _ = validators[1].AddTokensFromDel(pool, 50)
+	validators[2], pool, _ = validators[2].AddTokensFromDel(pool, 50)
 	keeper.SetPool(ctx, pool)
 	validators[2] = TestingUpdateValidator(keeper, ctx, validators[2])
 	resValidators = keeper.GetBondedValidatorsByPower(ctx)
@@ -572,7 +572,7 @@ func TestFullValidatorSetPowerChange(t *testing.T) {
 	for i, amt := range amts {
 		pool := keeper.GetPool(ctx)
 		validators[i] = types.NewValidator(sdk.ValAddress(Addrs[i]), PKs[i], types.Description{})
-		validators[i], pool, _ = validators[i].AddTokensFromDel(pool, sdk.NewInt(amt))
+		validators[i], pool, _ = validators[i].AddTokensFromDel(pool, amt)
 		validators[i].BondIntraTxCounter = int16(i)
 		keeper.SetPool(ctx, pool)
 		TestingUpdateValidator(keeper, ctx, validators[i])
@@ -594,7 +594,7 @@ func TestFullValidatorSetPowerChange(t *testing.T) {
 
 	// test a swap in voting power
 	pool := keeper.GetPool(ctx)
-	validators[0], pool, _ = validators[0].AddTokensFromDel(pool, sdk.NewInt(600))
+	validators[0], pool, _ = validators[0].AddTokensFromDel(pool, 600)
 	keeper.SetPool(ctx, pool)
 	validators[0] = TestingUpdateValidator(keeper, ctx, validators[0])
 	resValidators = keeper.GetBondedValidatorsByPower(ctx)
@@ -615,7 +615,7 @@ func TestApplyAndReturnValidatorSetUpdatesAllNone(t *testing.T) {
 		valAddr := sdk.ValAddress(valPubKey.Address().Bytes())
 
 		validators[i] = types.NewValidator(valAddr, valPubKey, types.Description{})
-		validators[i], pool, _ = validators[i].AddTokensFromDel(pool, sdk.NewInt(amt))
+		validators[i], pool, _ = validators[i].AddTokensFromDel(pool, amt)
 		keeper.SetPool(ctx, pool)
 	}
 
@@ -644,7 +644,7 @@ func TestApplyAndReturnValidatorSetUpdatesIdentical(t *testing.T) {
 	for i, amt := range amts {
 		pool := keeper.GetPool(ctx)
 		validators[i] = types.NewValidator(sdk.ValAddress(Addrs[i]), PKs[i], types.Description{})
-		validators[i], pool, _ = validators[i].AddTokensFromDel(pool, sdk.NewInt(amt))
+		validators[i], pool, _ = validators[i].AddTokensFromDel(pool, amt)
 		keeper.SetPool(ctx, pool)
 	}
 	validators[0] = TestingUpdateValidator(keeper, ctx, validators[0])
@@ -666,7 +666,7 @@ func TestApplyAndReturnValidatorSetUpdatesSingleValueChange(t *testing.T) {
 	for i, amt := range amts {
 		pool := keeper.GetPool(ctx)
 		validators[i] = types.NewValidator(sdk.ValAddress(Addrs[i]), PKs[i], types.Description{})
-		validators[i], pool, _ = validators[i].AddTokensFromDel(pool, sdk.NewInt(amt))
+		validators[i], pool, _ = validators[i].AddTokensFromDel(pool, amt)
 		keeper.SetPool(ctx, pool)
 	}
 	validators[0] = TestingUpdateValidator(keeper, ctx, validators[0])
@@ -693,7 +693,7 @@ func TestApplyAndReturnValidatorSetUpdatesMultipleValueChange(t *testing.T) {
 	for i, amt := range amts {
 		pool := keeper.GetPool(ctx)
 		validators[i] = types.NewValidator(sdk.ValAddress(Addrs[i]), PKs[i], types.Description{})
-		validators[i], pool, _ = validators[i].AddTokensFromDel(pool, sdk.NewInt(amt))
+		validators[i], pool, _ = validators[i].AddTokensFromDel(pool, amt)
 		keeper.SetPool(ctx, pool)
 	}
 	validators[0] = TestingUpdateValidator(keeper, ctx, validators[0])
@@ -703,8 +703,8 @@ func TestApplyAndReturnValidatorSetUpdatesMultipleValueChange(t *testing.T) {
 	// test multiple value change
 	//  tendermintUpdate set: {c1, c3} -> {c1', c3'}
 	pool := keeper.GetPool(ctx)
-	validators[0], pool, _ = validators[0].AddTokensFromDel(pool, sdk.NewInt(190))
-	validators[1], pool, _ = validators[1].AddTokensFromDel(pool, sdk.NewInt(80))
+	validators[0], pool, _ = validators[0].AddTokensFromDel(pool, 190)
+	validators[1], pool, _ = validators[1].AddTokensFromDel(pool, 80)
 	keeper.SetPool(ctx, pool)
 	validators[0] = TestingUpdateValidator(keeper, ctx, validators[0])
 	validators[1] = TestingUpdateValidator(keeper, ctx, validators[1])
@@ -723,7 +723,7 @@ func TestApplyAndReturnValidatorSetUpdatesInserted(t *testing.T) {
 	for i, amt := range amts {
 		pool := keeper.GetPool(ctx)
 		validators[i] = types.NewValidator(sdk.ValAddress(Addrs[i]), PKs[i], types.Description{})
-		validators[i], pool, _ = validators[i].AddTokensFromDel(pool, sdk.NewInt(amt))
+		validators[i], pool, _ = validators[i].AddTokensFromDel(pool, amt)
 		keeper.SetPool(ctx, pool)
 	}
 	validators[0] = TestingUpdateValidator(keeper, ctx, validators[0])
@@ -772,7 +772,7 @@ func TestApplyAndReturnValidatorSetUpdatesWithCliffValidator(t *testing.T) {
 	for i, amt := range amts {
 		pool := keeper.GetPool(ctx)
 		validators[i] = types.NewValidator(sdk.ValAddress(Addrs[i]), PKs[i], types.Description{})
-		validators[i], pool, _ = validators[i].AddTokensFromDel(pool, sdk.NewInt(amt))
+		validators[i], pool, _ = validators[i].AddTokensFromDel(pool, amt)
 		keeper.SetPool(ctx, pool)
 	}
 	validators[0] = TestingUpdateValidator(keeper, ctx, validators[0])
@@ -790,7 +790,7 @@ func TestApplyAndReturnValidatorSetUpdatesWithCliffValidator(t *testing.T) {
 	require.Equal(t, 0, len(keeper.ApplyAndReturnValidatorSetUpdates(ctx)))
 
 	pool := keeper.GetPool(ctx)
-	validators[2], pool, _ = validators[2].AddTokensFromDel(pool, sdk.NewInt(10))
+	validators[2], pool, _ = validators[2].AddTokensFromDel(pool, 10)
 	keeper.SetPool(ctx, pool)
 	keeper.SetValidator(ctx, validators[2])
 	keeper.SetValidatorByPowerIndex(ctx, validators[2], pool)
@@ -809,7 +809,7 @@ func TestApplyAndReturnValidatorSetUpdatesPowerDecrease(t *testing.T) {
 	for i, amt := range amts {
 		pool := keeper.GetPool(ctx)
 		validators[i] = types.NewValidator(sdk.ValAddress(Addrs[i]), PKs[i], types.Description{})
-		validators[i], pool, _ = validators[i].AddTokensFromDel(pool, sdk.NewInt(amt))
+		validators[i], pool, _ = validators[i].AddTokensFromDel(pool, amt)
 		validators[i].BondIntraTxCounter = int16(i)
 		keeper.SetPool(ctx, pool)
 	}
@@ -859,7 +859,7 @@ func TestApplyAndReturnValidatorSetUpdatesNewValidator(t *testing.T) {
 
 		validators[i] = types.NewValidator(valAddr, valPubKey, types.Description{})
 		validators[i].BondIntraTxCounter = int16(i)
-		validators[i], pool, _ = validators[i].AddTokensFromDel(pool, sdk.NewInt(amt))
+		validators[i], pool, _ = validators[i].AddTokensFromDel(pool, amt)
 
 		keeper.SetPool(ctx, pool)
 		keeper.SetValidator(ctx, validators[i])
@@ -880,7 +880,7 @@ func TestApplyAndReturnValidatorSetUpdatesNewValidator(t *testing.T) {
 	for i, amt := range amts {
 		pool := keeper.GetPool(ctx)
 		keeper.DeleteValidatorByPowerIndex(ctx, validators[i], pool)
-		validators[i], pool, _ = validators[i].AddTokensFromDel(pool, sdk.NewInt(amt))
+		validators[i], pool, _ = validators[i].AddTokensFromDel(pool, amt)
 
 		keeper.SetPool(ctx, pool)
 		keeper.SetValidator(ctx, validators[i])
@@ -892,7 +892,7 @@ func TestApplyAndReturnValidatorSetUpdatesNewValidator(t *testing.T) {
 	pool := keeper.GetPool(ctx)
 	valPubKey := PKs[len(validators)+1]
 	valAddr := sdk.ValAddress(valPubKey.Address().Bytes())
-	amt := sdk.NewInt(100)
+	amt := int64(100)
 
 	validator := types.NewValidator(valAddr, valPubKey, types.Description{})
 	validator, pool, _ = validator.AddTokensFromDel(pool, amt)
@@ -909,7 +909,7 @@ func TestApplyAndReturnValidatorSetUpdatesNewValidator(t *testing.T) {
 	valAddr = sdk.ValAddress(valPubKey.Address().Bytes())
 
 	validator = types.NewValidator(valAddr, valPubKey, types.Description{})
-	validator, pool, _ = validator.AddTokensFromDel(pool, sdk.NewInt(500))
+	validator, pool, _ = validator.AddTokensFromDel(pool, 500)
 	keeper.SetValidator(ctx, validator)
 	keeper.SetValidatorByPowerIndex(ctx, validator, pool)
 	keeper.SetPool(ctx, pool)
@@ -943,7 +943,7 @@ func TestApplyAndReturnValidatorSetUpdatesBondTransition(t *testing.T) {
 		valAddr := sdk.ValAddress(valPubKey.Address().Bytes())
 
 		validators[i] = types.NewValidator(valAddr, valPubKey, types.Description{Moniker: moniker})
-		validators[i], pool, _ = validators[i].AddTokensFromDel(pool, sdk.NewInt(amt))
+		validators[i], pool, _ = validators[i].AddTokensFromDel(pool, amt)
 		validators[i].BondIntraTxCounter = int16(i)
 		keeper.SetPool(ctx, pool)
 		keeper.SetValidator(ctx, validators[i])
@@ -969,7 +969,7 @@ func TestApplyAndReturnValidatorSetUpdatesBondTransition(t *testing.T) {
 	require.True(t, found)
 
 	keeper.DeleteValidatorByPowerIndex(ctx, validators[0], pool)
-	validators[0], pool, _ = validators[0].AddTokensFromDel(pool, sdk.NewInt(1))
+	validators[0], pool, _ = validators[0].AddTokensFromDel(pool, 1)
 	keeper.SetPool(ctx, pool)
 	keeper.SetValidator(ctx, validators[0])
 	keeper.SetValidatorByPowerIndex(ctx, validators[0], pool)
@@ -994,7 +994,7 @@ func TestApplyAndReturnValidatorSetUpdatesBondTransition(t *testing.T) {
 	require.Equal(t, 0, len(updates))
 
 	keeper.DeleteValidatorByPowerIndex(ctx, validators[1], pool)
-	validators[1], pool, _ = validators[1].AddTokensFromDel(pool, sdk.NewInt(250))
+	validators[1], pool, _ = validators[1].AddTokensFromDel(pool, 250)
 	keeper.SetPool(ctx, pool)
 	keeper.SetValidator(ctx, validators[1])
 	keeper.SetValidatorByPowerIndex(ctx, validators[1], pool)

--- a/x/stake/querier/queryable_test.go
+++ b/x/stake/querier/queryable_test.go
@@ -41,7 +41,7 @@ func TestNewQuerier(t *testing.T) {
 	ctx, _, keeper := keep.CreateTestInput(t, false, 1000)
 	pool := keeper.GetPool(ctx)
 	// Create Validators
-	amts := []sdk.Int{sdk.NewInt(9), sdk.NewInt(8)}
+	amts := []int64{9, 8}
 	var validators [2]types.Validator
 	for i, amt := range amts {
 		validators[i] = types.NewValidator(sdk.ValAddress(keep.Addrs[i]), keep.PKs[i], types.Description{})
@@ -136,7 +136,7 @@ func TestQueryValidators(t *testing.T) {
 	params := keeper.GetParams(ctx)
 
 	// Create Validators
-	amts := []sdk.Int{sdk.NewInt(9), sdk.NewInt(8)}
+	amts := []int64{9, 8}
 	var validators [2]types.Validator
 	for i, amt := range amts {
 		validators[i] = types.NewValidator(sdk.ValAddress(keep.Addrs[i]), keep.PKs[i], types.Description{})
@@ -189,7 +189,7 @@ func TestQueryDelegation(t *testing.T) {
 	pool := keeper.GetPool(ctx)
 	keeper.SetValidatorByPowerIndex(ctx, val1, pool)
 
-	keeper.Delegate(ctx, addrAcc2, sdk.NewCoin("steak", sdk.NewInt(20)), val1, true)
+	keeper.Delegate(ctx, addrAcc2, sdk.NewCoin("steak", 20), val1, true)
 
 	// apply TM updates
 	keeper.ApplyAndReturnValidatorSetUpdates(ctx)
@@ -346,7 +346,7 @@ func TestQueryRedelegations(t *testing.T) {
 	keeper.SetValidator(ctx, val1)
 	keeper.SetValidator(ctx, val2)
 
-	keeper.Delegate(ctx, addrAcc2, sdk.NewCoin("steak", sdk.NewInt(100)), val1, true)
+	keeper.Delegate(ctx, addrAcc2, sdk.NewCoin("steak", 100), val1, true)
 	keeper.ApplyAndReturnValidatorSetUpdates(ctx)
 
 	keeper.BeginRedelegation(ctx, addrAcc2, val1.GetOperator(), val2.GetOperator(), sdk.NewDec(20))

--- a/x/stake/simulation/msgs.go
+++ b/x/stake/simulation/msgs.go
@@ -25,21 +25,21 @@ func SimulateMsgCreateValidator(m auth.AccountKeeper, k stake.Keeper) simulation
 			Moniker: simulation.RandStringOfLength(r, 10),
 		}
 
-		maxCommission := sdk.NewInt(10)
+		maxCommission := int64(10)
 		commission := stake.NewCommissionMsg(
-			sdk.NewDecWithPrec(simulation.RandomAmount(r, maxCommission).Int64(), 1),
-			sdk.NewDecWithPrec(simulation.RandomAmount(r, maxCommission).Int64(), 1),
-			sdk.NewDecWithPrec(simulation.RandomAmount(r, maxCommission).Int64(), 1),
+			sdk.NewDecWithPrec(simulation.RandomAmount(r, maxCommission), 1),
+			sdk.NewDecWithPrec(simulation.RandomAmount(r, maxCommission), 1),
+			sdk.NewDecWithPrec(simulation.RandomAmount(r, maxCommission), 1),
 		)
 
 		acc := simulation.RandomAcc(r, accs)
 		address := sdk.ValAddress(acc.Address)
 		amount := m.GetAccount(ctx, acc.Address).GetCoins().AmountOf(denom)
-		if amount.GT(sdk.ZeroInt()) {
+		if amount > 0 {
 			amount = simulation.RandomAmount(r, amount)
 		}
 
-		if amount.Equal(sdk.ZeroInt()) {
+		if amount == 0 {
 			return "no-operation", nil, nil
 		}
 
@@ -84,8 +84,8 @@ func SimulateMsgEditValidator(k stake.Keeper) simulation.Operation {
 			Details:  simulation.RandStringOfLength(r, 10),
 		}
 
-		maxCommission := sdk.NewInt(10)
-		newCommissionRate := sdk.NewDecWithPrec(simulation.RandomAmount(r, maxCommission).Int64(), 1)
+		maxCommission := int64(10)
+		newCommissionRate := sdk.NewDecWithPrec(simulation.RandomAmount(r, maxCommission), 1)
 
 		acc := simulation.RandomAcc(r, accs)
 		address := sdk.ValAddress(acc.Address)
@@ -123,10 +123,10 @@ func SimulateMsgDelegate(m auth.AccountKeeper, k stake.Keeper) simulation.Operat
 		delegatorAcc := simulation.RandomAcc(r, accs)
 		delegatorAddress := delegatorAcc.Address
 		amount := m.GetAccount(ctx, delegatorAddress).GetCoins().AmountOf(denom)
-		if amount.GT(sdk.ZeroInt()) {
+		if amount > 0 {
 			amount = simulation.RandomAmount(r, amount)
 		}
-		if amount.Equal(sdk.ZeroInt()) {
+		if amount == 0 {
 			return "no-operation", nil, nil
 		}
 		msg := stake.MsgDelegate{
@@ -161,10 +161,10 @@ func SimulateMsgBeginUnbonding(m auth.AccountKeeper, k stake.Keeper) simulation.
 		delegatorAcc := simulation.RandomAcc(r, accs)
 		delegatorAddress := delegatorAcc.Address
 		amount := m.GetAccount(ctx, delegatorAddress).GetCoins().AmountOf(denom)
-		if amount.GT(sdk.ZeroInt()) {
+		if amount > 0 {
 			amount = simulation.RandomAmount(r, amount)
 		}
-		if amount.Equal(sdk.ZeroInt()) {
+		if amount == 0 {
 			return "no-operation", nil, nil
 		}
 		msg := stake.MsgBeginUnbonding{
@@ -202,10 +202,10 @@ func SimulateMsgBeginRedelegate(m auth.AccountKeeper, k stake.Keeper) simulation
 		delegatorAddress := delegatorAcc.Address
 		// TODO
 		amount := m.GetAccount(ctx, delegatorAddress).GetCoins().AmountOf(denom)
-		if amount.GT(sdk.ZeroInt()) {
+		if amount > 0 {
 			amount = simulation.RandomAmount(r, amount)
 		}
-		if amount.Equal(sdk.ZeroInt()) {
+		if amount == 0 {
 			return "no-operation", nil, nil
 		}
 		msg := stake.MsgBeginRedelegate{
@@ -237,16 +237,16 @@ func Setup(mapp *mock.App, k stake.Keeper) simulation.RandSetup {
 		stake.InitGenesis(ctx, k, gen)
 		params := k.GetParams(ctx)
 		denom := params.BondDenom
-		loose := sdk.ZeroInt()
+		var loose int64
 		mapp.AccountKeeper.IterateAccounts(ctx, func(acc auth.Account) bool {
-			balance := simulation.RandomAmount(r, sdk.NewInt(1000000))
+			balance := simulation.RandomAmount(r, int64(1000000))
 			acc.SetCoins(acc.GetCoins().Plus(sdk.Coins{sdk.NewCoin(denom, balance)}))
 			mapp.AccountKeeper.SetAccount(ctx, acc)
-			loose = loose.Add(balance)
+			loose = loose + balance
 			return false
 		})
 		pool := k.GetPool(ctx)
-		pool.LooseTokens = pool.LooseTokens.Add(sdk.NewDec(loose.Int64()))
+		pool.LooseTokens = pool.LooseTokens.Add(sdk.NewDec(loose))
 		k.SetPool(ctx, pool)
 	}
 }

--- a/x/stake/test_common.go
+++ b/x/stake/test_common.go
@@ -16,14 +16,14 @@ var (
 	addr3 = sdk.AccAddress(ed25519.GenPrivKey().PubKey().Address())
 	priv4 = ed25519.GenPrivKey()
 	addr4 = sdk.AccAddress(priv4.PubKey().Address())
-	coins = sdk.Coins{sdk.NewCoin("foocoin", sdk.NewInt(10))}
+	coins = sdk.Coins{sdk.NewCoin("foocoin", 10)}
 
 	commissionMsg = NewCommissionMsg(sdk.ZeroDec(), sdk.ZeroDec(), sdk.ZeroDec())
 )
 
 func NewTestMsgCreateValidator(address sdk.ValAddress, pubKey crypto.PubKey, amt int64) MsgCreateValidator {
 	return types.NewMsgCreateValidator(
-		address, pubKey, sdk.NewCoin("steak", sdk.NewInt(amt)), Description{}, commissionMsg,
+		address, pubKey, sdk.NewCoin("steak", amt), Description{}, commissionMsg,
 	)
 }
 
@@ -33,7 +33,7 @@ func NewTestMsgCreateValidatorWithCommission(address sdk.ValAddress, pubKey cryp
 	commission := NewCommissionMsg(commissionRate, sdk.OneDec(), sdk.ZeroDec())
 
 	return types.NewMsgCreateValidator(
-		address, pubKey, sdk.NewCoin("steak", sdk.NewInt(amt)), Description{}, commission,
+		address, pubKey, sdk.NewCoin("steak", amt), Description{}, commission,
 	)
 }
 
@@ -41,7 +41,7 @@ func NewTestMsgDelegate(delAddr sdk.AccAddress, valAddr sdk.ValAddress, amt int6
 	return MsgDelegate{
 		DelegatorAddr: delAddr,
 		ValidatorAddr: valAddr,
-		Delegation:    sdk.NewCoin("steak", sdk.NewInt(amt)),
+		Delegation:    sdk.NewCoin("steak", amt),
 	}
 }
 
@@ -52,6 +52,6 @@ func NewTestMsgCreateValidatorOnBehalfOf(delAddr sdk.AccAddress, valAddr sdk.Val
 		DelegatorAddr: delAddr,
 		ValidatorAddr: valAddr,
 		PubKey:        valPubKey,
-		Delegation:    sdk.NewCoin("steak", sdk.NewInt(amt)),
+		Delegation:    sdk.NewCoin("steak", amt),
 	}
 }

--- a/x/stake/types/msg.go
+++ b/x/stake/types/msg.go
@@ -96,14 +96,11 @@ func (msg MsgCreateValidator) ValidateBasic() sdk.Error {
 	if msg.ValidatorAddr == nil {
 		return ErrNilValidatorAddr(DefaultCodespace)
 	}
-	if !(msg.Delegation.Amount.GT(sdk.ZeroInt())) {
+	if !(msg.Delegation.Amount > 0) {
 		return ErrBadDelegationAmount(DefaultCodespace)
 	}
 	if msg.Description == (Description{}) {
 		return sdk.NewError(DefaultCodespace, CodeInvalidInput, "description must be included")
-	}
-	if msg.Commission == (CommissionMsg{}) {
-		return sdk.NewError(DefaultCodespace, CodeInvalidInput, "commission must be included")
 	}
 
 	return nil
@@ -212,7 +209,7 @@ func (msg MsgDelegate) ValidateBasic() sdk.Error {
 	if msg.ValidatorAddr == nil {
 		return ErrNilValidatorAddr(DefaultCodespace)
 	}
-	if !(msg.Delegation.Amount.GT(sdk.ZeroInt())) {
+	if !(msg.Delegation.Amount > 0) {
 		return ErrBadDelegationAmount(DefaultCodespace)
 	}
 	return nil

--- a/x/stake/types/msg_test.go
+++ b/x/stake/types/msg_test.go
@@ -10,14 +10,14 @@ import (
 )
 
 var (
-	coinPos  = sdk.NewInt64Coin("steak", 1000)
-	coinZero = sdk.NewInt64Coin("steak", 0)
-	coinNeg  = sdk.NewInt64Coin("steak", -10000)
+	coinPos  = sdk.NewCoin("steak", 1000)
+	coinZero = sdk.NewCoin("steak", 0)
+	coinNeg  = sdk.NewCoin("steak", -10000)
 )
 
 // test ValidateBasic for MsgCreateValidator
 func TestMsgCreateValidator(t *testing.T) {
-	commission1 := NewCommissionMsg(sdk.ZeroDec(), sdk.ZeroDec(), sdk.ZeroDec())
+	commission1 := NewCommissionMsg(sdk.NewDec(1), sdk.NewDec(1), sdk.NewDec(1))
 	commission2 := NewCommissionMsg(sdk.NewDec(5), sdk.NewDec(5), sdk.NewDec(5))
 
 	tests := []struct {
@@ -77,7 +77,7 @@ func TestMsgEditValidator(t *testing.T) {
 
 // test ValidateBasic and GetSigners for MsgCreateValidatorOnBehalfOf
 func TestMsgCreateValidatorOnBehalfOf(t *testing.T) {
-	commission1 := NewCommissionMsg(sdk.ZeroDec(), sdk.ZeroDec(), sdk.ZeroDec())
+	commission1 := NewCommissionMsg(sdk.NewDec(1), sdk.NewDec(1), sdk.NewDec(1))
 	commission2 := NewCommissionMsg(sdk.NewDec(5), sdk.NewDec(5), sdk.NewDec(5))
 
 	tests := []struct {

--- a/x/stake/types/pool.go
+++ b/x/stake/types/pool.go
@@ -50,6 +50,7 @@ func (p Pool) BondedRatio() sdk.Dec {
 //_______________________________________________________________________
 
 func (p Pool) looseTokensToBonded(bondedTokens sdk.Dec) Pool {
+
 	p.BondedTokens = p.BondedTokens.Add(bondedTokens)
 	p.LooseTokens = p.LooseTokens.Sub(bondedTokens)
 	if p.LooseTokens.LT(sdk.ZeroDec()) {

--- a/x/stake/types/validator.go
+++ b/x/stake/types/validator.go
@@ -382,7 +382,7 @@ func (v Validator) SetInitialCommission(commission Commission) (Validator, sdk.E
 //_________________________________________________________________________________________________________
 
 // AddTokensFromDel adds tokens to a validator
-func (v Validator) AddTokensFromDel(pool Pool, amount sdk.Int) (Validator, Pool, sdk.Dec) {
+func (v Validator) AddTokensFromDel(pool Pool, amount int64) (Validator, Pool, sdk.Dec) {
 
 	// bondedShare/delegatedShare
 	exRate := v.DelegatorShareExRate()

--- a/x/stake/types/validator_test.go
+++ b/x/stake/types/validator_test.go
@@ -110,7 +110,7 @@ func TestAddTokensValidatorBonded(t *testing.T) {
 	pool.LooseTokens = sdk.NewDec(10)
 	validator := NewValidator(addr1, pk1, Description{})
 	validator, pool = validator.UpdateStatus(pool, sdk.Bonded)
-	validator, pool, delShares := validator.AddTokensFromDel(pool, sdk.NewInt(10))
+	validator, pool, delShares := validator.AddTokensFromDel(pool, 10)
 
 	require.Equal(t, sdk.OneDec(), validator.DelegatorShareExRate())
 
@@ -123,7 +123,7 @@ func TestAddTokensValidatorUnbonding(t *testing.T) {
 	pool.LooseTokens = sdk.NewDec(10)
 	validator := NewValidator(addr1, pk1, Description{})
 	validator, pool = validator.UpdateStatus(pool, sdk.Unbonding)
-	validator, pool, delShares := validator.AddTokensFromDel(pool, sdk.NewInt(10))
+	validator, pool, delShares := validator.AddTokensFromDel(pool, 10)
 
 	require.Equal(t, sdk.OneDec(), validator.DelegatorShareExRate())
 
@@ -137,7 +137,7 @@ func TestAddTokensValidatorUnbonded(t *testing.T) {
 	pool.LooseTokens = sdk.NewDec(10)
 	validator := NewValidator(addr1, pk1, Description{})
 	validator, pool = validator.UpdateStatus(pool, sdk.Unbonded)
-	validator, pool, delShares := validator.AddTokensFromDel(pool, sdk.NewInt(10))
+	validator, pool, delShares := validator.AddTokensFromDel(pool, 10)
 
 	require.Equal(t, sdk.OneDec(), validator.DelegatorShareExRate())
 
@@ -190,7 +190,7 @@ func TestRemoveDelShares(t *testing.T) {
 	shares := sdk.NewDec(29)
 	_, newPool, tokens := validator.RemoveDelShares(pool, shares)
 
-	exp, err := sdk.NewDecFromStr("1286.5913043477")
+	exp, err := sdk.NewDecFromStr("1286.59130431")
 	require.NoError(t, err)
 
 	require.True(sdk.DecEq(t, exp, tokens))
@@ -205,7 +205,7 @@ func TestUpdateStatus(t *testing.T) {
 	pool.LooseTokens = sdk.NewDec(100)
 
 	validator := NewValidator(addr1, pk1, Description{})
-	validator, pool, _ = validator.AddTokensFromDel(pool, sdk.NewInt(100))
+	validator, pool, _ = validator.AddTokensFromDel(pool, 100)
 	require.Equal(t, sdk.Unbonded, validator.Status)
 	require.Equal(t, int64(100), validator.Tokens.RoundInt64())
 	require.Equal(t, int64(0), pool.BondedTokens.RoundInt64())
@@ -226,7 +226,7 @@ func TestUpdateStatus(t *testing.T) {
 
 func TestPossibleOverflow(t *testing.T) {
 	poolTokens := sdk.NewDec(2159)
-	delShares := sdk.NewDec(391432570689183511).Quo(sdk.NewDec(40113011844664))
+	delShares := sdk.NewDec(39143257068).Quo(sdk.NewDec(4011301))
 	validator := Validator{
 		OperatorAddr:    addr1,
 		ConsPubKey:      pk1,
@@ -240,7 +240,7 @@ func TestPossibleOverflow(t *testing.T) {
 	}
 	tokens := int64(71)
 	msg := fmt.Sprintf("validator %#v", validator)
-	newValidator, _, _ := validator.AddTokensFromDel(pool, sdk.NewInt(tokens))
+	newValidator, _, _ := validator.AddTokensFromDel(pool, tokens)
 
 	msg = fmt.Sprintf("Added %d tokens to %s", tokens, msg)
 	require.False(t, newValidator.DelegatorShareExRate().LT(sdk.ZeroDec()),


### PR DESCRIPTION
## Description
as titled. We use int64 to store coins amount. And so does the staking module. 

While stake is present as decimal, when doing mul, div algorithm we still need big int to avoid overflow.

This PR also change the decimal from 10 to 8.

## Rationale
We use int64 to store coins amount instead of bigInt. 

## Example
no
## Preflight checks
  build passed (make build)
  tests passed (make test)