### PR TITLE
Upgrade tendermint to include asynchronous mempool receive.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -452,7 +452,7 @@
   version = "v0.11.0"
 
 [[projects]]
-  digest = "1:b82bb74767b7f675b45eeb40dcd79f40b30b115b9acbe13fe6f4c9b81c26fb03"
+  digest = "1:fcf41ce02a11cdf48466ad3a94e96780f4e55ea81322e3967fd34e108cc75758"
   name = "github.com/tendermint/tendermint"
   packages = [
     "abci/client",
@@ -518,9 +518,9 @@
     "version",
   ]
   pruneopts = "UT"
-  revision = "3821815c90f5cd06304f0558e387938a73468799"
+  revision = "cf1745a54d84eae8688ae26b12dbaeb5a9a1eefe"
   source = "github.com/BiJie/bnc-tendermint"
-  version = "v0.25.1-br0"
+  version = "v0.25.1-br3"
 
 [[projects]]
   digest = "1:7886f86064faff6f8d08a3eb0e8c773648ff5a2e27730831e2bfbf07467f6666"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -58,7 +58,7 @@
 [[override]]
   name = "github.com/tendermint/tendermint"
   source = "github.com/BiJie/bnc-tendermint"
-  version = "=0.25.1-br0"
+  version = "=0.25.1-br3"
 
 ## deps without releases:
 


### PR DESCRIPTION
BiJie/BinanceChain#280

# Description
Upgrade Tendermint library version to include asynchronous mempool Receive routine.

- [x] make build pass
- [x] make test pass