### PR TITLE
[R4R]adapt to use coin amount int64 to represent decimal

### DIFF
--- a/client/lcd/test_helpers.go
+++ b/client/lcd/test_helpers.go
@@ -226,7 +226,7 @@ func InitializeTestLCD(
 		msg := stake.NewMsgCreateValidator(
 			sdk.ValAddress(operAddr),
 			pubKey,
-			sdk.NewCoin("steak", int64(delegation)),
+			sdk.NewCoin("steak", sdk.NewDecWithoutFra(int64(delegation)).RawInt()),
 			stake.Description{Moniker: fmt.Sprintf("validator-%d", i+1)},
 			stake.NewCommissionMsg(sdk.ZeroDec(), sdk.ZeroDec(), sdk.ZeroDec()),
 		)
@@ -250,10 +250,10 @@ func InitializeTestLCD(
 	// add some tokens to init accounts
 	for _, addr := range initAddrs {
 		accAuth := auth.NewBaseAccountWithAddress(addr)
-		accAuth.Coins = sdk.Coins{sdk.NewCoin("steak", 100)}
+		accAuth.Coins = sdk.Coins{sdk.NewCoin("steak", sdk.NewDecWithoutFra(100).RawInt())}
 		acc := gapp.NewGenesisAccount(&accAuth)
 		genesisState.Accounts = append(genesisState.Accounts, acc)
-		genesisState.StakeData.Pool.LooseTokens = genesisState.StakeData.Pool.LooseTokens.Add(sdk.NewDec(100))
+		genesisState.StakeData.Pool.LooseTokens = genesisState.StakeData.Pool.LooseTokens.Add(sdk.NewDecWithPrec(100, 0))
 	}
 
 	appState, err := codec.MarshalJSONIndent(cdc, genesisState)

--- a/cmd/gaia/app/genesis.go
+++ b/cmd/gaia/app/genesis.go
@@ -24,8 +24,8 @@ import (
 
 var (
 	// bonded tokens given to genesis validators/accounts
-	freeFermionVal  = int64(100)
-	freeFermionsAcc = int64(150)
+	freeFermionVal  = sdk.NewDecWithoutFra(100).RawInt()
+	freeFermionsAcc = sdk.NewDecWithoutFra(150).RawInt()
 )
 
 // State to Unmarshal

--- a/cmd/gaia/app/genesis_test.go
+++ b/cmd/gaia/app/genesis_test.go
@@ -37,7 +37,7 @@ func makeGenesisState(t *testing.T, genTxs []auth.StdTx) GenesisState {
 
 		// get genesis flag account information
 		genAccs[i] = genesisAccountFromMsgCreateValidator(msg, freeFermionsAcc)
-		stakeData.Pool.LooseTokens = stakeData.Pool.LooseTokens.Add(sdk.NewDecFromInt(freeFermionsAcc)) // increase the supply
+		stakeData.Pool.LooseTokens = stakeData.Pool.LooseTokens.Add(sdk.NewDecWithoutFra(freeFermionsAcc)) // increase the supply
 	}
 
 	// create the final app state

--- a/cmd/gaia/app/sim_test.go
+++ b/cmd/gaia/app/sim_test.go
@@ -74,13 +74,13 @@ func appStateFn(r *rand.Rand, accs []simulation.Account) json.RawMessage {
 		valAddrs[i] = valAddr
 
 		validator := stake.NewValidator(valAddr, accs[i].PubKey, stake.Description{})
-		validator.Tokens = sdk.NewDec(amt)
-		validator.DelegatorShares = sdk.NewDec(amt)
-		delegation := stake.Delegation{accs[i].Address, valAddr, sdk.NewDec(amt), 0}
+		validator.Tokens = sdk.NewDecWithoutFra(amt)
+		validator.DelegatorShares = sdk.NewDecWithoutFra(amt)
+		delegation := stake.Delegation{accs[i].Address, valAddr, sdk.NewDecWithoutFra(amt), 0}
 		validators = append(validators, validator)
 		delegations = append(delegations, delegation)
 	}
-	stakeGenesis.Pool.LooseTokens = sdk.NewDec(amt*250 + (numInitiallyBonded * amt))
+	stakeGenesis.Pool.LooseTokens = sdk.NewDecWithoutFra(amt * (250 + (numInitiallyBonded * amt)))
 	stakeGenesis.Validators = validators
 	stakeGenesis.Bonds = delegations
 	mintGenesis := mint.DefaultGenesisState()

--- a/types/stake.go
+++ b/types/stake.go
@@ -53,7 +53,7 @@ type Validator interface {
 func ABCIValidator(v Validator) abci.Validator {
 	return abci.Validator{
 		Address: v.GetConsPubKey().Address(),
-		Power:   v.GetPower().RoundInt64(),
+		Power:   v.GetPower().RawInt(),
 	}
 }
 

--- a/x/distribution/keeper/allocation_test.go
+++ b/x/distribution/keeper/allocation_test.go
@@ -12,13 +12,13 @@ import (
 func TestAllocateTokensBasic(t *testing.T) {
 
 	// no community tax on inputs
-	ctx, _, keeper, sk, fck := CreateTestInputAdvanced(t, false, 100, sdk.ZeroDec())
+	ctx, _, keeper, sk, fck := CreateTestInputAdvanced(t, false, sdk.NewDecWithoutFra(100).RawInt(), sdk.ZeroDec())
 	stakeHandler := stake.NewHandler(sk)
 	denom := sk.GetParams(ctx).BondDenom
 
 	//first make a validator
 	totalPower := int64(10)
-	totalPowerDec := sdk.NewDec(totalPower)
+	totalPowerDec := sdk.NewDecWithPrec(totalPower, 0)
 	msgCreateValidator := stake.NewTestMsgCreateValidator(valOpAddr1, valConsPk1, totalPower)
 	got := stakeHandler(ctx, msgCreateValidator)
 	require.True(t, got.IsOK(), "expected msg to be ok, got %v", got)
@@ -38,7 +38,7 @@ func TestAllocateTokensBasic(t *testing.T) {
 	require.Nil(t, feePool.Pool)
 
 	// allocate 100 denom of fees
-	feeInputs := int64(100)
+	feeInputs := sdk.NewDecWithoutFra(100).RawInt()
 	fck.SetCollectedFees(sdk.Coins{sdk.NewCoin(denom, feeInputs)})
 	require.Equal(t, feeInputs, fck.GetCollectedFees(ctx).AmountOf(denom))
 	keeper.AllocateTokens(ctx, sdk.OneDec(), valConsAddr1)
@@ -54,7 +54,7 @@ func TestAllocateTokensBasic(t *testing.T) {
 
 func TestAllocateTokensWithCommunityTax(t *testing.T) {
 	communityTax := sdk.NewDecWithPrec(1, 2) //1%
-	ctx, _, keeper, sk, fck := CreateTestInputAdvanced(t, false, 100, communityTax)
+	ctx, _, keeper, sk, fck := CreateTestInputAdvanced(t, false, sdk.NewDecWithoutFra(100).RawInt(), communityTax)
 	stakeHandler := stake.NewHandler(sk)
 	denom := sk.GetParams(ctx).BondDenom
 
@@ -66,7 +66,7 @@ func TestAllocateTokensWithCommunityTax(t *testing.T) {
 	_ = sk.ApplyAndReturnValidatorSetUpdates(ctx)
 
 	// allocate 100 denom of fees
-	feeInputs := int64(100)
+	feeInputs := sdk.NewDecWithoutFra(100).RawInt()
 	fck.SetCollectedFees(sdk.Coins{sdk.NewCoin(denom, feeInputs)})
 	keeper.AllocateTokens(ctx, sdk.OneDec(), valConsAddr1)
 
@@ -82,7 +82,7 @@ func TestAllocateTokensWithCommunityTax(t *testing.T) {
 
 func TestAllocateTokensWithPartialPrecommitPower(t *testing.T) {
 	communityTax := sdk.NewDecWithPrec(1, 2)
-	ctx, _, keeper, sk, fck := CreateTestInputAdvanced(t, false, 100, communityTax)
+	ctx, _, keeper, sk, fck := CreateTestInputAdvanced(t, false, sdk.NewDecWithoutFra(100).RawInt(), communityTax)
 	stakeHandler := stake.NewHandler(sk)
 	denom := sk.GetParams(ctx).BondDenom
 

--- a/x/distribution/keeper/delegation_test.go
+++ b/x/distribution/keeper/delegation_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestWithdrawDelegationRewardBasic(t *testing.T) {
-	ctx, accMapper, keeper, sk, fck := CreateTestInputAdvanced(t, false, 100, sdk.ZeroDec())
+	ctx, accMapper, keeper, sk, fck := CreateTestInputAdvanced(t, false, sdk.NewDecWithoutFra(100).RawInt(), sdk.ZeroDec())
 	stakeHandler := stake.NewHandler(sk)
 	denom := sk.GetParams(ctx).BondDenom
 
@@ -24,33 +24,33 @@ func TestWithdrawDelegationRewardBasic(t *testing.T) {
 	got = stakeHandler(ctx, msgDelegate)
 	require.True(t, got.IsOK())
 	amt := accMapper.GetAccount(ctx, delAddr1).GetCoins().AmountOf(denom)
-	require.Equal(t, int64(90), amt)
+	require.Equal(t, sdk.NewDecWithoutFra(90).RawInt(), amt)
 
 	// allocate 100 denom of fees
-	feeInputs := int64(100)
+	feeInputs := sdk.NewDecWithoutFra(100).RawInt()
 	fck.SetCollectedFees(sdk.Coins{sdk.NewCoin(denom, feeInputs)})
 	require.Equal(t, feeInputs, fck.GetCollectedFees(ctx).AmountOf(denom))
 	keeper.AllocateTokens(ctx, sdk.OneDec(), valConsAddr1)
 
 	// withdraw delegation
 	ctx = ctx.WithBlockHeight(1)
-	sk.SetLastTotalPower(ctx, 10)
-	sk.SetLastValidatorPower(ctx, valOpAddr1, int64(10))
+	sk.SetLastTotalPower(ctx, sdk.NewDecWithoutFra(10).RawInt())
+	sk.SetLastValidatorPower(ctx, valOpAddr1, sdk.NewDecWithoutFra(10).RawInt())
 	keeper.WithdrawDelegationReward(ctx, delAddr1, valOpAddr1)
 	amt = accMapper.GetAccount(ctx, delAddr1).GetCoins().AmountOf(denom)
 
-	expRes := sdk.NewDec(90).Add(sdk.NewDec(100).Quo(sdk.NewDec(2))).TruncateInt() // 90 + 100 tokens * 10/20
+	expRes := sdk.NewDecWithoutFra(90).Add(sdk.NewDecWithoutFra(100).Quo(sdk.NewDecWithoutFra(2))).TruncateInt() // 90 + 100 tokens * 10/20
 	require.True(t, expRes == amt)
 }
 
 func TestWithdrawDelegationRewardWithCommission(t *testing.T) {
-	ctx, accMapper, keeper, sk, fck := CreateTestInputAdvanced(t, false, 100, sdk.ZeroDec())
+	ctx, accMapper, keeper, sk, fck := CreateTestInputAdvanced(t, false, sdk.NewDecWithoutFra(100).RawInt(), sdk.ZeroDec())
 	stakeHandler := stake.NewHandler(sk)
 	denom := sk.GetParams(ctx).BondDenom
 
 	//first make a validator with 10% commission
 	msgCreateValidator := stake.NewTestMsgCreateValidatorWithCommission(
-		valOpAddr1, valConsPk1, 10, sdk.NewDecWithPrec(1, 1))
+		valOpAddr1, valConsPk1, sdk.NewDecWithoutFra(10).RawInt(), sdk.NewDecWithPrec(1, 1))
 	got := stakeHandler(ctx, msgCreateValidator)
 	require.True(t, got.IsOK(), "expected msg to be ok, got %v", got)
 	_ = sk.ApplyAndReturnValidatorSetUpdates(ctx)
@@ -60,10 +60,10 @@ func TestWithdrawDelegationRewardWithCommission(t *testing.T) {
 	got = stakeHandler(ctx, msgDelegate)
 	require.True(t, got.IsOK())
 	amt := accMapper.GetAccount(ctx, delAddr1).GetCoins().AmountOf(denom)
-	require.Equal(t, int64(90), amt)
+	require.Equal(t, sdk.NewDecWithoutFra(90).RawInt(), amt)
 
 	// allocate 100 denom of fees
-	feeInputs := int64(100)
+	feeInputs := sdk.NewDecWithoutFra(100).RawInt()
 	fck.SetCollectedFees(sdk.Coins{sdk.NewCoin(denom, feeInputs)})
 	require.Equal(t, feeInputs, fck.GetCollectedFees(ctx).AmountOf(denom))
 	keeper.AllocateTokens(ctx, sdk.OneDec(), valConsAddr1)
@@ -73,18 +73,18 @@ func TestWithdrawDelegationRewardWithCommission(t *testing.T) {
 	keeper.WithdrawDelegationReward(ctx, delAddr1, valOpAddr1)
 	amt = accMapper.GetAccount(ctx, delAddr1).GetCoins().AmountOf(denom)
 
-	expRes := sdk.NewDec(90).Add(sdk.NewDec(90).Quo(sdk.NewDec(2))).TruncateInt() // 90 + 100*90% tokens * 10/20
+	expRes := sdk.NewDecWithoutFra(90).Add(sdk.NewDecWithoutFra(90).Quo(sdk.NewDecWithoutFra(2))).TruncateInt() // 90 + 100*90% tokens * 10/20
 	require.True(t, expRes == amt)
 }
 
 func TestWithdrawDelegationRewardTwoDelegators(t *testing.T) {
-	ctx, accMapper, keeper, sk, fck := CreateTestInputAdvanced(t, false, 100, sdk.ZeroDec())
+	ctx, accMapper, keeper, sk, fck := CreateTestInputAdvanced(t, false, sdk.NewDecWithoutFra(100).RawInt(), sdk.ZeroDec())
 	stakeHandler := stake.NewHandler(sk)
 	denom := sk.GetParams(ctx).BondDenom
 
 	//first make a validator with 10% commission
 	msgCreateValidator := stake.NewTestMsgCreateValidatorWithCommission(
-		valOpAddr1, valConsPk1, 10, sdk.NewDecWithPrec(1, 1))
+		valOpAddr1, valConsPk1, sdk.NewDecWithoutFra(10).RawInt(), sdk.NewDecWithPrec(1, 1))
 	got := stakeHandler(ctx, msgCreateValidator)
 	require.True(t, got.IsOK(), "expected msg to be ok, got %v", got)
 	_ = sk.ApplyAndReturnValidatorSetUpdates(ctx)
@@ -94,16 +94,16 @@ func TestWithdrawDelegationRewardTwoDelegators(t *testing.T) {
 	got = stakeHandler(ctx, msgDelegate)
 	require.True(t, got.IsOK())
 	amt := accMapper.GetAccount(ctx, delAddr1).GetCoins().AmountOf(denom)
-	require.Equal(t, int64(90), amt)
+	require.Equal(t, sdk.NewDecWithoutFra(90).RawInt(), amt)
 
 	msgDelegate = stake.NewTestMsgDelegate(delAddr2, valOpAddr1, 20)
 	got = stakeHandler(ctx, msgDelegate)
 	require.True(t, got.IsOK())
 	amt = accMapper.GetAccount(ctx, delAddr2).GetCoins().AmountOf(denom)
-	require.Equal(t, int64(80), amt)
+	require.Equal(t, sdk.NewDecWithoutFra(80).RawInt(), amt)
 
 	// allocate 100 denom of fees
-	feeInputs := int64(100)
+	feeInputs := sdk.NewDecWithoutFra(100).RawInt()
 	fck.SetCollectedFees(sdk.Coins{sdk.NewCoin(denom, feeInputs)})
 	require.Equal(t, feeInputs, fck.GetCollectedFees(ctx).AmountOf(denom))
 	keeper.AllocateTokens(ctx, sdk.OneDec(), valConsAddr1)
@@ -113,20 +113,20 @@ func TestWithdrawDelegationRewardTwoDelegators(t *testing.T) {
 	keeper.WithdrawDelegationReward(ctx, delAddr1, valOpAddr1)
 	amt = accMapper.GetAccount(ctx, delAddr1).GetCoins().AmountOf(denom)
 
-	expRes := sdk.NewDec(90).Add(sdk.NewDec(90).Quo(sdk.NewDec(4))).TruncateInt() // 90 + 100*90% tokens * 10/40
+	expRes := sdk.NewDecWithoutFra(90).Add(sdk.NewDecWithoutFra(90).Quo(sdk.NewDecWithoutFra(4))).TruncateInt() // 90 + 100*90% tokens * 10/40
 	require.True(t, expRes == amt)
 }
 
 // this test demonstrates how two delegators with the same power can end up
 // with different rewards in the end
 func TestWithdrawDelegationRewardTwoDelegatorsUneven(t *testing.T) {
-	ctx, accMapper, keeper, sk, fck := CreateTestInputAdvanced(t, false, 100, sdk.ZeroDec())
+	ctx, accMapper, keeper, sk, fck := CreateTestInputAdvanced(t, false, sdk.NewDecWithoutFra(100).RawInt(), sdk.ZeroDec())
 	stakeHandler := stake.NewHandler(sk)
 	denom := sk.GetParams(ctx).BondDenom
 
 	//first make a validator with no commission
 	msgCreateValidator := stake.NewTestMsgCreateValidatorWithCommission(
-		valOpAddr1, valConsPk1, 10, sdk.ZeroDec())
+		valOpAddr1, valConsPk1, sdk.NewDecWithoutFra(10).RawInt(), sdk.ZeroDec())
 	got := stakeHandler(ctx, msgCreateValidator)
 	require.True(t, got.IsOK(), "expected msg to be ok, got %v", got)
 	_ = sk.ApplyAndReturnValidatorSetUpdates(ctx)
@@ -136,16 +136,16 @@ func TestWithdrawDelegationRewardTwoDelegatorsUneven(t *testing.T) {
 	got = stakeHandler(ctx, msgDelegate)
 	require.True(t, got.IsOK())
 	amt := accMapper.GetAccount(ctx, delAddr1).GetCoins().AmountOf(denom)
-	require.Equal(t, int64(90), amt)
+	require.Equal(t, sdk.NewDecWithoutFra(90).RawInt(), amt)
 
 	msgDelegate = stake.NewTestMsgDelegate(delAddr2, valOpAddr1, 10)
 	got = stakeHandler(ctx, msgDelegate)
 	require.True(t, got.IsOK())
 	amt = accMapper.GetAccount(ctx, delAddr2).GetCoins().AmountOf(denom)
-	require.Equal(t, int64(90), amt)
+	require.Equal(t, sdk.NewDecWithoutFra(90).RawInt(), amt)
 
-	// allocate 100 denom of fees
-	feeInputs := int64(90)
+	// allocate 90 denom of fees
+	feeInputs := sdk.NewDecWithoutFra(90).RawInt()
 	fck.SetCollectedFees(sdk.Coins{sdk.NewCoin(denom, feeInputs)})
 	require.Equal(t, feeInputs, fck.GetCollectedFees(ctx).AmountOf(denom))
 	keeper.AllocateTokens(ctx, sdk.OneDec(), valConsAddr1)
@@ -155,11 +155,11 @@ func TestWithdrawDelegationRewardTwoDelegatorsUneven(t *testing.T) {
 	keeper.WithdrawDelegationReward(ctx, delAddr1, valOpAddr1)
 	amt = accMapper.GetAccount(ctx, delAddr1).GetCoins().AmountOf(denom)
 
-	expRes1 := sdk.NewDec(90).Add(sdk.NewDec(90).Quo(sdk.NewDec(3))).TruncateInt() // 90 + 100 * 10/30
+	expRes1 := sdk.NewDecWithoutFra(90).Add(sdk.NewDecWithoutFra(90).Quo(sdk.NewDecWithoutFra(3))).TruncateInt() // 90 + 100 * 10/30
 	require.True(t, expRes1 == amt)
 
-	// allocate 200 denom of fees
-	feeInputs = int64(180)
+	// allocate 180 denom of fees
+	feeInputs = sdk.NewDecWithoutFra(180).RawInt()
 	fck.SetCollectedFees(sdk.Coins{sdk.NewCoin(denom, feeInputs)})
 	require.Equal(t, feeInputs, fck.GetCollectedFees(ctx).AmountOf(denom))
 	keeper.AllocateTokens(ctx, sdk.OneDec(), valConsAddr1)
@@ -169,16 +169,17 @@ func TestWithdrawDelegationRewardTwoDelegatorsUneven(t *testing.T) {
 	keeper.WithdrawDelegationReward(ctx, delAddr2, valOpAddr1)
 	amt = accMapper.GetAccount(ctx, delAddr2).GetCoins().AmountOf(denom)
 	// existingTokens + (100+200 * (10/(20+30))
-	withdrawnFromVal := sdk.NewDec(60 + 180).Mul(sdk.NewDec(2)).Quo(sdk.NewDec(5))
-	expRes2 := sdk.NewDec(90).Add(withdrawnFromVal).TruncateInt()
+	withdrawnFromVal := sdk.NewDecWithoutFra((60 + 180)).Mul(sdk.NewDecWithoutFra(2)).Quo(sdk.NewDecWithoutFra(5))
+	expRes2 := sdk.NewDecWithoutFra(90).Add(withdrawnFromVal).TruncateInt()
 	require.True(t, expRes2 == amt)
 
 	// finally delegator 1 withdraws the remainder of its reward
 	keeper.WithdrawDelegationReward(ctx, delAddr1, valOpAddr1)
 	amt = accMapper.GetAccount(ctx, delAddr1).GetCoins().AmountOf(denom)
 
-	remainingInVal := sdk.NewDec(60 + 180).Sub(withdrawnFromVal)
-	expRes3 := sdk.NewDecFromInt(expRes1).Add(remainingInVal.Mul(sdk.NewDec(1)).Quo(sdk.NewDec(3))).TruncateInt()
+	remainingInVal := sdk.NewDecWithoutFra((60 + 180)).Sub(withdrawnFromVal)
+	expRes3 := sdk.NewDecFromInt(expRes1).Add(remainingInVal.Mul(sdk.NewDecWithoutFra(1)).Quo(sdk.NewDecWithoutFra(3))).TruncateInt()
+
 	require.True(t, expRes3 == amt)
 
 	// verify the final withdraw amounts are different
@@ -186,23 +187,23 @@ func TestWithdrawDelegationRewardTwoDelegatorsUneven(t *testing.T) {
 }
 
 func TestWithdrawDelegationRewardsAll(t *testing.T) {
-	ctx, accMapper, keeper, sk, fck := CreateTestInputAdvanced(t, false, 100, sdk.ZeroDec())
+	ctx, accMapper, keeper, sk, fck := CreateTestInputAdvanced(t, false, sdk.NewDecWithoutFra(100).RawInt(), sdk.ZeroDec())
 	stakeHandler := stake.NewHandler(sk)
 	denom := sk.GetParams(ctx).BondDenom
 
 	//make some  validators with different commissions
 	msgCreateValidator := stake.NewTestMsgCreateValidatorWithCommission(
-		valOpAddr1, valConsPk1, 10, sdk.NewDecWithPrec(1, 1))
+		valOpAddr1, valConsPk1, sdk.NewDecWithoutFra(10).RawInt(), sdk.NewDecWithPrec(1, 1))
 	got := stakeHandler(ctx, msgCreateValidator)
 	require.True(t, got.IsOK(), "expected msg to be ok, got %v", got)
 
 	msgCreateValidator = stake.NewTestMsgCreateValidatorWithCommission(
-		valOpAddr2, valConsPk2, 50, sdk.NewDecWithPrec(2, 1))
+		valOpAddr2, valConsPk2, sdk.NewDecWithoutFra(50).RawInt(), sdk.NewDecWithPrec(2, 1))
 	got = stakeHandler(ctx, msgCreateValidator)
 	require.True(t, got.IsOK(), "expected msg to be ok, got %v", got)
 
 	msgCreateValidator = stake.NewTestMsgCreateValidatorWithCommission(
-		valOpAddr3, valConsPk3, 40, sdk.NewDecWithPrec(3, 1))
+		valOpAddr3, valConsPk3, sdk.NewDecWithoutFra(40).RawInt(), sdk.NewDecWithPrec(3, 1))
 	got = stakeHandler(ctx, msgCreateValidator)
 	require.True(t, got.IsOK(), "expected msg to be ok, got %v", got)
 
@@ -219,7 +220,7 @@ func TestWithdrawDelegationRewardsAll(t *testing.T) {
 
 	// 40 tokens left after delegating 60 of them
 	amt := accMapper.GetAccount(ctx, delAddr1).GetCoins().AmountOf(denom)
-	require.Equal(t, int64(40), amt)
+	require.Equal(t, sdk.NewDecWithoutFra(40).RawInt(), amt)
 
 	// total power of each validator:
 	// validator 1: 10 (self) + 10 (delegator) = 20
@@ -227,8 +228,8 @@ func TestWithdrawDelegationRewardsAll(t *testing.T) {
 	// validator 3: 40 (self) + 30 (delegator) = 70
 	// grand total: 160
 
-	// allocate 100 denom of fees
-	feeInputs := int64(1000)
+	// allocate 1000 denom of fees
+	feeInputs := sdk.NewDecWithoutFra(1000).RawInt()
 	fck.SetCollectedFees(sdk.Coins{sdk.NewCoin(denom, feeInputs)})
 	require.Equal(t, feeInputs, fck.GetCollectedFees(ctx).AmountOf(denom))
 	keeper.AllocateTokens(ctx, sdk.OneDec(), valConsAddr1)
@@ -244,10 +245,10 @@ func TestWithdrawDelegationRewardsAll(t *testing.T) {
 	// 40          + 1000 *( 0.05)  * (10/20 * 0.9)
 	feesInNonProposer := sdk.NewDecFromInt(feeInputs).Mul(sdk.NewDecWithPrec(95, 2))
 	feesInProposer := sdk.NewDecFromInt(feeInputs).Mul(sdk.NewDecWithPrec(5, 2))
-	feesInVal1 := feesInNonProposer.Mul(sdk.NewDec(10).Quo(sdk.NewDec(160))).Mul(sdk.NewDecWithPrec(9, 1))
-	feesInVal2 := feesInNonProposer.Mul(sdk.NewDec(20).Quo(sdk.NewDec(160))).Mul(sdk.NewDecWithPrec(8, 1))
-	feesInVal3 := feesInNonProposer.Mul(sdk.NewDec(30).Quo(sdk.NewDec(160))).Mul(sdk.NewDecWithPrec(7, 1))
-	feesInVal1Proposer := feesInProposer.Mul(sdk.NewDec(10).Quo(sdk.NewDec(20))).Mul(sdk.NewDecWithPrec(9, 1))
-	expRes := sdk.NewDec(40).Add(feesInVal1).Add(feesInVal2).Add(feesInVal3).Add(feesInVal1Proposer).TruncateInt()
+	feesInVal1 := feesInNonProposer.Mul(sdk.NewDecWithoutFra(10).Quo(sdk.NewDecWithoutFra(160))).Mul(sdk.NewDecWithPrec(9, 1))
+	feesInVal2 := feesInNonProposer.Mul(sdk.NewDecWithoutFra(20).Quo(sdk.NewDecWithoutFra(160))).Mul(sdk.NewDecWithPrec(8, 1))
+	feesInVal3 := feesInNonProposer.Mul(sdk.NewDecWithoutFra(30).Quo(sdk.NewDecWithoutFra(160))).Mul(sdk.NewDecWithPrec(7, 1))
+	feesInVal1Proposer := feesInProposer.Mul(sdk.NewDecWithoutFra(10).Quo(sdk.NewDecWithoutFra(20))).Mul(sdk.NewDecWithPrec(9, 1))
+	expRes := sdk.NewDecWithoutFra(40).Add(feesInVal1).Add(feesInVal2).Add(feesInVal3).Add(feesInVal1Proposer).TruncateInt()
 	require.True(t, expRes == amt)
 }

--- a/x/distribution/keeper/keeper_test.go
+++ b/x/distribution/keeper/keeper_test.go
@@ -19,7 +19,7 @@ func TestSetGetPreviousProposerConsAddr(t *testing.T) {
 func TestSetGetCommunityTax(t *testing.T) {
 	ctx, _, keeper, _, _ := CreateTestInputDefault(t, false, 0)
 
-	someDec := sdk.NewDec(333)
+	someDec := sdk.NewDecWithoutFra(333)
 	keeper.SetCommunityTax(ctx, someDec)
 	res := keeper.GetCommunityTax(ctx)
 	require.True(sdk.DecEq(t, someDec, res))

--- a/x/distribution/types/delegator_info_test.go
+++ b/x/distribution/types/delegator_info_test.go
@@ -14,43 +14,43 @@ func TestWithdrawRewards(t *testing.T) {
 	fp := InitialFeePool()
 	vi := NewValidatorDistInfo(valAddr1, height)
 	commissionRate := sdk.NewDecWithPrec(2, 2)
-	validatorTokens := sdk.NewDec(10)
-	validatorDelShares := sdk.NewDec(10)
-	totalBondedTokens := validatorTokens.Add(sdk.NewDec(90)) // validator-1 is 10% of total power
+	validatorTokens := sdk.NewDecWithoutFra(10)
+	validatorDelShares := sdk.NewDecWithoutFra(10)
+	totalBondedTokens := validatorTokens.Add(sdk.NewDecWithoutFra(90)) // validator-1 is 10% of total power
 
 	di1 := NewDelegationDistInfo(delAddr1, valAddr1, height)
-	di1Shares := sdk.NewDec(5) // this delegator has half the shares in the validator
+	di1Shares := sdk.NewDecWithoutFra(5) // this delegator has half the shares in the validator
 
 	di2 := NewDelegationDistInfo(delAddr2, valAddr1, height)
-	di2Shares := sdk.NewDec(5)
+	di2Shares := sdk.NewDecWithoutFra(5)
 
 	// simulate adding some stake for inflation
 	height = 10
-	fp.Pool = DecCoins{NewDecCoin("stake", 1000)}
+	fp.Pool = DecCoins{NewDecCoin("stake", sdk.NewDecWithoutFra(1000).RawInt())}
 
 	// withdraw rewards
 	di1, vi, fp, rewardRecv1 := di1.WithdrawRewards(fp, vi, height, totalBondedTokens,
 		validatorTokens, validatorDelShares, di1Shares, commissionRate)
 
 	assert.Equal(t, height, di1.WithdrawalHeight)
-	assert.True(sdk.DecEq(t, sdk.NewDec(900), fp.TotalValAccum.Accum))
-	assert.True(sdk.DecEq(t, sdk.NewDec(900), fp.Pool[0].Amount))
-	assert.True(sdk.DecEq(t, sdk.NewDec(49), vi.Pool[0].Amount))
-	assert.True(sdk.DecEq(t, sdk.NewDec(2), vi.PoolCommission[0].Amount))
-	assert.True(sdk.DecEq(t, sdk.NewDec(49), rewardRecv1[0].Amount))
+	assert.True(sdk.DecEq(t, sdk.NewDecWithoutFra(900), fp.TotalValAccum.Accum))
+	assert.True(sdk.DecEq(t, sdk.NewDecWithoutFra(900), fp.Pool[0].Amount))
+	assert.True(sdk.DecEq(t, sdk.NewDecWithoutFra(49), vi.Pool[0].Amount))
+	assert.True(sdk.DecEq(t, sdk.NewDecWithoutFra(2), vi.PoolCommission[0].Amount))
+	assert.True(sdk.DecEq(t, sdk.NewDecWithoutFra(49), rewardRecv1[0].Amount))
 
 	// add more blocks and inflation
 	height = 20
-	fp.Pool[0].Amount = fp.Pool[0].Amount.Add(sdk.NewDec(1000))
+	fp.Pool[0].Amount = fp.Pool[0].Amount.Add(sdk.NewDecWithoutFra(1000))
 
 	// withdraw rewards
 	di2, vi, fp, rewardRecv2 := di2.WithdrawRewards(fp, vi, height, totalBondedTokens,
 		validatorTokens, validatorDelShares, di2Shares, commissionRate)
 
 	assert.Equal(t, height, di2.WithdrawalHeight)
-	assert.True(sdk.DecEq(t, sdk.NewDec(1800), fp.TotalValAccum.Accum))
-	assert.True(sdk.DecEq(t, sdk.NewDec(1800), fp.Pool[0].Amount))
-	assert.True(sdk.DecEq(t, sdk.NewDec(49), vi.Pool[0].Amount))
-	assert.True(sdk.DecEq(t, sdk.NewDec(4), vi.PoolCommission[0].Amount))
-	assert.True(sdk.DecEq(t, sdk.NewDec(98), rewardRecv2[0].Amount))
+	assert.True(sdk.DecEq(t, sdk.NewDecWithoutFra(1800), fp.TotalValAccum.Accum))
+	assert.True(sdk.DecEq(t, sdk.NewDecWithoutFra(1800), fp.Pool[0].Amount))
+	assert.True(sdk.DecEq(t, sdk.NewDecWithoutFra(49), vi.Pool[0].Amount))
+	assert.True(sdk.DecEq(t, sdk.NewDecWithoutFra(4), vi.PoolCommission[0].Amount))
+	assert.True(sdk.DecEq(t, sdk.NewDecWithoutFra(98), rewardRecv2[0].Amount))
 }

--- a/x/distribution/types/fee_pool_test.go
+++ b/x/distribution/types/fee_pool_test.go
@@ -11,20 +11,20 @@ func TestTotalAccumUpdateForNewHeight(t *testing.T) {
 
 	ta := NewTotalAccum(0)
 
-	ta = ta.UpdateForNewHeight(5, sdk.NewDec(3))
-	require.True(sdk.DecEq(t, sdk.NewDec(15), ta.Accum))
+	ta = ta.UpdateForNewHeight(5, sdk.NewDecWithoutFra(3))
+	require.True(sdk.DecEq(t, sdk.NewDecWithoutFra(15), ta.Accum))
 
-	ta = ta.UpdateForNewHeight(8, sdk.NewDec(2))
-	require.True(sdk.DecEq(t, sdk.NewDec(21), ta.Accum))
+	ta = ta.UpdateForNewHeight(8, sdk.NewDecWithoutFra(2))
+	require.True(sdk.DecEq(t, sdk.NewDecWithoutFra(21), ta.Accum))
 }
 
 func TestUpdateTotalValAccum(t *testing.T) {
 
 	fp := InitialFeePool()
 
-	fp = fp.UpdateTotalValAccum(5, sdk.NewDec(3))
-	require.True(sdk.DecEq(t, sdk.NewDec(15), fp.TotalValAccum.Accum))
+	fp = fp.UpdateTotalValAccum(5, sdk.NewDecWithoutFra(3))
+	require.True(sdk.DecEq(t, sdk.NewDecWithoutFra(15), fp.TotalValAccum.Accum))
 
-	fp = fp.UpdateTotalValAccum(8, sdk.NewDec(2))
-	require.True(sdk.DecEq(t, sdk.NewDec(21), fp.TotalValAccum.Accum))
+	fp = fp.UpdateTotalValAccum(8, sdk.NewDecWithoutFra(2))
+	require.True(sdk.DecEq(t, sdk.NewDecWithoutFra(21), fp.TotalValAccum.Accum))
 }

--- a/x/distribution/types/validator_info_test.go
+++ b/x/distribution/types/validator_info_test.go
@@ -19,36 +19,36 @@ func TestTakeFeePoolRewards(t *testing.T) {
 	commissionRate1 := sdk.NewDecWithPrec(2, 2)
 	commissionRate2 := sdk.NewDecWithPrec(3, 2)
 	commissionRate3 := sdk.NewDecWithPrec(4, 2)
-	validatorTokens1 := sdk.NewDec(10)
-	validatorTokens2 := sdk.NewDec(40)
-	validatorTokens3 := sdk.NewDec(50)
+	validatorTokens1 := sdk.NewDecWithoutFra(10)
+	validatorTokens2 := sdk.NewDecWithoutFra(40)
+	validatorTokens3 := sdk.NewDecWithoutFra(50)
 	totalBondedTokens := validatorTokens1.Add(validatorTokens2).Add(validatorTokens3)
 
 	// simulate adding some stake for inflation
 	height = 10
-	fp.Pool = DecCoins{NewDecCoin("stake", 1000)}
+	fp.Pool = DecCoins{NewDecCoin("stake", sdk.NewDecWithoutFra(1000).RawInt())}
 
 	vi1, fp = vi1.TakeFeePoolRewards(fp, height, totalBondedTokens, validatorTokens1, commissionRate1)
-	require.True(sdk.DecEq(t, sdk.NewDec(900), fp.TotalValAccum.Accum))
-	assert.True(sdk.DecEq(t, sdk.NewDec(900), fp.Pool[0].Amount))
-	assert.True(sdk.DecEq(t, sdk.NewDec(100-2), vi1.Pool[0].Amount))
-	assert.True(sdk.DecEq(t, sdk.NewDec(2), vi1.PoolCommission[0].Amount))
+	require.True(sdk.DecEq(t, sdk.NewDecWithoutFra(900), fp.TotalValAccum.Accum))
+	assert.True(sdk.DecEq(t, sdk.NewDecWithoutFra(900), fp.Pool[0].Amount))
+	assert.True(sdk.DecEq(t, sdk.NewDecWithoutFra(100-2), vi1.Pool[0].Amount))
+	assert.True(sdk.DecEq(t, sdk.NewDecWithoutFra(2), vi1.PoolCommission[0].Amount))
 
 	vi2, fp = vi2.TakeFeePoolRewards(fp, height, totalBondedTokens, validatorTokens2, commissionRate2)
-	require.True(sdk.DecEq(t, sdk.NewDec(500), fp.TotalValAccum.Accum))
-	assert.True(sdk.DecEq(t, sdk.NewDec(500), fp.Pool[0].Amount))
-	assert.True(sdk.DecEq(t, sdk.NewDec(400-12), vi2.Pool[0].Amount))
-	assert.True(sdk.DecEq(t, vi2.PoolCommission[0].Amount, sdk.NewDec(12)))
+	require.True(sdk.DecEq(t, sdk.NewDecWithoutFra(500), fp.TotalValAccum.Accum))
+	assert.True(sdk.DecEq(t, sdk.NewDecWithoutFra(500), fp.Pool[0].Amount))
+	assert.True(sdk.DecEq(t, sdk.NewDecWithoutFra((400 - 12)), vi2.Pool[0].Amount))
+	assert.True(sdk.DecEq(t, vi2.PoolCommission[0].Amount, sdk.NewDecWithoutFra(12)))
 
 	// add more blocks and inflation
 	height = 20
-	fp.Pool[0].Amount = fp.Pool[0].Amount.Add(sdk.NewDec(1000))
+	fp.Pool[0].Amount = fp.Pool[0].Amount.Add(sdk.NewDecWithoutFra(1000))
 
 	vi3, fp = vi3.TakeFeePoolRewards(fp, height, totalBondedTokens, validatorTokens3, commissionRate3)
-	require.True(sdk.DecEq(t, sdk.NewDec(500), fp.TotalValAccum.Accum))
-	assert.True(sdk.DecEq(t, sdk.NewDec(500), fp.Pool[0].Amount))
-	assert.True(sdk.DecEq(t, sdk.NewDec(1000-40), vi3.Pool[0].Amount))
-	assert.True(sdk.DecEq(t, vi3.PoolCommission[0].Amount, sdk.NewDec(40)))
+	require.True(sdk.DecEq(t, sdk.NewDecWithoutFra(500), fp.TotalValAccum.Accum))
+	assert.True(sdk.DecEq(t, sdk.NewDecWithoutFra(500), fp.Pool[0].Amount))
+	assert.True(sdk.DecEq(t, sdk.NewDecWithoutFra(1000-40), vi3.Pool[0].Amount))
+	assert.True(sdk.DecEq(t, vi3.PoolCommission[0].Amount, sdk.NewDecWithoutFra(40)))
 }
 
 func TestWithdrawCommission(t *testing.T) {
@@ -58,28 +58,28 @@ func TestWithdrawCommission(t *testing.T) {
 	fp := InitialFeePool()
 	vi := NewValidatorDistInfo(valAddr1, height)
 	commissionRate := sdk.NewDecWithPrec(2, 2)
-	validatorTokens := sdk.NewDec(10)
-	totalBondedTokens := validatorTokens.Add(sdk.NewDec(90)) // validator-1 is 10% of total power
+	validatorTokens := sdk.NewDecWithoutFra(10)
+	totalBondedTokens := validatorTokens.Add(sdk.NewDecWithoutFra(90)) // validator-1 is 10% of total power
 
 	// simulate adding some stake for inflation
 	height = 10
-	fp.Pool = DecCoins{NewDecCoin("stake", 1000)}
+	fp.Pool = DecCoins{NewDecCoin("stake", sdk.NewDecWithoutFra(1000).RawInt())}
 
 	// for a more fun staring condition, have an non-withdraw update
 	vi, fp = vi.TakeFeePoolRewards(fp, height, totalBondedTokens, validatorTokens, commissionRate)
-	require.True(sdk.DecEq(t, sdk.NewDec(900), fp.TotalValAccum.Accum))
-	assert.True(sdk.DecEq(t, sdk.NewDec(900), fp.Pool[0].Amount))
-	assert.True(sdk.DecEq(t, sdk.NewDec(100-2), vi.Pool[0].Amount))
-	assert.True(sdk.DecEq(t, sdk.NewDec(2), vi.PoolCommission[0].Amount))
+	require.True(sdk.DecEq(t, sdk.NewDecWithoutFra(900), fp.TotalValAccum.Accum))
+	assert.True(sdk.DecEq(t, sdk.NewDecWithoutFra(900), fp.Pool[0].Amount))
+	assert.True(sdk.DecEq(t, sdk.NewDecWithoutFra(100-2), vi.Pool[0].Amount))
+	assert.True(sdk.DecEq(t, sdk.NewDecWithoutFra(2), vi.PoolCommission[0].Amount))
 
 	// add more blocks and inflation
 	height = 20
-	fp.Pool[0].Amount = fp.Pool[0].Amount.Add(sdk.NewDec(1000))
+	fp.Pool[0].Amount = fp.Pool[0].Amount.Add(sdk.NewDecWithPrec(1000, 0))
 
 	vi, fp, commissionRecv := vi.WithdrawCommission(fp, height, totalBondedTokens, validatorTokens, commissionRate)
-	require.True(sdk.DecEq(t, sdk.NewDec(1800), fp.TotalValAccum.Accum))
-	assert.True(sdk.DecEq(t, sdk.NewDec(1800), fp.Pool[0].Amount))
-	assert.True(sdk.DecEq(t, sdk.NewDec(200-4), vi.Pool[0].Amount))
+	require.True(sdk.DecEq(t, sdk.NewDecWithoutFra(1800), fp.TotalValAccum.Accum))
+	assert.True(sdk.DecEq(t, sdk.NewDecWithoutFra(1800), fp.Pool[0].Amount))
+	assert.True(sdk.DecEq(t, sdk.NewDecWithoutFra(200-4), vi.Pool[0].Amount))
 	assert.Zero(t, len(vi.PoolCommission))
-	assert.True(sdk.DecEq(t, sdk.NewDec(4), commissionRecv[0].Amount))
+	assert.True(sdk.DecEq(t, sdk.NewDecWithoutFra(4), commissionRecv[0].Amount))
 }

--- a/x/gov/test_common.go
+++ b/x/gov/test_common.go
@@ -67,7 +67,7 @@ func getInitChainer(mapp *mock.App, keeper Keeper, stakeKeeper stake.Keeper) sdk
 		mapp.InitChainer(ctx, req)
 
 		stakeGenesis := stake.DefaultGenesisState()
-		stakeGenesis.Pool.LooseTokens = sdk.NewDec(100000)
+		stakeGenesis.Pool.LooseTokens = sdk.NewDecWithoutFra(100000)
 
 		validators, err := stake.InitGenesis(ctx, stakeKeeper, stakeGenesis)
 		if err != nil {

--- a/x/mint/minter.go
+++ b/x/mint/minter.go
@@ -31,7 +31,7 @@ func validateMinter(minter Minter) error {
 	return nil
 }
 
-var hrsPerYr = sdk.NewDec(8766) // as defined by a julian year of 365.25 days
+var hrsPerYr = sdk.NewDecWithoutFra(8766) // as defined by a julian year of 365.25 days
 
 // process provisions for an hour period
 func (m Minter) ProcessProvisions(params Params, totalSupply, bondedRatio sdk.Dec) (

--- a/x/params/keeper_test.go
+++ b/x/params/keeper_test.go
@@ -158,7 +158,7 @@ func TestSubspace(t *testing.T) {
 		{"uint64", uint64(1), uint64(0), new(uint64)},
 		{"int", sdk.NewInt(1), *new(sdk.Int), new(sdk.Int)},
 		{"uint", sdk.NewUint(1), *new(sdk.Uint), new(sdk.Uint)},
-		{"dec", sdk.NewDec(1), *new(sdk.Dec), new(sdk.Dec)},
+		{"dec", sdk.NewDecWithoutFra(1), *new(sdk.Dec), new(sdk.Dec)},
 		{"struct", s{1}, s{0}, new(s)},
 	}
 

--- a/x/slashing/app_test.go
+++ b/x/slashing/app_test.go
@@ -62,7 +62,7 @@ func getInitChainer(mapp *mock.App, keeper stake.Keeper) sdk.InitChainer {
 	return func(ctx sdk.Context, req abci.RequestInitChain) abci.ResponseInitChain {
 		mapp.InitChainer(ctx, req)
 		stakeGenesis := stake.DefaultGenesisState()
-		stakeGenesis.Pool.LooseTokens = sdk.NewDec(100000)
+		stakeGenesis.Pool.LooseTokens = sdk.NewDecWithoutFra(100000)
 		validators, err := stake.InitGenesis(ctx, keeper, stakeGenesis)
 		if err != nil {
 			panic(err)
@@ -93,8 +93,8 @@ func checkValidatorSigningInfo(t *testing.T, mapp *mock.App, keeper Keeper,
 func TestSlashingMsgs(t *testing.T) {
 	mapp, stakeKeeper, keeper := getMockApp(t)
 
-	genCoin := sdk.NewCoin("steak", 42)
-	bondCoin := sdk.NewCoin("steak", 10)
+	genCoin := sdk.NewCoin("steak", sdk.NewDecWithoutFra(42).RawInt())
+	bondCoin := sdk.NewCoin("steak", sdk.NewDecWithoutFra(10).RawInt())
 
 	acc1 := &auth.BaseAccount{
 		Address: addr1,
@@ -116,7 +116,7 @@ func TestSlashingMsgs(t *testing.T) {
 	validator := checkValidator(t, mapp, stakeKeeper, addr1, true)
 	require.Equal(t, sdk.ValAddress(addr1), validator.OperatorAddr)
 	require.Equal(t, sdk.Bonded, validator.Status)
-	require.True(sdk.DecEq(t, sdk.NewDec(10), validator.BondedTokens()))
+	require.True(sdk.DecEq(t, sdk.NewDecWithoutFra(10), validator.BondedTokens()))
 	unjailMsg := MsgUnjail{ValidatorAddr: sdk.ValAddress(validator.ConsPubKey.Address())}
 
 	// no signing info yet

--- a/x/slashing/keeper_test.go
+++ b/x/slashing/keeper_test.go
@@ -30,7 +30,7 @@ func TestHandleDoubleSign(t *testing.T) {
 	ctx, ck, sk, _, keeper := createTestInput(t, keeperTestParams())
 	// validator added pre-genesis
 	ctx = ctx.WithBlockHeight(-1)
-	amtInt := int64(100)
+	amtInt := sdk.NewDecWithoutFra(100).RawInt()
 	operatorAddr, val, amt := addrs[0], pks[0], amtInt
 	got := stake.NewHandler(sk)(ctx, NewTestMsgCreateValidator(operatorAddr, val, amt))
 	require.True(t, got.IsOK())
@@ -51,7 +51,7 @@ func TestHandleDoubleSign(t *testing.T) {
 	sk.Unjail(ctx, sdk.ConsAddress(val.Address()))
 	// power should be reduced
 	require.Equal(
-		t, sdk.NewDecFromInt(amt).Mul(sdk.NewDec(19).Quo(sdk.NewDec(20))),
+		t, sdk.NewDecFromInt(amt).Mul(sdk.NewDecWithoutFra(19).Quo(sdk.NewDecWithoutFra(20))),
 		sk.Validator(ctx, operatorAddr).GetPower(),
 	)
 	ctx = ctx.WithBlockHeader(abci.Header{Time: time.Unix(1, 0).Add(keeper.MaxEvidenceAge(ctx))})
@@ -59,7 +59,7 @@ func TestHandleDoubleSign(t *testing.T) {
 	// double sign past max age
 	keeper.handleDoubleSign(ctx, val.Address(), 0, time.Unix(0, 0), amtInt)
 	require.Equal(
-		t, sdk.NewDecFromInt(amt).Mul(sdk.NewDec(19).Quo(sdk.NewDec(20))),
+		t, sdk.NewDecFromInt(amt).Mul(sdk.NewDecWithoutFra(19).Quo(sdk.NewDecWithoutFra(20))),
 		sk.Validator(ctx, operatorAddr).GetPower(),
 	)
 }
@@ -70,7 +70,7 @@ func TestSlashingPeriodCap(t *testing.T) {
 
 	// initial setup
 	ctx, ck, sk, _, keeper := createTestInput(t, DefaultParams())
-	amtInt := int64(100)
+	amtInt := sdk.NewDecWithoutFra(100).RawInt()
 	operatorAddr, amt := addrs[0], amtInt
 	valConsPubKey, valConsAddr := pks[0], pks[0].Address()
 	got := stake.NewHandler(sk)(ctx, NewTestMsgCreateValidator(operatorAddr, valConsPubKey, amt))
@@ -97,7 +97,7 @@ func TestSlashingPeriodCap(t *testing.T) {
 	// end block
 	stake.EndBlocker(ctx, sk)
 	// power should be reduced
-	expectedPower := sdk.NewDecFromInt(amt).Mul(sdk.NewDec(19).Quo(sdk.NewDec(20)))
+	expectedPower := sdk.NewDecFromInt(amt).Mul(sdk.NewDecWithoutFra(19).Quo(sdk.NewDecWithoutFra(20)))
 	require.Equal(t, expectedPower, sk.Validator(ctx, operatorAddr).GetPower())
 
 	// double sign again, same slashing period
@@ -113,7 +113,7 @@ func TestSlashingPeriodCap(t *testing.T) {
 	// end block
 	stake.EndBlocker(ctx, sk)
 	// power should be equal, no more should have been slashed
-	expectedPower = sdk.NewDecFromInt(amt).Mul(sdk.NewDec(19).Quo(sdk.NewDec(20)))
+	expectedPower = sdk.NewDecFromInt(amt).Mul(sdk.NewDecWithoutFra(19).Quo(sdk.NewDecWithoutFra(20)))
 	require.Equal(t, expectedPower, sk.Validator(ctx, operatorAddr).GetPower())
 
 	// double sign again, new slashing period
@@ -125,7 +125,7 @@ func TestSlashingPeriodCap(t *testing.T) {
 	// end block
 	stake.EndBlocker(ctx, sk)
 	// power should be reduced
-	expectedPower = sdk.NewDecFromInt(amt).Mul(sdk.NewDec(18).Quo(sdk.NewDec(20)))
+	expectedPower = sdk.NewDecFromInt(amt).Mul(sdk.NewDecWithoutFra(18).Quo(sdk.NewDecWithoutFra(20)))
 	require.Equal(t, expectedPower, sk.Validator(ctx, operatorAddr).GetPower())
 }
 
@@ -135,7 +135,7 @@ func TestHandleAbsentValidator(t *testing.T) {
 
 	// initial setup
 	ctx, ck, sk, _, keeper := createTestInput(t, keeperTestParams())
-	amtInt := int64(100)
+	amtInt := sdk.NewDecWithoutFra(100).RawInt()
 	addr, val, amt := addrs[0], pks[0], amtInt
 	sh := stake.NewHandler(sk)
 	slh := NewHandler(keeper)
@@ -178,7 +178,7 @@ func TestHandleAbsentValidator(t *testing.T) {
 	validator, _ := sk.GetValidatorByConsAddr(ctx, sdk.GetConsAddress(val))
 	require.Equal(t, sdk.Bonded, validator.GetStatus())
 	pool := sk.GetPool(ctx)
-	require.Equal(t, amtInt, pool.BondedTokens.RoundInt64())
+	require.Equal(t, amtInt, pool.BondedTokens.RawInt())
 
 	// 501st block missed
 	ctx = ctx.WithBlockHeight(height)
@@ -196,10 +196,10 @@ func TestHandleAbsentValidator(t *testing.T) {
 	validator, _ = sk.GetValidatorByConsAddr(ctx, sdk.GetConsAddress(val))
 	require.Equal(t, sdk.Unbonding, validator.GetStatus())
 
-	slashAmt := sdk.NewDec(amtInt).Mul(keeper.SlashFractionDowntime(ctx)).RoundInt64()
+	slashAmt := sdk.NewDec(amtInt).Mul(keeper.SlashFractionDowntime(ctx)).RawInt()
 
 	// validator should have been slashed
-	require.Equal(t, amtInt-slashAmt, validator.GetTokens().RoundInt64())
+	require.Equal(t, amtInt-slashAmt, validator.GetTokens().RawInt())
 
 	// 502nd block *also* missed (since the LastCommit would have still included the just-unbonded validator)
 	height++
@@ -215,15 +215,15 @@ func TestHandleAbsentValidator(t *testing.T) {
 
 	// validator should not have been slashed any more, since it was already jailed
 	validator, _ = sk.GetValidatorByConsAddr(ctx, sdk.GetConsAddress(val))
-	require.Equal(t, amtInt-slashAmt, validator.GetTokens().RoundInt64())
+	require.Equal(t, amtInt-slashAmt, validator.GetTokens().RawInt())
 
 	// 502nd block *double signed* (oh no!)
 	keeper.handleDoubleSign(ctx, val.Address(), height, ctx.BlockHeader().Time, amtInt)
 
 	// validator should have been slashed
 	validator, _ = sk.GetValidatorByConsAddr(ctx, sdk.GetConsAddress(val))
-	secondSlashAmt := sdk.NewDec(amtInt).Mul(keeper.SlashFractionDoubleSign(ctx)).RoundInt64()
-	require.Equal(t, amtInt-slashAmt-secondSlashAmt, validator.GetTokens().RoundInt64())
+	secondSlashAmt := sdk.NewDec(amtInt).Mul(keeper.SlashFractionDoubleSign(ctx)).RawInt()
+	require.Equal(t, amtInt-slashAmt-secondSlashAmt, validator.GetTokens().RawInt())
 
 	// unrevocation should fail prior to jail expiration
 	got = slh(ctx, NewMsgUnjail(addr))
@@ -243,7 +243,7 @@ func TestHandleAbsentValidator(t *testing.T) {
 
 	// validator should have been slashed
 	pool = sk.GetPool(ctx)
-	require.Equal(t, amtInt-slashAmt-secondSlashAmt, pool.BondedTokens.RoundInt64())
+	require.Equal(t, amtInt-slashAmt-secondSlashAmt, pool.BondedTokens.RawInt())
 
 	// validator start height should not have been changed
 	info, found = keeper.getValidatorSigningInfo(ctx, sdk.ConsAddress(val.Address()))
@@ -289,7 +289,7 @@ func TestHandleAbsentValidator(t *testing.T) {
 func TestHandleNewValidator(t *testing.T) {
 	// initial setup
 	ctx, ck, sk, _, keeper := createTestInput(t, keeperTestParams())
-	addr, val, amt := addrs[0], pks[0], int64(100)
+	addr, val, amt := addrs[0], pks[0], sdk.NewDecWithoutFra(100).RawInt()
 	sh := stake.NewHandler(sk)
 
 	// 1000 first blocks not a validator
@@ -319,7 +319,7 @@ func TestHandleNewValidator(t *testing.T) {
 	validator, _ := sk.GetValidatorByConsAddr(ctx, sdk.GetConsAddress(val))
 	require.Equal(t, sdk.Bonded, validator.GetStatus())
 	pool := sk.GetPool(ctx)
-	require.Equal(t, int64(100), pool.BondedTokens.RoundInt64())
+	require.Equal(t, sdk.NewDecWithoutFra(100), pool.BondedTokens)
 }
 
 // Test a jailed validator being "down" twice
@@ -331,7 +331,7 @@ func TestHandleAlreadyJailed(t *testing.T) {
 	amtInt := int64(100)
 	addr, val, amt := addrs[0], pks[0], amtInt
 	sh := stake.NewHandler(sk)
-	got := sh(ctx, NewTestMsgCreateValidator(addr, val, amt))
+	got := sh(ctx, NewTestMsgCreateValidator(addr, val, sdk.NewDecWithoutFra(amt).RawInt()))
 	require.True(t, got.IsOK())
 	validatorUpdates := stake.EndBlocker(ctx, sk)
 	keeper.AddValidators(ctx, validatorUpdates)
@@ -340,13 +340,13 @@ func TestHandleAlreadyJailed(t *testing.T) {
 	height := int64(0)
 	for ; height < keeper.SignedBlocksWindow(ctx); height++ {
 		ctx = ctx.WithBlockHeight(height)
-		keeper.handleValidatorSignature(ctx, val.Address(), amtInt, true)
+		keeper.handleValidatorSignature(ctx, val.Address(), sdk.NewDecWithoutFra(amtInt).RawInt(), true)
 	}
 
 	// 501 blocks missed
 	for ; height < keeper.SignedBlocksWindow(ctx)+(keeper.SignedBlocksWindow(ctx)-keeper.MinSignedPerWindow(ctx))+1; height++ {
 		ctx = ctx.WithBlockHeight(height)
-		keeper.handleValidatorSignature(ctx, val.Address(), amtInt, false)
+		keeper.handleValidatorSignature(ctx, val.Address(), sdk.NewDecWithoutFra(amtInt).RawInt(), false)
 	}
 
 	// end block
@@ -357,15 +357,15 @@ func TestHandleAlreadyJailed(t *testing.T) {
 	require.Equal(t, sdk.Unbonding, validator.GetStatus())
 
 	// validator should have been slashed
-	require.Equal(t, amtInt-1, validator.GetTokens().RoundInt64())
+	require.Equal(t, sdk.NewDecWithoutFra(amtInt-1), validator.GetTokens())
 
 	// another block missed
 	ctx = ctx.WithBlockHeight(height)
-	keeper.handleValidatorSignature(ctx, val.Address(), amtInt, false)
+	keeper.handleValidatorSignature(ctx, val.Address(), sdk.NewDecWithoutFra(amtInt).RawInt(), false)
 
 	// validator should not have been slashed twice
 	validator, _ = sk.GetValidatorByConsAddr(ctx, sdk.GetConsAddress(val))
-	require.Equal(t, amtInt-1, validator.GetTokens().RoundInt64())
+	require.Equal(t, sdk.NewDecWithoutFra(amtInt-1), validator.GetTokens())
 
 }
 
@@ -384,7 +384,7 @@ func TestValidatorDippingInAndOut(t *testing.T) {
 	addr, val, amt := addrs[0], pks[0], amtInt
 	consAddr := sdk.ConsAddress(addr)
 	sh := stake.NewHandler(sk)
-	got := sh(ctx, NewTestMsgCreateValidator(addr, val, amt))
+	got := sh(ctx, NewTestMsgCreateValidator(addr, val, sdk.NewDecWithoutFra(amt).RawInt()))
 	require.True(t, got.IsOK())
 	validatorUpdates := stake.EndBlocker(ctx, sk)
 	keeper.AddValidators(ctx, validatorUpdates)
@@ -398,7 +398,7 @@ func TestValidatorDippingInAndOut(t *testing.T) {
 
 	// validator kicked out of validator set
 	newAmt := int64(101)
-	got = sh(ctx, NewTestMsgCreateValidator(addrs[1], pks[1], newAmt))
+	got = sh(ctx, NewTestMsgCreateValidator(addrs[1], pks[1], sdk.NewDecWithoutFra(newAmt).RawInt()))
 	require.True(t, got.IsOK())
 	validatorUpdates = stake.EndBlocker(ctx, sk)
 	require.Equal(t, 2, len(validatorUpdates))
@@ -411,7 +411,7 @@ func TestValidatorDippingInAndOut(t *testing.T) {
 	ctx = ctx.WithBlockHeight(height)
 
 	// validator added back in
-	got = sh(ctx, newTestMsgDelegate(sdk.AccAddress(addrs[2]), addrs[0], 2))
+	got = sh(ctx, newTestMsgDelegate(sdk.AccAddress(addrs[2]), addrs[0], sdk.NewDecWithoutFra(2).RawInt()))
 	require.True(t, got.IsOK())
 	validatorUpdates = stake.EndBlocker(ctx, sk)
 	require.Equal(t, 2, len(validatorUpdates))

--- a/x/slashing/params.go
+++ b/x/slashing/params.go
@@ -70,9 +70,9 @@ func DefaultParams() Params {
 
 		MinSignedPerWindow: sdk.NewDecWithPrec(5, 1),
 
-		SlashFractionDoubleSign: sdk.NewDec(1).Quo(sdk.NewDec(20)),
+		SlashFractionDoubleSign: sdk.OneDec().Quo(sdk.NewDecWithoutFra(20)),
 
-		SlashFractionDowntime: sdk.NewDec(1).Quo(sdk.NewDec(100)),
+		SlashFractionDowntime: sdk.OneDec().Quo(sdk.NewDecWithoutFra(100)),
 	}
 }
 
@@ -94,7 +94,7 @@ func (k Keeper) MinSignedPerWindow(ctx sdk.Context) int64 {
 	var minSignedPerWindow sdk.Dec
 	k.paramspace.Get(ctx, KeyMinSignedPerWindow, &minSignedPerWindow)
 	signedBlocksWindow := k.SignedBlocksWindow(ctx)
-	return sdk.NewDec(signedBlocksWindow).Mul(minSignedPerWindow).RoundInt64()
+	return sdk.NewDec(signedBlocksWindow).Mul(minSignedPerWindow).RawInt()
 }
 
 // Double-sign unbond duration

--- a/x/slashing/test_common.go
+++ b/x/slashing/test_common.go
@@ -36,7 +36,7 @@ var (
 		sdk.ValAddress(pks[1].Address()),
 		sdk.ValAddress(pks[2].Address()),
 	}
-	initCoins = int64(200)
+	initCoins = sdk.NewDecWithoutFra(200).RawInt()
 )
 
 func createTestCodec() *codec.Codec {

--- a/x/slashing/tick_test.go
+++ b/x/slashing/tick_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestBeginBlocker(t *testing.T) {
 	ctx, ck, sk, _, keeper := createTestInput(t, DefaultParams())
-	addr, pk, amt := addrs[2], pks[2], int64(100)
+	addr, pk, amt := addrs[2], pks[2], sdk.NewDecWithoutFra(100).RawInt()
 
 	// bond the validator
 	got := stake.NewHandler(sk)(ctx, NewTestMsgCreateValidator(addr, pk, amt))

--- a/x/stake/app_test.go
+++ b/x/stake/app_test.go
@@ -55,7 +55,7 @@ func getInitChainer(mapp *mock.App, keeper Keeper) sdk.InitChainer {
 		mapp.InitChainer(ctx, req)
 
 		stakeGenesis := DefaultGenesisState()
-		stakeGenesis.Pool.LooseTokens = sdk.NewDec(100000)
+		stakeGenesis.Pool.LooseTokens = sdk.NewDecWithoutFra(100000)
 
 		validators, err := InitGenesis(ctx, keeper, stakeGenesis)
 		if err != nil {
@@ -100,8 +100,8 @@ func checkDelegation(
 func TestStakeMsgs(t *testing.T) {
 	mApp, keeper := getMockApp(t)
 
-	genCoin := sdk.NewCoin("steak", 42)
-	bondCoin := sdk.NewCoin("steak", 10)
+	genCoin := sdk.NewCoin("steak", sdk.NewDecWithoutFra(42).RawInt())
+	bondCoin := sdk.NewCoin("steak", sdk.NewDecWithoutFra(10).RawInt())
 
 	acc1 := &auth.BaseAccount{
 		Address: addr1,
@@ -130,7 +130,7 @@ func TestStakeMsgs(t *testing.T) {
 	validator := checkValidator(t, mApp, keeper, sdk.ValAddress(addr1), true)
 	require.Equal(t, sdk.ValAddress(addr1), validator.OperatorAddr)
 	require.Equal(t, sdk.Bonded, validator.Status)
-	require.True(sdk.DecEq(t, sdk.NewDec(10), validator.BondedTokens()))
+	require.True(sdk.DecEq(t, sdk.NewDecWithoutFra(10), validator.BondedTokens()))
 
 	// addr1 create validator on behalf of addr2
 	createValidatorMsgOnBehalfOf := NewMsgCreateValidatorOnBehalfOf(
@@ -144,10 +144,10 @@ func TestStakeMsgs(t *testing.T) {
 	validator = checkValidator(t, mApp, keeper, sdk.ValAddress(addr2), true)
 	require.Equal(t, sdk.ValAddress(addr2), validator.OperatorAddr)
 	require.Equal(t, sdk.Bonded, validator.Status)
-	require.True(sdk.DecEq(t, sdk.NewDec(10), validator.Tokens))
+	require.True(sdk.DecEq(t, sdk.NewDecWithoutFra(10), validator.Tokens))
 
 	// check the bond that should have been created as well
-	checkDelegation(t, mApp, keeper, addr1, sdk.ValAddress(addr1), true, sdk.NewDec(10))
+	checkDelegation(t, mApp, keeper, addr1, sdk.ValAddress(addr1), true, sdk.NewDecWithoutFra(10))
 
 	// edit the validator
 	description = NewDescription("bar_moniker", "", "", "")
@@ -163,10 +163,10 @@ func TestStakeMsgs(t *testing.T) {
 
 	mock.SignCheckDeliver(t, mApp.BaseApp, []sdk.Msg{delegateMsg}, []int64{0}, []int64{1}, true, true, priv2)
 	mock.CheckBalance(t, mApp, addr2, sdk.Coins{genCoin.Minus(bondCoin)})
-	checkDelegation(t, mApp, keeper, addr2, sdk.ValAddress(addr1), true, sdk.NewDec(10))
+	checkDelegation(t, mApp, keeper, addr2, sdk.ValAddress(addr1), true, sdk.NewDecWithoutFra(10))
 
 	// begin unbonding
-	beginUnbondingMsg := NewMsgBeginUnbonding(addr2, sdk.ValAddress(addr1), sdk.NewDec(10))
+	beginUnbondingMsg := NewMsgBeginUnbonding(addr2, sdk.ValAddress(addr1), sdk.NewDecWithoutFra(10))
 	mock.SignCheckDeliver(t, mApp.BaseApp, []sdk.Msg{beginUnbondingMsg}, []int64{0}, []int64{2}, true, true, priv2)
 
 	// delegation should exist anymore

--- a/x/stake/genesis.go
+++ b/x/stake/genesis.go
@@ -75,7 +75,7 @@ func WriteValidators(ctx sdk.Context, keeper Keeper) (vals []tmtypes.GenesisVali
 	keeper.IterateValidatorsBonded(ctx, func(_ int64, validator sdk.Validator) (stop bool) {
 		vals = append(vals, tmtypes.GenesisValidator{
 			PubKey: validator.GetConsPubKey(),
-			Power:  validator.GetPower().RoundInt64(),
+			Power:  validator.GetPower().RawInt(),
 			Name:   validator.GetMoniker(),
 		})
 

--- a/x/stake/genesis_test.go
+++ b/x/stake/genesis_test.go
@@ -19,7 +19,7 @@ func TestInitGenesis(t *testing.T) {
 	ctx, _, keeper := keep.CreateTestInput(t, false, 1000)
 
 	pool := keeper.GetPool(ctx)
-	pool.BondedTokens = sdk.NewDec(2)
+	pool.BondedTokens = sdk.NewDecWithoutFra(2)
 
 	params := keeper.GetParams(ctx)
 	var delegations []Delegation
@@ -77,7 +77,7 @@ func TestInitGenesisLargeValidatorSet(t *testing.T) {
 
 	// Assigning 2 to the first 100 vals, 1 to the rest
 	pool := keeper.GetPool(ctx)
-	pool.BondedTokens = sdk.NewDec(int64(200 + (size - 100)))
+	pool.BondedTokens = sdk.NewDecWithoutFra(int64(200 + (size - 100)))
 
 	params := keeper.GetParams(ctx)
 	delegations := []Delegation{}
@@ -88,8 +88,8 @@ func TestInitGenesisLargeValidatorSet(t *testing.T) {
 
 		validators[i].Status = sdk.Bonded
 		if i < 100 {
-			validators[i].Tokens = sdk.NewDec(2)
-			validators[i].DelegatorShares = sdk.NewDec(2)
+			validators[i].Tokens = sdk.NewDecWithoutFra(2)
+			validators[i].DelegatorShares = sdk.NewDecWithoutFra(2)
 		} else {
 			validators[i].Tokens = sdk.OneDec()
 			validators[i].DelegatorShares = sdk.OneDec()

--- a/x/stake/keeper/delegation_test.go
+++ b/x/stake/keeper/delegation_test.go
@@ -22,7 +22,7 @@ func TestDelegation(t *testing.T) {
 	var validators [3]types.Validator
 	for i, amt := range amts {
 		validators[i] = types.NewValidator(addrVals[i], PKs[i], types.Description{})
-		validators[i], pool, _ = validators[i].AddTokensFromDel(pool, amt)
+		validators[i], pool, _ = validators[i].AddTokensFromDel(pool, sdk.NewDecWithoutFra(amt).RawInt())
 	}
 
 	keeper.SetPool(ctx, pool)
@@ -35,7 +35,7 @@ func TestDelegation(t *testing.T) {
 	bond1to1 := types.Delegation{
 		DelegatorAddr: addrDels[0],
 		ValidatorAddr: addrVals[0],
-		Shares:        sdk.NewDec(9),
+		Shares:        sdk.NewDecWithoutFra(9),
 	}
 
 	// check the empty keeper first
@@ -49,18 +49,18 @@ func TestDelegation(t *testing.T) {
 	require.True(t, bond1to1.Equal(resBond))
 
 	// modify a records, save, and retrieve
-	bond1to1.Shares = sdk.NewDec(99)
+	bond1to1.Shares = sdk.NewDecWithoutFra(99)
 	keeper.SetDelegation(ctx, bond1to1)
 	resBond, found = keeper.GetDelegation(ctx, addrDels[0], addrVals[0])
 	require.True(t, found)
 	require.True(t, bond1to1.Equal(resBond))
 
 	// add some more records
-	bond1to2 := types.Delegation{addrDels[0], addrVals[1], sdk.NewDec(9), 0}
-	bond1to3 := types.Delegation{addrDels[0], addrVals[2], sdk.NewDec(9), 1}
-	bond2to1 := types.Delegation{addrDels[1], addrVals[0], sdk.NewDec(9), 2}
-	bond2to2 := types.Delegation{addrDels[1], addrVals[1], sdk.NewDec(9), 3}
-	bond2to3 := types.Delegation{addrDels[1], addrVals[2], sdk.NewDec(9), 4}
+	bond1to2 := types.Delegation{addrDels[0], addrVals[1], sdk.NewDecWithoutFra(9), 0}
+	bond1to3 := types.Delegation{addrDels[0], addrVals[2], sdk.NewDecWithoutFra(9), 1}
+	bond2to1 := types.Delegation{addrDels[1], addrVals[0], sdk.NewDecWithoutFra(9), 2}
+	bond2to2 := types.Delegation{addrDels[1], addrVals[1], sdk.NewDecWithoutFra(9), 3}
+	bond2to3 := types.Delegation{addrDels[1], addrVals[2], sdk.NewDecWithoutFra(9), 4}
 	keeper.SetDelegation(ctx, bond1to2)
 	keeper.SetDelegation(ctx, bond1to3)
 	keeper.SetDelegation(ctx, bond2to1)
@@ -178,18 +178,18 @@ func TestUnbondingDelegation(t *testing.T) {
 func TestUnbondDelegation(t *testing.T) {
 	ctx, _, keeper := CreateTestInput(t, false, 0)
 	pool := keeper.GetPool(ctx)
-	pool.LooseTokens = sdk.NewDec(10)
+	pool.LooseTokens = sdk.NewDecWithoutFra(10)
 
 	//create a validator and a delegator to that validator
 	validator := types.NewValidator(addrVals[0], PKs[0], types.Description{})
-	validator, pool, issuedShares := validator.AddTokensFromDel(pool, 10)
-	require.Equal(t, int64(10), issuedShares.RoundInt64())
+	validator, pool, issuedShares := validator.AddTokensFromDel(pool, sdk.NewDecWithoutFra(10).RawInt())
+	require.Equal(t, sdk.NewDecWithoutFra(10), issuedShares)
 	keeper.SetPool(ctx, pool)
 	validator = TestingUpdateValidator(keeper, ctx, validator)
 
 	pool = keeper.GetPool(ctx)
-	require.Equal(t, int64(10), pool.BondedTokens.RoundInt64())
-	require.Equal(t, int64(10), validator.BondedTokens().RoundInt64())
+	require.Equal(t, sdk.NewDecWithoutFra(10), pool.BondedTokens)
+	require.Equal(t, sdk.NewDecWithoutFra(10), validator.BondedTokens())
 
 	delegation := types.Delegation{
 		DelegatorAddr: addrDels[0],
@@ -198,9 +198,9 @@ func TestUnbondDelegation(t *testing.T) {
 	}
 	keeper.SetDelegation(ctx, delegation)
 
-	amount, err := keeper.unbond(ctx, addrDels[0], addrVals[0], sdk.NewDec(6))
+	amount, err := keeper.unbond(ctx, addrDels[0], addrVals[0], sdk.NewDecWithoutFra(6))
 	require.NoError(t, err)
-	require.Equal(t, int64(6), amount.RoundInt64()) // shares to be added to an unbonding delegation / redelegation
+	require.Equal(t, sdk.NewDecWithoutFra(6), amount) // shares to be added to an unbonding delegation / redelegation
 
 	delegation, found := keeper.GetDelegation(ctx, addrDels[0], addrVals[0])
 	require.True(t, found)
@@ -208,10 +208,10 @@ func TestUnbondDelegation(t *testing.T) {
 	require.True(t, found)
 	pool = keeper.GetPool(ctx)
 
-	require.Equal(t, int64(4), delegation.Shares.RoundInt64())
-	require.Equal(t, int64(4), validator.BondedTokens().RoundInt64())
-	require.Equal(t, int64(6), pool.LooseTokens.RoundInt64(), "%v", pool)
-	require.Equal(t, int64(4), pool.BondedTokens.RoundInt64())
+	require.Equal(t, sdk.NewDecWithoutFra(4), delegation.Shares)
+	require.Equal(t, sdk.NewDecWithoutFra(4), validator.BondedTokens())
+	require.Equal(t, sdk.NewDecWithoutFra(6), pool.LooseTokens, "%v", pool)
+	require.Equal(t, sdk.NewDecWithoutFra(4), pool.BondedTokens)
 }
 
 // test removing all self delegation from a validator which should
@@ -220,12 +220,12 @@ func TestUndelegateSelfDelegation(t *testing.T) {
 
 	ctx, _, keeper := CreateTestInput(t, false, 0)
 	pool := keeper.GetPool(ctx)
-	pool.LooseTokens = sdk.NewDec(20)
+	pool.LooseTokens = sdk.NewDecWithoutFra(20)
 
 	//create a validator with a self-delegation
 	validator := types.NewValidator(addrVals[0], PKs[0], types.Description{})
-	validator, pool, issuedShares := validator.AddTokensFromDel(pool, 10)
-	require.Equal(t, int64(10), issuedShares.RoundInt64())
+	validator, pool, issuedShares := validator.AddTokensFromDel(pool, sdk.NewDecWithoutFra(10).RawInt())
+	require.Equal(t, sdk.NewDecWithoutFra(10), issuedShares)
 	keeper.SetPool(ctx, pool)
 	validator = TestingUpdateValidator(keeper, ctx, validator)
 	pool = keeper.GetPool(ctx)
@@ -238,8 +238,8 @@ func TestUndelegateSelfDelegation(t *testing.T) {
 
 	// create a second delegation to this validator
 	keeper.DeleteValidatorByPowerIndex(ctx, validator, pool)
-	validator, pool, issuedShares = validator.AddTokensFromDel(pool, 10)
-	require.Equal(t, int64(10), issuedShares.RoundInt64())
+	validator, pool, issuedShares = validator.AddTokensFromDel(pool, sdk.NewDecWithoutFra(10).RawInt())
+	require.Equal(t, sdk.NewDecWithoutFra(10), issuedShares)
 	keeper.SetPool(ctx, pool)
 	validator = TestingUpdateValidator(keeper, ctx, validator)
 	pool = keeper.GetPool(ctx)
@@ -251,7 +251,7 @@ func TestUndelegateSelfDelegation(t *testing.T) {
 	keeper.SetDelegation(ctx, delegation)
 
 	val0AccAddr := sdk.AccAddress(addrVals[0].Bytes())
-	_, err := keeper.BeginUnbonding(ctx, val0AccAddr, addrVals[0], sdk.NewDec(10))
+	_, err := keeper.BeginUnbonding(ctx, val0AccAddr, addrVals[0], sdk.NewDecWithoutFra(10))
 	require.NoError(t, err)
 
 	// end block
@@ -260,20 +260,20 @@ func TestUndelegateSelfDelegation(t *testing.T) {
 
 	validator, found := keeper.GetValidator(ctx, addrVals[0])
 	require.True(t, found)
-	require.Equal(t, int64(10), validator.Tokens.RoundInt64())
+	require.Equal(t, sdk.NewDecWithoutFra(10), validator.Tokens)
 	require.Equal(t, sdk.Unbonding, validator.Status)
 }
 
 func TestUndelegateFromUnbondingValidator(t *testing.T) {
 	ctx, _, keeper := CreateTestInput(t, false, 0)
 	pool := keeper.GetPool(ctx)
-	pool.LooseTokens = sdk.NewDec(20)
+	pool.LooseTokens = sdk.NewDecWithoutFra(20)
 
 	//create a validator with a self-delegation
 	validator := types.NewValidator(addrVals[0], PKs[0], types.Description{})
 
-	validator, pool, issuedShares := validator.AddTokensFromDel(pool, 10)
-	require.Equal(t, int64(10), issuedShares.RoundInt64())
+	validator, pool, issuedShares := validator.AddTokensFromDel(pool, sdk.NewDecWithoutFra(10).RawInt())
+	require.Equal(t, sdk.NewDecWithoutFra(10), issuedShares)
 	keeper.SetPool(ctx, pool)
 	validator = TestingUpdateValidator(keeper, ctx, validator)
 	pool = keeper.GetPool(ctx)
@@ -286,8 +286,8 @@ func TestUndelegateFromUnbondingValidator(t *testing.T) {
 
 	// create a second delegation to this validator
 	keeper.DeleteValidatorByPowerIndex(ctx, validator, pool)
-	validator, pool, issuedShares = validator.AddTokensFromDel(pool, 10)
-	require.Equal(t, int64(10), issuedShares.RoundInt64())
+	validator, pool, issuedShares = validator.AddTokensFromDel(pool, sdk.NewDecWithoutFra(10).RawInt())
+	require.Equal(t, sdk.NewDecWithoutFra(10), issuedShares)
 	keeper.SetPool(ctx, pool)
 	validator = TestingUpdateValidator(keeper, ctx, validator)
 	pool = keeper.GetPool(ctx)
@@ -307,7 +307,7 @@ func TestUndelegateFromUnbondingValidator(t *testing.T) {
 
 	// unbond the all self-delegation to put validator in unbonding state
 	val0AccAddr := sdk.AccAddress(addrVals[0].Bytes())
-	_, err := keeper.BeginUnbonding(ctx, val0AccAddr, addrVals[0], sdk.NewDec(10))
+	_, err := keeper.BeginUnbonding(ctx, val0AccAddr, addrVals[0], sdk.NewDecWithoutFra(10))
 	require.NoError(t, err)
 
 	// end block
@@ -329,13 +329,13 @@ func TestUndelegateFromUnbondingValidator(t *testing.T) {
 	ctx = ctx.WithBlockHeader(header)
 
 	// unbond some of the other delegation's shares
-	_, err = keeper.BeginUnbonding(ctx, addrDels[0], addrVals[0], sdk.NewDec(6))
+	_, err = keeper.BeginUnbonding(ctx, addrDels[0], addrVals[0], sdk.NewDecWithoutFra(6))
 	require.NoError(t, err)
 
 	// retrieve the unbonding delegation
 	ubd, found := keeper.GetUnbondingDelegation(ctx, addrDels[0], addrVals[0])
 	require.True(t, found)
-	require.True(t, ubd.Balance.IsEqual(sdk.NewCoin(params.BondDenom, 6)))
+	require.True(t, ubd.Balance.IsEqual(sdk.NewCoin(params.BondDenom, sdk.NewDecWithoutFra(6).RawInt())))
 	assert.Equal(t, blockHeight, ubd.CreationHeight)
 	assert.True(t, blockTime.Add(params.UnbondingTime).Equal(ubd.MinTime))
 }
@@ -343,13 +343,13 @@ func TestUndelegateFromUnbondingValidator(t *testing.T) {
 func TestUndelegateFromUnbondedValidator(t *testing.T) {
 	ctx, _, keeper := CreateTestInput(t, false, 0)
 	pool := keeper.GetPool(ctx)
-	pool.LooseTokens = sdk.NewDec(20)
+	pool.LooseTokens = sdk.NewDecWithoutFra(20)
 
 	//create a validator with a self-delegation
 	validator := types.NewValidator(addrVals[0], PKs[0], types.Description{})
 
-	validator, pool, issuedShares := validator.AddTokensFromDel(pool, 10)
-	require.Equal(t, int64(10), issuedShares.RoundInt64())
+	validator, pool, issuedShares := validator.AddTokensFromDel(pool, sdk.NewDecWithoutFra(10).RawInt())
+	require.Equal(t, sdk.NewDecWithoutFra(10), issuedShares)
 	keeper.SetPool(ctx, pool)
 	validator = TestingUpdateValidator(keeper, ctx, validator)
 	pool = keeper.GetPool(ctx)
@@ -363,8 +363,8 @@ func TestUndelegateFromUnbondedValidator(t *testing.T) {
 
 	// create a second delegation to this validator
 	keeper.DeleteValidatorByPowerIndex(ctx, validator, pool)
-	validator, pool, issuedShares = validator.AddTokensFromDel(pool, 10)
-	require.Equal(t, int64(10), issuedShares.RoundInt64())
+	validator, pool, issuedShares = validator.AddTokensFromDel(pool, sdk.NewDecWithoutFra(10).RawInt())
+	require.Equal(t, sdk.NewDecWithoutFra(10), issuedShares)
 	keeper.SetPool(ctx, pool)
 	validator = TestingUpdateValidator(keeper, ctx, validator)
 	pool = keeper.GetPool(ctx)
@@ -379,7 +379,7 @@ func TestUndelegateFromUnbondedValidator(t *testing.T) {
 	ctx = ctx.WithBlockTime(time.Unix(333, 0))
 
 	// unbond the all self-delegation to put validator in unbonding state
-	_, err := keeper.BeginUnbonding(ctx, val0AccAddr, addrVals[0], sdk.NewDec(10))
+	_, err := keeper.BeginUnbonding(ctx, val0AccAddr, addrVals[0], sdk.NewDecWithoutFra(10))
 	require.NoError(t, err)
 
 	// end block
@@ -402,7 +402,7 @@ func TestUndelegateFromUnbondedValidator(t *testing.T) {
 	require.Equal(t, validator.Status, sdk.Unbonded)
 
 	// unbond some of the other delegation's shares
-	_, err = keeper.BeginUnbonding(ctx, addrDels[0], addrVals[0], sdk.NewDec(6))
+	_, err = keeper.BeginUnbonding(ctx, addrDels[0], addrVals[0], sdk.NewDecWithoutFra(6))
 	require.NoError(t, err)
 
 	// no ubd should have been found, coins should have been returned direcly to account
@@ -410,7 +410,7 @@ func TestUndelegateFromUnbondedValidator(t *testing.T) {
 	require.False(t, found, "%v", ubd)
 
 	// unbond rest of the other delegation's shares
-	_, err = keeper.BeginUnbonding(ctx, addrDels[0], addrVals[0], sdk.NewDec(4))
+	_, err = keeper.BeginUnbonding(ctx, addrDels[0], addrVals[0], sdk.NewDecWithoutFra(4))
 	require.NoError(t, err)
 
 	//  now validator should now be deleted from state
@@ -422,13 +422,13 @@ func TestUndelegateFromUnbondedValidator(t *testing.T) {
 func TestUnbondingAllDelegationFromValidator(t *testing.T) {
 	ctx, _, keeper := CreateTestInput(t, false, 0)
 	pool := keeper.GetPool(ctx)
-	pool.LooseTokens = sdk.NewDec(20)
+	pool.LooseTokens = sdk.NewDecWithoutFra(20)
 
 	//create a validator with a self-delegation
 	validator := types.NewValidator(addrVals[0], PKs[0], types.Description{})
 
-	validator, pool, issuedShares := validator.AddTokensFromDel(pool, 10)
-	require.Equal(t, int64(10), issuedShares.RoundInt64())
+	validator, pool, issuedShares := validator.AddTokensFromDel(pool, sdk.NewDecWithoutFra(10).RawInt())
+	require.Equal(t, sdk.NewDecWithoutFra(10), issuedShares)
 	keeper.SetPool(ctx, pool)
 	validator = TestingUpdateValidator(keeper, ctx, validator)
 	pool = keeper.GetPool(ctx)
@@ -442,8 +442,8 @@ func TestUnbondingAllDelegationFromValidator(t *testing.T) {
 
 	// create a second delegation to this validator
 	keeper.DeleteValidatorByPowerIndex(ctx, validator, pool)
-	validator, pool, issuedShares = validator.AddTokensFromDel(pool, 10)
-	require.Equal(t, int64(10), issuedShares.RoundInt64())
+	validator, pool, issuedShares = validator.AddTokensFromDel(pool, sdk.NewDecWithoutFra(10).RawInt())
+	require.Equal(t, sdk.NewDecWithoutFra(10), issuedShares)
 	keeper.SetPool(ctx, pool)
 	validator = TestingUpdateValidator(keeper, ctx, validator)
 	pool = keeper.GetPool(ctx)
@@ -458,7 +458,7 @@ func TestUnbondingAllDelegationFromValidator(t *testing.T) {
 	ctx = ctx.WithBlockTime(time.Unix(333, 0))
 
 	// unbond the all self-delegation to put validator in unbonding state
-	_, err := keeper.BeginUnbonding(ctx, val0AccAddr, addrVals[0], sdk.NewDec(10))
+	_, err := keeper.BeginUnbonding(ctx, val0AccAddr, addrVals[0], sdk.NewDecWithoutFra(10))
 	require.NoError(t, err)
 
 	// end block
@@ -466,7 +466,7 @@ func TestUnbondingAllDelegationFromValidator(t *testing.T) {
 	require.Equal(t, 1, len(updates))
 
 	// unbond all the remaining delegation
-	_, err = keeper.BeginUnbonding(ctx, addrDels[0], addrVals[0], sdk.NewDec(10))
+	_, err = keeper.BeginUnbonding(ctx, addrDels[0], addrVals[0], sdk.NewDecWithoutFra(10))
 	require.NoError(t, err)
 
 	// validator should still be in state and still be in unbonding state
@@ -493,8 +493,8 @@ func TestGetRedelegationsFromValidator(t *testing.T) {
 		ValidatorDstAddr: addrVals[1],
 		CreationHeight:   0,
 		MinTime:          time.Unix(0, 0),
-		SharesSrc:        sdk.NewDec(5),
-		SharesDst:        sdk.NewDec(5),
+		SharesSrc:        sdk.NewDecWithoutFra(5),
+		SharesDst:        sdk.NewDecWithoutFra(5),
 	}
 
 	// set and retrieve a record
@@ -523,8 +523,8 @@ func TestRedelegation(t *testing.T) {
 		ValidatorDstAddr: addrVals[1],
 		CreationHeight:   0,
 		MinTime:          time.Unix(0, 0),
-		SharesSrc:        sdk.NewDec(5),
-		SharesDst:        sdk.NewDec(5),
+		SharesSrc:        sdk.NewDecWithoutFra(5),
+		SharesDst:        sdk.NewDecWithoutFra(5),
 	}
 
 	// test shouldn't have and redelegations
@@ -553,8 +553,8 @@ func TestRedelegation(t *testing.T) {
 	require.True(t, has)
 
 	// modify a records, save, and retrieve
-	rd.SharesSrc = sdk.NewDec(21)
-	rd.SharesDst = sdk.NewDec(21)
+	rd.SharesSrc = sdk.NewDecWithoutFra(21)
+	rd.SharesDst = sdk.NewDecWithoutFra(21)
 	keeper.SetRedelegation(ctx, rd)
 
 	resRed, found = keeper.GetRedelegation(ctx, addrDels[0], addrVals[0], addrVals[1])
@@ -585,12 +585,12 @@ func TestRedelegateSelfDelegation(t *testing.T) {
 
 	ctx, _, keeper := CreateTestInput(t, false, 0)
 	pool := keeper.GetPool(ctx)
-	pool.LooseTokens = sdk.NewDec(30)
+	pool.LooseTokens = sdk.NewDecWithoutFra(30)
 
 	//create a validator with a self-delegation
 	validator := types.NewValidator(addrVals[0], PKs[0], types.Description{})
-	validator, pool, issuedShares := validator.AddTokensFromDel(pool, 10)
-	require.Equal(t, int64(10), issuedShares.RoundInt64())
+	validator, pool, issuedShares := validator.AddTokensFromDel(pool, sdk.NewDecWithoutFra(10).RawInt())
+	require.Equal(t, sdk.NewDecWithoutFra(10), issuedShares)
 	keeper.SetPool(ctx, pool)
 	validator = TestingUpdateValidator(keeper, ctx, validator)
 	pool = keeper.GetPool(ctx)
@@ -604,16 +604,16 @@ func TestRedelegateSelfDelegation(t *testing.T) {
 
 	// create a second validator
 	validator2 := types.NewValidator(addrVals[1], PKs[1], types.Description{})
-	validator2, pool, issuedShares = validator2.AddTokensFromDel(pool, 10)
-	require.Equal(t, int64(10), issuedShares.RoundInt64())
-	pool.BondedTokens = pool.BondedTokens.Add(sdk.NewDec(10))
+	validator2, pool, issuedShares = validator2.AddTokensFromDel(pool, sdk.NewDecWithoutFra(10).RawInt())
+	require.Equal(t, sdk.NewDecWithoutFra(10), issuedShares)
+	pool.BondedTokens = pool.BondedTokens.Add(sdk.NewDecWithoutFra(10))
 	keeper.SetPool(ctx, pool)
 	validator2 = TestingUpdateValidator(keeper, ctx, validator2)
 	require.Equal(t, sdk.Bonded, validator2.Status)
 
 	// create a second delegation to this validator
-	validator, pool, issuedShares = validator.AddTokensFromDel(pool, 10)
-	require.Equal(t, int64(10), issuedShares.RoundInt64())
+	validator, pool, issuedShares = validator.AddTokensFromDel(pool, sdk.NewDecWithoutFra(10).RawInt())
+	require.Equal(t, sdk.NewDecWithoutFra(10), issuedShares)
 	keeper.SetPool(ctx, pool)
 	validator = TestingUpdateValidator(keeper, ctx, validator)
 	pool = keeper.GetPool(ctx)
@@ -624,7 +624,7 @@ func TestRedelegateSelfDelegation(t *testing.T) {
 	}
 	keeper.SetDelegation(ctx, delegation)
 
-	_, err := keeper.BeginRedelegation(ctx, val0AccAddr, addrVals[0], addrVals[1], sdk.NewDec(10))
+	_, err := keeper.BeginRedelegation(ctx, val0AccAddr, addrVals[0], addrVals[1], sdk.NewDecWithoutFra(10))
 	require.NoError(t, err)
 
 	// end block
@@ -633,21 +633,21 @@ func TestRedelegateSelfDelegation(t *testing.T) {
 
 	validator, found := keeper.GetValidator(ctx, addrVals[0])
 	require.True(t, found)
-	require.Equal(t, int64(10), validator.Tokens.RoundInt64())
+	require.Equal(t, sdk.NewDecWithoutFra(10), validator.Tokens)
 	require.Equal(t, sdk.Unbonding, validator.Status)
 }
 
 func TestRedelegateFromUnbondingValidator(t *testing.T) {
 	ctx, _, keeper := CreateTestInput(t, false, 0)
 	pool := keeper.GetPool(ctx)
-	pool.LooseTokens = sdk.NewDec(30)
+	pool.LooseTokens = sdk.NewDecWithoutFra(30)
 
 	//create a validator with a self-delegation
 	validator := types.NewValidator(addrVals[0], PKs[0], types.Description{})
 	validator.BondIntraTxCounter = 1
 
-	validator, pool, issuedShares := validator.AddTokensFromDel(pool, 10)
-	require.Equal(t, int64(10), issuedShares.RoundInt64())
+	validator, pool, issuedShares := validator.AddTokensFromDel(pool, sdk.NewDecWithoutFra(10).RawInt())
+	require.Equal(t, sdk.NewDecWithoutFra(10), issuedShares)
 	keeper.SetPool(ctx, pool)
 	validator = TestingUpdateValidator(keeper, ctx, validator)
 	pool = keeper.GetPool(ctx)
@@ -661,8 +661,8 @@ func TestRedelegateFromUnbondingValidator(t *testing.T) {
 
 	// create a second delegation to this validator
 	keeper.DeleteValidatorByPowerIndex(ctx, validator, pool)
-	validator, pool, issuedShares = validator.AddTokensFromDel(pool, 10)
-	require.Equal(t, int64(10), issuedShares.RoundInt64())
+	validator, pool, issuedShares = validator.AddTokensFromDel(pool, sdk.NewDecWithoutFra(10).RawInt())
+	require.Equal(t, sdk.NewDecWithoutFra(10), issuedShares)
 	keeper.SetPool(ctx, pool)
 	validator = TestingUpdateValidator(keeper, ctx, validator)
 	pool = keeper.GetPool(ctx)
@@ -676,8 +676,8 @@ func TestRedelegateFromUnbondingValidator(t *testing.T) {
 	// create a second validator
 	validator2 := types.NewValidator(addrVals[1], PKs[1], types.Description{})
 	validator2.BondIntraTxCounter = 2
-	validator2, pool, issuedShares = validator2.AddTokensFromDel(pool, 10)
-	require.Equal(t, int64(10), issuedShares.RoundInt64())
+	validator2, pool, issuedShares = validator2.AddTokensFromDel(pool, sdk.NewDecWithoutFra(10).RawInt())
+	require.Equal(t, sdk.NewDecWithoutFra(10), issuedShares)
 	keeper.SetPool(ctx, pool)
 	validator2 = TestingUpdateValidator(keeper, ctx, validator2)
 
@@ -689,7 +689,7 @@ func TestRedelegateFromUnbondingValidator(t *testing.T) {
 	ctx = ctx.WithBlockHeader(header)
 
 	// unbond the all self-delegation to put validator in unbonding state
-	_, err := keeper.BeginUnbonding(ctx, val0AccAddr, addrVals[0], sdk.NewDec(10))
+	_, err := keeper.BeginUnbonding(ctx, val0AccAddr, addrVals[0], sdk.NewDecWithoutFra(10))
 	require.NoError(t, err)
 
 	// end block
@@ -711,13 +711,13 @@ func TestRedelegateFromUnbondingValidator(t *testing.T) {
 	ctx = ctx.WithBlockHeader(header)
 
 	// unbond some of the other delegation's shares
-	_, err = keeper.BeginRedelegation(ctx, addrDels[0], addrVals[0], addrVals[1], sdk.NewDec(6))
+	_, err = keeper.BeginRedelegation(ctx, addrDels[0], addrVals[0], addrVals[1], sdk.NewDecWithoutFra(6))
 	require.NoError(t, err)
 
 	// retrieve the unbonding delegation
 	ubd, found := keeper.GetRedelegation(ctx, addrDels[0], addrVals[0], addrVals[1])
 	require.True(t, found)
-	require.True(t, ubd.Balance.IsEqual(sdk.NewCoin(params.BondDenom, 6)))
+	require.True(t, ubd.Balance.IsEqual(sdk.NewCoin(params.BondDenom, sdk.NewDecWithoutFra(6).RawInt())))
 	assert.Equal(t, blockHeight, ubd.CreationHeight)
 	assert.True(t, blockTime.Add(params.UnbondingTime).Equal(ubd.MinTime))
 }
@@ -725,13 +725,13 @@ func TestRedelegateFromUnbondingValidator(t *testing.T) {
 func TestRedelegateFromUnbondedValidator(t *testing.T) {
 	ctx, _, keeper := CreateTestInput(t, false, 0)
 	pool := keeper.GetPool(ctx)
-	pool.LooseTokens = sdk.NewDec(30)
+	pool.LooseTokens = sdk.NewDecWithoutFra(30)
 
 	//create a validator with a self-delegation
 	validator := types.NewValidator(addrVals[0], PKs[0], types.Description{})
 
-	validator, pool, issuedShares := validator.AddTokensFromDel(pool, 10)
-	require.Equal(t, int64(10), issuedShares.RoundInt64())
+	validator, pool, issuedShares := validator.AddTokensFromDel(pool, sdk.NewDecWithoutFra(10).RawInt())
+	require.Equal(t, sdk.NewDecWithoutFra(10), issuedShares)
 	keeper.SetPool(ctx, pool)
 	validator = TestingUpdateValidator(keeper, ctx, validator)
 	pool = keeper.GetPool(ctx)
@@ -745,9 +745,9 @@ func TestRedelegateFromUnbondedValidator(t *testing.T) {
 
 	// create a second delegation to this validator
 	keeper.DeleteValidatorByPowerIndex(ctx, validator, pool)
-	validator, pool, issuedShares = validator.AddTokensFromDel(pool, 10)
+	validator, pool, issuedShares = validator.AddTokensFromDel(pool, sdk.NewDecWithoutFra(10).RawInt())
 	validator.BondIntraTxCounter = 1
-	require.Equal(t, int64(10), issuedShares.RoundInt64())
+	require.Equal(t, sdk.NewDecWithoutFra(10), issuedShares)
 	keeper.SetPool(ctx, pool)
 	validator = TestingUpdateValidator(keeper, ctx, validator)
 	pool = keeper.GetPool(ctx)
@@ -761,8 +761,8 @@ func TestRedelegateFromUnbondedValidator(t *testing.T) {
 	// create a second validator
 	validator2 := types.NewValidator(addrVals[1], PKs[1], types.Description{})
 	validator2.BondIntraTxCounter = 2
-	validator2, pool, issuedShares = validator2.AddTokensFromDel(pool, 10)
-	require.Equal(t, int64(10), issuedShares.RoundInt64())
+	validator2, pool, issuedShares = validator2.AddTokensFromDel(pool, sdk.NewDecWithoutFra(10).RawInt())
+	require.Equal(t, sdk.NewDecWithoutFra(10), issuedShares)
 	keeper.SetPool(ctx, pool)
 	validator2 = TestingUpdateValidator(keeper, ctx, validator2)
 	require.Equal(t, sdk.Bonded, validator2.Status)
@@ -771,7 +771,7 @@ func TestRedelegateFromUnbondedValidator(t *testing.T) {
 	ctx = ctx.WithBlockTime(time.Unix(333, 0))
 
 	// unbond the all self-delegation to put validator in unbonding state
-	_, err := keeper.BeginUnbonding(ctx, val0AccAddr, addrVals[0], sdk.NewDec(10))
+	_, err := keeper.BeginUnbonding(ctx, val0AccAddr, addrVals[0], sdk.NewDecWithoutFra(10))
 	require.NoError(t, err)
 
 	// end block
@@ -788,7 +788,7 @@ func TestRedelegateFromUnbondedValidator(t *testing.T) {
 	keeper.unbondingToUnbonded(ctx, validator)
 
 	// redelegate some of the delegation's shares
-	_, err = keeper.BeginRedelegation(ctx, addrDels[0], addrVals[0], addrVals[1], sdk.NewDec(6))
+	_, err = keeper.BeginRedelegation(ctx, addrDels[0], addrVals[0], addrVals[1], sdk.NewDecWithoutFra(6))
 	require.NoError(t, err)
 
 	// no red should have been found

--- a/x/stake/keeper/key.go
+++ b/x/stake/keeper/key.go
@@ -79,7 +79,7 @@ func getValidatorPowerRank(validator types.Validator) []byte {
 	potentialPower := validator.Tokens
 
 	// todo: deal with cases above 2**64, ref https://github.com/cosmos/cosmos-sdk/issues/2439#issuecomment-427167556
-	tendermintPower := potentialPower.RoundInt64()
+	tendermintPower := potentialPower.RawInt()
 	tendermintPowerBytes := make([]byte, 8)
 	binary.BigEndian.PutUint64(tendermintPowerBytes[:], uint64(tendermintPower))
 

--- a/x/stake/keeper/key_test.go
+++ b/x/stake/keeper/key_test.go
@@ -26,19 +26,19 @@ func TestGetValidatorPowerRank(t *testing.T) {
 	val1 := types.NewValidator(valAddr1, pk1, emptyDesc)
 	val1.Tokens = sdk.NewDec(0)
 	val2, val3, val4 := val1, val1, val1
-	val2.Tokens = sdk.NewDec(1)
-	val3.Tokens = sdk.NewDec(10)
+	val2.Tokens = sdk.NewDecWithoutFra(1)
+	val3.Tokens = sdk.NewDecWithoutFra(10)
 	x := new(big.Int).Exp(big.NewInt(2), big.NewInt(20), big.NewInt(0))
-	val4.Tokens = sdk.NewDecFromBigInt(x.Int64())
+	val4.Tokens = sdk.NewDecWithoutFra(x.Int64())
 
 	tests := []struct {
 		validator types.Validator
 		wantHex   string
 	}{
 		{val1, "230000000000000000ffffffffffffffffffff"},
-		{val2, "230000000000000001ffffffffffffffffffff"},
-		{val3, "23000000000000000affffffffffffffffffff"},
-		{val4, "230000000000100000ffffffffffffffffffff"},
+		{val2, "230000000005f5e100ffffffffffffffffffff"}, // "5f5e100" is	100000000 in base 10.
+		{val3, "23000000003b9aca00ffffffffffffffffffff"}, // "3b9aca00" is 1000000000 in base 10
+		{val4, "2300005f5e10000000ffffffffffffffffffff"}, // "5f5e10000000" is 2^20.e8 in base 10
 	}
 	for i, tt := range tests {
 		got := hex.EncodeToString(getValidatorPowerRank(tt.validator))

--- a/x/stake/keeper/slash.go
+++ b/x/stake/keeper/slash.go
@@ -165,13 +165,13 @@ func (k Keeper) slashUnbondingDelegation(ctx sdk.Context, unbondingDelegation ty
 	}
 
 	// Calculate slash amount proportional to stake contributing to infraction
-	slashAmount = slashFactor.MulInt(unbondingDelegation.InitialBalance.Amount)
+	slashAmount = slashFactor.Mul(sdk.NewDec(unbondingDelegation.InitialBalance.Amount))
 
 	// Don't slash more tokens than held
 	// Possible since the unbonding delegation may already
 	// have been slashed, and slash amounts are calculated
 	// according to stake held at time of infraction
-	unbondingSlashAmount := sdk.MinInt64(slashAmount.RoundInt(), unbondingDelegation.Balance.Amount)
+	unbondingSlashAmount := sdk.MinInt64(slashAmount.RawInt(), unbondingDelegation.Balance.Amount)
 
 	// Update unbonding delegation if necessary
 	if unbondingSlashAmount != 0 {
@@ -211,13 +211,13 @@ func (k Keeper) slashRedelegation(ctx sdk.Context, validator types.Validator, re
 	}
 
 	// Calculate slash amount proportional to stake contributing to infraction
-	slashAmount = slashFactor.MulInt(redelegation.InitialBalance.Amount)
+	slashAmount = slashFactor.Mul(sdk.NewDec(redelegation.InitialBalance.Amount))
 
 	// Don't slash more tokens than held
 	// Possible since the redelegation may already
 	// have been slashed, and slash amounts are calculated
 	// according to stake held at time of infraction
-	redelegationSlashAmount := sdk.MinInt64(slashAmount.RoundInt(), redelegation.Balance.Amount)
+	redelegationSlashAmount := sdk.MinInt64(slashAmount.RawInt(), redelegation.Balance.Amount)
 
 	// Update redelegation if necessary
 	if redelegationSlashAmount != 0 {

--- a/x/stake/keeper/test_common.go
+++ b/x/stake/keeper/test_common.go
@@ -116,10 +116,10 @@ func CreateTestInput(t *testing.T, isCheckTx bool, initCoins int64) (sdk.Context
 	for _, addr := range Addrs {
 		pool := keeper.GetPool(ctx)
 		_, _, err := ck.AddCoins(ctx, addr, sdk.Coins{
-			{keeper.BondDenom(ctx), initCoins},
+			{keeper.BondDenom(ctx), sdk.NewDecWithoutFra(initCoins).RawInt()},
 		})
 		require.Nil(t, err)
-		pool.LooseTokens = pool.LooseTokens.Add(sdk.NewDec(initCoins))
+		pool.LooseTokens = pool.LooseTokens.Add(sdk.NewDecWithoutFra(initCoins))
 		keeper.SetPool(ctx, pool)
 	}
 

--- a/x/stake/keeper/val_state_change.go
+++ b/x/stake/keeper/val_state_change.go
@@ -50,7 +50,7 @@ func (k Keeper) ApplyAndReturnValidatorSetUpdates(ctx sdk.Context) (updates []ab
 		// if we get to a zero-power validator (which we don't bond),
 		// there are no more possible bonded validators
 		// note: we must check the ABCI power, since we round before sending to Tendermint
-		if validator.Tokens.RoundInt64() == int64(0) {
+		if validator.Tokens.RawInt() == int64(0) {
 			break
 		}
 
@@ -72,7 +72,7 @@ func (k Keeper) ApplyAndReturnValidatorSetUpdates(ctx sdk.Context) (updates []ab
 		oldPowerBytes, found := last[operatorBytes]
 
 		// calculate the new power bytes
-		newPower := validator.BondedTokens().RoundInt64()
+		newPower := validator.BondedTokens().RawInt()
 		newPowerBytes := k.cdc.MustMarshalBinary(newPower)
 		// update the validator set if power has changed
 		if !found || !bytes.Equal(oldPowerBytes, newPowerBytes) {

--- a/x/stake/querier/queryable_test.go
+++ b/x/stake/querier/queryable_test.go
@@ -45,7 +45,7 @@ func TestNewQuerier(t *testing.T) {
 	var validators [2]types.Validator
 	for i, amt := range amts {
 		validators[i] = types.NewValidator(sdk.ValAddress(keep.Addrs[i]), keep.PKs[i], types.Description{})
-		validators[i], pool, _ = validators[i].AddTokensFromDel(pool, amt)
+		validators[i], pool, _ = validators[i].AddTokensFromDel(pool, sdk.NewDecWithoutFra(amt).RawInt())
 		validators[i].BondIntraTxCounter = int16(i)
 		keeper.SetValidator(ctx, validators[i])
 		keeper.SetValidatorByPowerIndex(ctx, validators[i], pool)
@@ -140,7 +140,7 @@ func TestQueryValidators(t *testing.T) {
 	var validators [2]types.Validator
 	for i, amt := range amts {
 		validators[i] = types.NewValidator(sdk.ValAddress(keep.Addrs[i]), keep.PKs[i], types.Description{})
-		validators[i], pool, _ = validators[i].AddTokensFromDel(pool, amt)
+		validators[i], pool, _ = validators[i].AddTokensFromDel(pool, sdk.NewDecWithoutFra(amt).RawInt())
 	}
 	keeper.SetPool(ctx, pool)
 	keeper.SetValidator(ctx, validators[0])
@@ -189,7 +189,7 @@ func TestQueryDelegation(t *testing.T) {
 	pool := keeper.GetPool(ctx)
 	keeper.SetValidatorByPowerIndex(ctx, val1, pool)
 
-	keeper.Delegate(ctx, addrAcc2, sdk.NewCoin("steak", 20), val1, true)
+	keeper.Delegate(ctx, addrAcc2, sdk.NewCoin("steak", sdk.NewDecWithoutFra(20).RawInt()), val1, true)
 
 	// apply TM updates
 	keeper.ApplyAndReturnValidatorSetUpdates(ctx)
@@ -289,7 +289,7 @@ func TestQueryDelegation(t *testing.T) {
 	require.NotNil(t, err)
 
 	// Query unbonging delegation
-	keeper.BeginUnbonding(ctx, addrAcc2, val1.OperatorAddr, sdk.NewDec(10))
+	keeper.BeginUnbonding(ctx, addrAcc2, val1.OperatorAddr, sdk.NewDec(sdk.NewDecWithoutFra(10).RawInt()))
 
 	query = abci.RequestQuery{
 		Path: "/custom/stake/unbondingDelegation",
@@ -346,10 +346,10 @@ func TestQueryRedelegations(t *testing.T) {
 	keeper.SetValidator(ctx, val1)
 	keeper.SetValidator(ctx, val2)
 
-	keeper.Delegate(ctx, addrAcc2, sdk.NewCoin("steak", 100), val1, true)
+	keeper.Delegate(ctx, addrAcc2, sdk.NewCoin("steak", sdk.NewDecWithoutFra(100).RawInt()), val1, true)
 	keeper.ApplyAndReturnValidatorSetUpdates(ctx)
 
-	keeper.BeginRedelegation(ctx, addrAcc2, val1.GetOperator(), val2.GetOperator(), sdk.NewDec(20))
+	keeper.BeginRedelegation(ctx, addrAcc2, val1.GetOperator(), val2.GetOperator(), sdk.NewDec(sdk.NewDecWithoutFra(20).RawInt()))
 	keeper.ApplyAndReturnValidatorSetUpdates(ctx)
 
 	redelegation, found := keeper.GetRedelegation(ctx, addrAcc2, val1.OperatorAddr, val2.OperatorAddr)

--- a/x/stake/test_common.go
+++ b/x/stake/test_common.go
@@ -23,7 +23,7 @@ var (
 
 func NewTestMsgCreateValidator(address sdk.ValAddress, pubKey crypto.PubKey, amt int64) MsgCreateValidator {
 	return types.NewMsgCreateValidator(
-		address, pubKey, sdk.NewCoin("steak", amt), Description{}, commissionMsg,
+		address, pubKey, sdk.NewCoin("steak", sdk.NewDecWithoutFra(amt).RawInt()), Description{}, commissionMsg,
 	)
 }
 
@@ -41,7 +41,7 @@ func NewTestMsgDelegate(delAddr sdk.AccAddress, valAddr sdk.ValAddress, amt int6
 	return MsgDelegate{
 		DelegatorAddr: delAddr,
 		ValidatorAddr: valAddr,
-		Delegation:    sdk.NewCoin("steak", amt),
+		Delegation:    sdk.NewCoin("steak", sdk.NewDecWithoutFra(amt).RawInt()),
 	}
 }
 
@@ -52,6 +52,6 @@ func NewTestMsgCreateValidatorOnBehalfOf(delAddr sdk.AccAddress, valAddr sdk.Val
 		DelegatorAddr: delAddr,
 		ValidatorAddr: valAddr,
 		PubKey:        valPubKey,
-		Delegation:    sdk.NewCoin("steak", amt),
+		Delegation:    sdk.NewCoin("steak", sdk.NewDecWithoutFra(amt).RawInt()),
 	}
 }

--- a/x/stake/types/msg_test.go
+++ b/x/stake/types/msg_test.go
@@ -17,8 +17,8 @@ var (
 
 // test ValidateBasic for MsgCreateValidator
 func TestMsgCreateValidator(t *testing.T) {
-	commission1 := NewCommissionMsg(sdk.NewDec(1), sdk.NewDec(1), sdk.NewDec(1))
-	commission2 := NewCommissionMsg(sdk.NewDec(5), sdk.NewDec(5), sdk.NewDec(5))
+	commission1 := NewCommissionMsg(sdk.NewDecWithoutFra(1), sdk.NewDecWithoutFra(1), sdk.NewDecWithoutFra(1))
+	commission2 := NewCommissionMsg(sdk.NewDecWithoutFra(5), sdk.NewDecWithoutFra(5), sdk.NewDecWithoutFra(5))
 
 	tests := []struct {
 		name, moniker, identity, website, details string
@@ -77,8 +77,8 @@ func TestMsgEditValidator(t *testing.T) {
 
 // test ValidateBasic and GetSigners for MsgCreateValidatorOnBehalfOf
 func TestMsgCreateValidatorOnBehalfOf(t *testing.T) {
-	commission1 := NewCommissionMsg(sdk.NewDec(1), sdk.NewDec(1), sdk.NewDec(1))
-	commission2 := NewCommissionMsg(sdk.NewDec(5), sdk.NewDec(5), sdk.NewDec(5))
+	commission1 := NewCommissionMsg(sdk.NewDecWithoutFra(1), sdk.NewDecWithoutFra(1), sdk.NewDecWithoutFra(1))
+	commission2 := NewCommissionMsg(sdk.NewDecWithoutFra(5), sdk.NewDecWithoutFra(5), sdk.NewDecWithoutFra(5))
 
 	tests := []struct {
 		name, moniker, identity, website, details string

--- a/x/stake/types/pool_test.go
+++ b/x/stake/types/pool_test.go
@@ -11,28 +11,28 @@ func TestPoolEqual(t *testing.T) {
 	p1 := InitialPool()
 	p2 := InitialPool()
 	require.True(t, p1.Equal(p2))
-	p2.BondedTokens = sdk.NewDec(3)
+	p2.BondedTokens = sdk.NewDecWithoutFra(3)
 	require.False(t, p1.Equal(p2))
 }
 
 func TestAddBondedTokens(t *testing.T) {
 	pool := InitialPool()
-	pool.LooseTokens = sdk.NewDec(10)
-	pool.BondedTokens = sdk.NewDec(10)
+	pool.LooseTokens = sdk.NewDecWithoutFra(10)
+	pool.BondedTokens = sdk.NewDecWithoutFra(10)
 
-	pool = pool.looseTokensToBonded(sdk.NewDec(10))
+	pool = pool.looseTokensToBonded(sdk.NewDecWithoutFra(10))
 
-	require.True(sdk.DecEq(t, sdk.NewDec(20), pool.BondedTokens))
-	require.True(sdk.DecEq(t, sdk.NewDec(0), pool.LooseTokens))
+	require.True(sdk.DecEq(t, sdk.NewDecWithoutFra(20), pool.BondedTokens))
+	require.True(sdk.DecEq(t, sdk.NewDecWithoutFra(0), pool.LooseTokens))
 }
 
 func TestRemoveBondedTokens(t *testing.T) {
 	pool := InitialPool()
-	pool.LooseTokens = sdk.NewDec(10)
-	pool.BondedTokens = sdk.NewDec(10)
+	pool.LooseTokens = sdk.NewDecWithoutFra(10)
+	pool.BondedTokens = sdk.NewDecWithoutFra(10)
 
-	pool = pool.bondedTokensToLoose(sdk.NewDec(5))
+	pool = pool.bondedTokensToLoose(sdk.NewDecWithoutFra(5))
 
-	require.True(sdk.DecEq(t, sdk.NewDec(5), pool.BondedTokens))
-	require.True(sdk.DecEq(t, sdk.NewDec(15), pool.LooseTokens))
+	require.True(sdk.DecEq(t, sdk.NewDecWithoutFra(5), pool.BondedTokens))
+	require.True(sdk.DecEq(t, sdk.NewDecWithoutFra(15), pool.LooseTokens))
 }

--- a/x/stake/types/validator.go
+++ b/x/stake/types/validator.go
@@ -310,7 +310,7 @@ func (d Description) EnsureLength() (Description, sdk.Error) {
 func (v Validator) ABCIValidatorUpdate() abci.ValidatorUpdate {
 	return abci.ValidatorUpdate{
 		PubKey: tmtypes.TM2PB.PubKey(v.ConsPubKey),
-		Power:  v.BondedTokens().RoundInt64(),
+		Power:  v.BondedTokens().RawInt(),
 	}
 }
 

--- a/x/stake/types/validator_test.go
+++ b/x/stake/types/validator_test.go
@@ -59,7 +59,7 @@ func TestABCIValidatorUpdate(t *testing.T) {
 
 	abciVal := validator.ABCIValidatorUpdate()
 	require.Equal(t, tmtypes.TM2PB.PubKey(validator.ConsPubKey), abciVal.PubKey)
-	require.Equal(t, validator.BondedTokens().RoundInt64(), abciVal.Power)
+	require.Equal(t, validator.BondedTokens().RawInt(), abciVal.Power)
 }
 
 func TestABCIValidatorUpdateZero(t *testing.T) {
@@ -76,74 +76,74 @@ func TestRemoveTokens(t *testing.T) {
 		OperatorAddr:    addr1,
 		ConsPubKey:      pk1,
 		Status:          sdk.Bonded,
-		Tokens:          sdk.NewDec(100),
-		DelegatorShares: sdk.NewDec(100),
+		Tokens:          sdk.NewDecWithoutFra(100),
+		DelegatorShares: sdk.NewDecWithoutFra(100),
 	}
 
 	pool := InitialPool()
-	pool.LooseTokens = sdk.NewDec(10)
+	pool.LooseTokens = sdk.NewDecWithoutFra(10)
 	pool.BondedTokens = validator.BondedTokens()
 
 	validator, pool = validator.UpdateStatus(pool, sdk.Bonded)
 	require.Equal(t, sdk.Bonded, validator.Status)
 
 	// remove tokens and test check everything
-	validator, pool = validator.RemoveTokens(pool, sdk.NewDec(10))
-	require.Equal(t, int64(90), validator.Tokens.RoundInt64())
-	require.Equal(t, int64(90), pool.BondedTokens.RoundInt64())
-	require.Equal(t, int64(20), pool.LooseTokens.RoundInt64())
+	validator, pool = validator.RemoveTokens(pool, sdk.NewDecWithoutFra(10))
+	require.Equal(t, sdk.NewDecWithoutFra(90), validator.Tokens)
+	require.Equal(t, sdk.NewDecWithoutFra(90), pool.BondedTokens)
+	require.Equal(t, sdk.NewDecWithoutFra(20), pool.LooseTokens)
 
 	// update validator to unbonded and remove some more tokens
 	validator, pool = validator.UpdateStatus(pool, sdk.Unbonded)
 	require.Equal(t, sdk.Unbonded, validator.Status)
-	require.Equal(t, int64(0), pool.BondedTokens.RoundInt64())
-	require.Equal(t, int64(110), pool.LooseTokens.RoundInt64())
+	require.Equal(t, int64(0), pool.BondedTokens.RawInt())
+	require.Equal(t, sdk.NewDecWithoutFra(110), pool.LooseTokens)
 
-	validator, pool = validator.RemoveTokens(pool, sdk.NewDec(10))
-	require.Equal(t, int64(80), validator.Tokens.RoundInt64())
-	require.Equal(t, int64(0), pool.BondedTokens.RoundInt64())
-	require.Equal(t, int64(110), pool.LooseTokens.RoundInt64())
+	validator, pool = validator.RemoveTokens(pool, sdk.NewDecWithoutFra(10))
+	require.Equal(t, sdk.NewDecWithoutFra(80), validator.Tokens)
+	require.Equal(t, int64(0), pool.BondedTokens.RawInt())
+	require.Equal(t, sdk.NewDecWithoutFra(110), pool.LooseTokens)
 }
 
 func TestAddTokensValidatorBonded(t *testing.T) {
 	pool := InitialPool()
-	pool.LooseTokens = sdk.NewDec(10)
+	pool.LooseTokens = sdk.NewDecWithoutFra(10)
 	validator := NewValidator(addr1, pk1, Description{})
 	validator, pool = validator.UpdateStatus(pool, sdk.Bonded)
-	validator, pool, delShares := validator.AddTokensFromDel(pool, 10)
+	validator, pool, delShares := validator.AddTokensFromDel(pool, sdk.NewDecWithoutFra(10).RawInt())
 
 	require.Equal(t, sdk.OneDec(), validator.DelegatorShareExRate())
 
-	assert.True(sdk.DecEq(t, sdk.NewDec(10), delShares))
-	assert.True(sdk.DecEq(t, sdk.NewDec(10), validator.BondedTokens()))
+	assert.True(sdk.DecEq(t, sdk.NewDecWithoutFra(10), delShares))
+	assert.True(sdk.DecEq(t, sdk.NewDecWithoutFra(10), validator.BondedTokens()))
 }
 
 func TestAddTokensValidatorUnbonding(t *testing.T) {
 	pool := InitialPool()
-	pool.LooseTokens = sdk.NewDec(10)
+	pool.LooseTokens = sdk.NewDecWithoutFra(10)
 	validator := NewValidator(addr1, pk1, Description{})
 	validator, pool = validator.UpdateStatus(pool, sdk.Unbonding)
-	validator, pool, delShares := validator.AddTokensFromDel(pool, 10)
+	validator, pool, delShares := validator.AddTokensFromDel(pool, sdk.NewDecWithoutFra(10).RawInt())
 
 	require.Equal(t, sdk.OneDec(), validator.DelegatorShareExRate())
 
-	assert.True(sdk.DecEq(t, sdk.NewDec(10), delShares))
+	assert.True(sdk.DecEq(t, sdk.NewDecWithoutFra(10), delShares))
 	assert.Equal(t, sdk.Unbonding, validator.Status)
-	assert.True(sdk.DecEq(t, sdk.NewDec(10), validator.Tokens))
+	assert.True(sdk.DecEq(t, sdk.NewDecWithoutFra(10), validator.Tokens))
 }
 
 func TestAddTokensValidatorUnbonded(t *testing.T) {
 	pool := InitialPool()
-	pool.LooseTokens = sdk.NewDec(10)
+	pool.LooseTokens = sdk.NewDecWithoutFra(10)
 	validator := NewValidator(addr1, pk1, Description{})
 	validator, pool = validator.UpdateStatus(pool, sdk.Unbonded)
-	validator, pool, delShares := validator.AddTokensFromDel(pool, 10)
+	validator, pool, delShares := validator.AddTokensFromDel(pool, sdk.NewDecWithoutFra(10).RawInt())
 
 	require.Equal(t, sdk.OneDec(), validator.DelegatorShareExRate())
 
-	assert.True(sdk.DecEq(t, sdk.NewDec(10), delShares))
+	assert.True(sdk.DecEq(t, sdk.NewDecWithoutFra(10), delShares))
 	assert.Equal(t, sdk.Unbonded, validator.Status)
-	assert.True(sdk.DecEq(t, sdk.NewDec(10), validator.Tokens))
+	assert.True(sdk.DecEq(t, sdk.NewDecWithoutFra(10), validator.Tokens))
 }
 
 // TODO refactor to make simpler like the AddToken tests above
@@ -152,21 +152,21 @@ func TestRemoveDelShares(t *testing.T) {
 		OperatorAddr:    addr1,
 		ConsPubKey:      pk1,
 		Status:          sdk.Bonded,
-		Tokens:          sdk.NewDec(100),
-		DelegatorShares: sdk.NewDec(100),
+		Tokens:          sdk.NewDecWithoutFra(100),
+		DelegatorShares: sdk.NewDecWithoutFra(100),
 	}
 	poolA := InitialPool()
-	poolA.LooseTokens = sdk.NewDec(10)
+	poolA.LooseTokens = sdk.NewDecWithoutFra(10)
 	poolA.BondedTokens = valA.BondedTokens()
 	require.Equal(t, valA.DelegatorShareExRate(), sdk.OneDec())
 
 	// Remove delegator shares
-	valB, poolB, coinsB := valA.RemoveDelShares(poolA, sdk.NewDec(10))
-	assert.Equal(t, int64(10), coinsB.RoundInt64())
-	assert.Equal(t, int64(90), valB.DelegatorShares.RoundInt64())
-	assert.Equal(t, int64(90), valB.BondedTokens().RoundInt64())
-	assert.Equal(t, int64(90), poolB.BondedTokens.RoundInt64())
-	assert.Equal(t, int64(20), poolB.LooseTokens.RoundInt64())
+	valB, poolB, coinsB := valA.RemoveDelShares(poolA, sdk.NewDecWithoutFra(10))
+	assert.Equal(t, sdk.NewDecWithoutFra(10).RawInt(), coinsB.RawInt())
+	assert.Equal(t, sdk.NewDecWithoutFra(90).RawInt(), valB.DelegatorShares.RawInt())
+	assert.Equal(t, sdk.NewDecWithoutFra(90).RawInt(), valB.BondedTokens().RawInt())
+	assert.Equal(t, sdk.NewDecWithoutFra(90).RawInt(), poolB.BondedTokens.RawInt())
+	assert.Equal(t, sdk.NewDecWithoutFra(20).RawInt(), poolB.LooseTokens.RawInt())
 
 	// conservation of tokens
 	require.True(sdk.DecEq(t,
@@ -174,8 +174,8 @@ func TestRemoveDelShares(t *testing.T) {
 		poolA.LooseTokens.Add(poolA.BondedTokens)))
 
 	// specific case from random tests
-	poolTokens := sdk.NewDec(5102)
-	delShares := sdk.NewDec(115)
+	poolTokens := sdk.NewDecWithoutFra(5102)
+	delShares := sdk.NewDecWithoutFra(115)
 	validator := Validator{
 		OperatorAddr:    addr1,
 		ConsPubKey:      pk1,
@@ -184,13 +184,13 @@ func TestRemoveDelShares(t *testing.T) {
 		DelegatorShares: delShares,
 	}
 	pool := Pool{
-		BondedTokens: sdk.NewDec(248305),
-		LooseTokens:  sdk.NewDec(232147),
+		BondedTokens: sdk.NewDecWithoutFra(248305),
+		LooseTokens:  sdk.NewDecWithoutFra(232147),
 	}
-	shares := sdk.NewDec(29)
+	shares := sdk.NewDecWithoutFra(29)
 	_, newPool, tokens := validator.RemoveDelShares(pool, shares)
 
-	exp, err := sdk.NewDecFromStr("1286.59130431")
+	exp, err := sdk.NewDecFromStr("128659130431")
 	require.NoError(t, err)
 
 	require.True(sdk.DecEq(t, exp, tokens))
@@ -202,31 +202,31 @@ func TestRemoveDelShares(t *testing.T) {
 
 func TestUpdateStatus(t *testing.T) {
 	pool := InitialPool()
-	pool.LooseTokens = sdk.NewDec(100)
+	pool.LooseTokens = sdk.NewDecWithoutFra(100)
 
 	validator := NewValidator(addr1, pk1, Description{})
-	validator, pool, _ = validator.AddTokensFromDel(pool, 100)
+	validator, pool, _ = validator.AddTokensFromDel(pool, sdk.NewDecWithoutFra(100).RawInt())
 	require.Equal(t, sdk.Unbonded, validator.Status)
-	require.Equal(t, int64(100), validator.Tokens.RoundInt64())
-	require.Equal(t, int64(0), pool.BondedTokens.RoundInt64())
-	require.Equal(t, int64(100), pool.LooseTokens.RoundInt64())
+	require.Equal(t, sdk.NewDecWithoutFra(100), validator.Tokens)
+	require.Equal(t, int64(0), pool.BondedTokens.RawInt())
+	require.Equal(t, sdk.NewDecWithoutFra(100), pool.LooseTokens)
 
 	validator, pool = validator.UpdateStatus(pool, sdk.Bonded)
 	require.Equal(t, sdk.Bonded, validator.Status)
-	require.Equal(t, int64(100), validator.Tokens.RoundInt64())
-	require.Equal(t, int64(100), pool.BondedTokens.RoundInt64())
-	require.Equal(t, int64(0), pool.LooseTokens.RoundInt64())
+	require.Equal(t, sdk.NewDecWithoutFra(100), validator.Tokens)
+	require.Equal(t, sdk.NewDecWithoutFra(100), pool.BondedTokens)
+	require.Equal(t, int64(0), pool.LooseTokens.RawInt())
 
 	validator, pool = validator.UpdateStatus(pool, sdk.Unbonding)
 	require.Equal(t, sdk.Unbonding, validator.Status)
-	require.Equal(t, int64(100), validator.Tokens.RoundInt64())
-	require.Equal(t, int64(0), pool.BondedTokens.RoundInt64())
-	require.Equal(t, int64(100), pool.LooseTokens.RoundInt64())
+	require.Equal(t, sdk.NewDecWithoutFra(100), validator.Tokens)
+	require.Equal(t, int64(0), pool.BondedTokens.RawInt())
+	require.Equal(t, sdk.NewDecWithoutFra(100), pool.LooseTokens)
 }
 
 func TestPossibleOverflow(t *testing.T) {
-	poolTokens := sdk.NewDec(2159)
-	delShares := sdk.NewDec(39143257068).Quo(sdk.NewDec(4011301))
+	poolTokens := sdk.NewDecWithoutFra(2159)
+	delShares := sdk.NewDecWithoutFra(39143257068).Quo(sdk.NewDecWithoutFra(4011301))
 	validator := Validator{
 		OperatorAddr:    addr1,
 		ConsPubKey:      pk1,
@@ -235,12 +235,12 @@ func TestPossibleOverflow(t *testing.T) {
 		DelegatorShares: delShares,
 	}
 	pool := Pool{
-		LooseTokens:  sdk.NewDec(100),
+		LooseTokens:  sdk.NewDecWithoutFra(100),
 		BondedTokens: poolTokens,
 	}
 	tokens := int64(71)
 	msg := fmt.Sprintf("validator %#v", validator)
-	newValidator, _, _ := validator.AddTokensFromDel(pool, tokens)
+	newValidator, _, _ := validator.AddTokensFromDel(pool, sdk.NewDecWithoutFra(tokens).RawInt())
 
 	msg = fmt.Sprintf("Added %d tokens to %s", tokens, msg)
 	require.False(t, newValidator.DelegatorShareExRate().LT(sdk.ZeroDec()),
@@ -279,7 +279,7 @@ func TestValidatorSetInitialCommission(t *testing.T) {
 	}{
 		{val, NewCommission(sdk.ZeroDec(), sdk.ZeroDec(), sdk.ZeroDec()), false},
 		{val, NewCommission(sdk.ZeroDec(), sdk.NewDecWithPrec(-1, 1), sdk.ZeroDec()), true},
-		{val, NewCommission(sdk.ZeroDec(), sdk.NewDec(15000000000), sdk.ZeroDec()), true},
+		{val, NewCommission(sdk.ZeroDec(), sdk.NewDecWithoutFra(15000000000), sdk.ZeroDec()), true},
 		{val, NewCommission(sdk.NewDecWithPrec(-1, 1), sdk.ZeroDec(), sdk.ZeroDec()), true},
 		{val, NewCommission(sdk.NewDecWithPrec(2, 1), sdk.NewDecWithPrec(1, 1), sdk.ZeroDec()), true},
 		{val, NewCommission(sdk.ZeroDec(), sdk.ZeroDec(), sdk.NewDecWithPrec(-1, 1)), true},


### PR DESCRIPTION
Description
We use fix8 to represent decimal in ABCI application.
While cosmos just use int64 and treat is as int, we should change the logical.

And for interface for abci application, cosmos get fix8 input, so we should change the construct method of decimal.

Example
no

Preflight checks
build passed (make build)
tests passed (make test)