### PR TITLE
[R4R] Change gov test package 

### DIFF
--- a/x/gov/endblocker_test.go
+++ b/x/gov/endblocker_test.go
@@ -1,4 +1,4 @@
-package gov
+package gov_test
 
 import (
 	"testing"
@@ -8,11 +8,12 @@ import (
 	abci "github.com/tendermint/tendermint/abci/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/gov"
 	"github.com/cosmos/cosmos-sdk/x/stake"
 )
 
 func TestTickExpiredDepositPeriod(t *testing.T) {
-	mapp, keeper, stakeKeeper, addrs, pubKeys, _ := getMockApp(t, 10)
+	mapp, ck, keeper, stakeKeeper, addrs, pubKeys, _ := getMockApp(t, 10)
 
 	validator := stake.NewValidator(sdk.ValAddress(addrs[0]), pubKeys[0], stake.Description{})
 	mapp.BeginBlock(abci.RequestBeginBlock{})
@@ -22,46 +23,46 @@ func TestTickExpiredDepositPeriod(t *testing.T) {
 	stakeKeeper.SetValidator(ctx, validator)
 	stakeKeeper.SetValidatorByConsAddr(ctx, validator)
 
-	govHandler := NewHandler(keeper)
+	govHandler := gov.NewHandler(keeper)
 
 	require.Nil(t, keeper.InactiveProposalQueuePeek(ctx))
-	require.False(t, shouldPopInactiveProposalQueue(ctx, keeper))
+	require.False(t, gov.ShouldPopInactiveProposalQueue(ctx, keeper))
 
-	newProposalMsg := NewMsgSubmitProposal("Test", "test", ProposalTypeText, addrs[1], sdk.Coins{sdk.NewCoin(DefaultDepositDenom, 1000e8)})
+	newProposalMsg := gov.NewMsgSubmitProposal("Test", "test", gov.ProposalTypeText, addrs[1], sdk.Coins{sdk.NewCoin(gov.DefaultDepositDenom, 1000e8)})
 
 	res := govHandler(ctx, newProposalMsg)
 	require.True(t, res.IsOK())
 
-	EndBlocker(ctx, keeper)
+	gov.EndBlocker(ctx, keeper)
 	require.NotNil(t, keeper.InactiveProposalQueuePeek(ctx))
-	require.False(t, shouldPopInactiveProposalQueue(ctx, keeper))
+	require.False(t, gov.ShouldPopInactiveProposalQueue(ctx, keeper))
 
 	newHeader := ctx.BlockHeader()
 	newHeader.Time = ctx.BlockHeader().Time.Add(time.Duration(1) * time.Second)
 	ctx = ctx.WithBlockHeader(newHeader)
 
-	EndBlocker(ctx, keeper)
+	gov.EndBlocker(ctx, keeper)
 	require.NotNil(t, keeper.InactiveProposalQueuePeek(ctx))
-	require.False(t, shouldPopInactiveProposalQueue(ctx, keeper))
+	require.False(t, gov.ShouldPopInactiveProposalQueue(ctx, keeper))
 
 	newHeader = ctx.BlockHeader()
 	newHeader.Time = ctx.BlockHeader().Time.Add(keeper.GetDepositProcedure(ctx).MaxDepositPeriod)
 	ctx = ctx.WithBlockHeader(newHeader)
 
 	require.NotNil(t, keeper.InactiveProposalQueuePeek(ctx))
-	require.True(t, shouldPopInactiveProposalQueue(ctx, keeper))
-	EndBlocker(ctx, keeper)
+	require.True(t, gov.ShouldPopInactiveProposalQueue(ctx, keeper))
+	gov.EndBlocker(ctx, keeper)
 
-	validatorCoins := keeper.ck.GetCoins(ctx, addrs[0])
+	validatorCoins := ck.GetCoins(ctx, addrs[0])
 	// check distribute deposits to proposer
-	require.Equal(t, validatorCoins, sdk.Coins{sdk.NewCoin(DefaultDepositDenom, 6000e8)})
+	require.Equal(t, validatorCoins, sdk.Coins{sdk.NewCoin(gov.DefaultDepositDenom, 6000e8)})
 
 	require.Nil(t, keeper.InactiveProposalQueuePeek(ctx))
-	require.False(t, shouldPopInactiveProposalQueue(ctx, keeper))
+	require.False(t, gov.ShouldPopInactiveProposalQueue(ctx, keeper))
 }
 
 func TestTickMultipleExpiredDepositPeriod(t *testing.T) {
-	mapp, keeper, stakeKeeper, addrs, pubKeys, _ := getMockApp(t, 10)
+	mapp, _, keeper, stakeKeeper, addrs, pubKeys, _ := getMockApp(t, 10)
 
 	validator := stake.NewValidator(sdk.ValAddress(addrs[0]), pubKeys[0], stake.Description{})
 	mapp.BeginBlock(abci.RequestBeginBlock{})
@@ -71,29 +72,29 @@ func TestTickMultipleExpiredDepositPeriod(t *testing.T) {
 	stakeKeeper.SetValidator(ctx, validator)
 	stakeKeeper.SetValidatorByConsAddr(ctx, validator)
 
-	govHandler := NewHandler(keeper)
+	govHandler := gov.NewHandler(keeper)
 
 	require.Nil(t, keeper.InactiveProposalQueuePeek(ctx))
-	require.False(t, shouldPopInactiveProposalQueue(ctx, keeper))
+	require.False(t, gov.ShouldPopInactiveProposalQueue(ctx, keeper))
 
-	newProposalMsg := NewMsgSubmitProposal("Test", "test", ProposalTypeText, addrs[0], sdk.Coins{sdk.NewCoin(DefaultDepositDenom, 1000e8)})
+	newProposalMsg := gov.NewMsgSubmitProposal("Test", "test", gov.ProposalTypeText, addrs[0], sdk.Coins{sdk.NewCoin(gov.DefaultDepositDenom, 1000e8)})
 
 	res := govHandler(ctx, newProposalMsg)
 	require.True(t, res.IsOK())
 
-	EndBlocker(ctx, keeper)
+	gov.EndBlocker(ctx, keeper)
 	require.NotNil(t, keeper.InactiveProposalQueuePeek(ctx))
-	require.False(t, shouldPopInactiveProposalQueue(ctx, keeper))
+	require.False(t, gov.ShouldPopInactiveProposalQueue(ctx, keeper))
 
 	newHeader := ctx.BlockHeader()
 	newHeader.Time = ctx.BlockHeader().Time.Add(time.Duration(2) * time.Second)
 	ctx = ctx.WithBlockHeader(newHeader)
 
-	EndBlocker(ctx, keeper)
+	gov.EndBlocker(ctx, keeper)
 	require.NotNil(t, keeper.InactiveProposalQueuePeek(ctx))
-	require.False(t, shouldPopInactiveProposalQueue(ctx, keeper))
+	require.False(t, gov.ShouldPopInactiveProposalQueue(ctx, keeper))
 
-	newProposalMsg2 := NewMsgSubmitProposal("Test2", "test2", ProposalTypeText, addrs[1], sdk.Coins{sdk.NewCoin(DefaultDepositDenom, 5)})
+	newProposalMsg2 := gov.NewMsgSubmitProposal("Test2", "test2", gov.ProposalTypeText, addrs[1], sdk.Coins{sdk.NewCoin(gov.DefaultDepositDenom, 5)})
 	res = govHandler(ctx, newProposalMsg2)
 	require.True(t, res.IsOK())
 
@@ -102,71 +103,71 @@ func TestTickMultipleExpiredDepositPeriod(t *testing.T) {
 	ctx = ctx.WithBlockHeader(newHeader)
 
 	require.NotNil(t, keeper.InactiveProposalQueuePeek(ctx))
-	require.True(t, shouldPopInactiveProposalQueue(ctx, keeper))
-	EndBlocker(ctx, keeper)
+	require.True(t, gov.ShouldPopInactiveProposalQueue(ctx, keeper))
+	gov.EndBlocker(ctx, keeper)
 	require.NotNil(t, keeper.InactiveProposalQueuePeek(ctx))
-	require.False(t, shouldPopInactiveProposalQueue(ctx, keeper))
+	require.False(t, gov.ShouldPopInactiveProposalQueue(ctx, keeper))
 
 	newHeader = ctx.BlockHeader()
 	newHeader.Time = ctx.BlockHeader().Time.Add(time.Duration(5) * time.Second)
 	ctx = ctx.WithBlockHeader(newHeader)
 
 	require.NotNil(t, keeper.InactiveProposalQueuePeek(ctx))
-	require.True(t, shouldPopInactiveProposalQueue(ctx, keeper))
-	EndBlocker(ctx, keeper)
+	require.True(t, gov.ShouldPopInactiveProposalQueue(ctx, keeper))
+	gov.EndBlocker(ctx, keeper)
 	require.Nil(t, keeper.InactiveProposalQueuePeek(ctx))
-	require.False(t, shouldPopInactiveProposalQueue(ctx, keeper))
+	require.False(t, gov.ShouldPopInactiveProposalQueue(ctx, keeper))
 }
 
 func TestTickPassedDepositPeriod(t *testing.T) {
-	mapp, keeper, _, addrs, _, _ := getMockApp(t, 10)
+	mapp, _, keeper, _, addrs, _, _ := getMockApp(t, 10)
 	mapp.BeginBlock(abci.RequestBeginBlock{})
 	ctx := mapp.BaseApp.NewContext(sdk.RunTxModeDeliver, abci.Header{})
-	govHandler := NewHandler(keeper)
+	govHandler := gov.NewHandler(keeper)
 
 	require.Nil(t, keeper.InactiveProposalQueuePeek(ctx))
-	require.False(t, shouldPopInactiveProposalQueue(ctx, keeper))
+	require.False(t, gov.ShouldPopInactiveProposalQueue(ctx, keeper))
 	require.Nil(t, keeper.ActiveProposalQueuePeek(ctx))
-	require.False(t, shouldPopActiveProposalQueue(ctx, keeper))
+	require.False(t, gov.ShouldPopActiveProposalQueue(ctx, keeper))
 
-	newProposalMsg := NewMsgSubmitProposal("Test", "test", ProposalTypeText, addrs[0], sdk.Coins{sdk.NewCoin(DefaultDepositDenom, 1000e8)})
+	newProposalMsg := gov.NewMsgSubmitProposal("Test", "test", gov.ProposalTypeText, addrs[0], sdk.Coins{sdk.NewCoin(gov.DefaultDepositDenom, 1000e8)})
 
 	res := govHandler(ctx, newProposalMsg)
 	require.True(t, res.IsOK())
 	var proposalID int64
-	keeper.cdc.UnmarshalBinaryBare(res.Data, &proposalID)
+	mapp.Cdc.UnmarshalBinaryBare(res.Data, &proposalID)
 
-	EndBlocker(ctx, keeper)
+	gov.EndBlocker(ctx, keeper)
 	require.NotNil(t, keeper.InactiveProposalQueuePeek(ctx))
-	require.False(t, shouldPopInactiveProposalQueue(ctx, keeper))
+	require.False(t, gov.ShouldPopInactiveProposalQueue(ctx, keeper))
 
 	newHeader := ctx.BlockHeader()
 	newHeader.Time = ctx.BlockHeader().Time.Add(time.Duration(1) * time.Second)
 	ctx = ctx.WithBlockHeader(newHeader)
 
-	EndBlocker(ctx, keeper)
+	gov.EndBlocker(ctx, keeper)
 	require.NotNil(t, keeper.InactiveProposalQueuePeek(ctx))
-	require.False(t, shouldPopInactiveProposalQueue(ctx, keeper))
+	require.False(t, gov.ShouldPopInactiveProposalQueue(ctx, keeper))
 
-	newDepositMsg := NewMsgDeposit(addrs[1], proposalID, sdk.Coins{sdk.NewCoin(DefaultDepositDenom, 1000e8)})
+	newDepositMsg := gov.NewMsgDeposit(addrs[1], proposalID, sdk.Coins{sdk.NewCoin(gov.DefaultDepositDenom, 1000e8)})
 	res = govHandler(ctx, newDepositMsg)
 	require.True(t, res.IsOK())
 
 	require.NotNil(t, keeper.InactiveProposalQueuePeek(ctx))
-	require.True(t, shouldPopInactiveProposalQueue(ctx, keeper))
+	require.True(t, gov.ShouldPopInactiveProposalQueue(ctx, keeper))
 	require.NotNil(t, keeper.ActiveProposalQueuePeek(ctx))
 
-	EndBlocker(ctx, keeper)
+	gov.EndBlocker(ctx, keeper)
 
 	require.Nil(t, keeper.InactiveProposalQueuePeek(ctx))
-	require.False(t, shouldPopInactiveProposalQueue(ctx, keeper))
+	require.False(t, gov.ShouldPopInactiveProposalQueue(ctx, keeper))
 	require.NotNil(t, keeper.ActiveProposalQueuePeek(ctx))
-	require.False(t, shouldPopActiveProposalQueue(ctx, keeper))
+	require.False(t, gov.ShouldPopActiveProposalQueue(ctx, keeper))
 
 }
 
 func TestTickPassedVotingPeriodRejected(t *testing.T) {
-	mapp, keeper, stakeKeeper, addrs, pubKeys, _ := getMockApp(t, 10)
+	mapp, ck, keeper, stakeKeeper, addrs, pubKeys, _ := getMockApp(t, 10)
 
 	validator := stake.NewValidator(sdk.ValAddress(addrs[0]), pubKeys[0], stake.Description{})
 	mapp.BeginBlock(abci.RequestBeginBlock{})
@@ -176,56 +177,56 @@ func TestTickPassedVotingPeriodRejected(t *testing.T) {
 	stakeKeeper.SetValidator(ctx, validator)
 	stakeKeeper.SetValidatorByConsAddr(ctx, validator)
 
-	govHandler := NewHandler(keeper)
+	govHandler := gov.NewHandler(keeper)
 
 	require.Nil(t, keeper.InactiveProposalQueuePeek(ctx))
-	require.False(t, shouldPopInactiveProposalQueue(ctx, keeper))
+	require.False(t, gov.ShouldPopInactiveProposalQueue(ctx, keeper))
 	require.Nil(t, keeper.ActiveProposalQueuePeek(ctx))
-	require.False(t, shouldPopActiveProposalQueue(ctx, keeper))
+	require.False(t, gov.ShouldPopActiveProposalQueue(ctx, keeper))
 
-	newProposalMsg := NewMsgSubmitProposal("Test", "test", ProposalTypeText, addrs[0], sdk.Coins{sdk.NewCoin(DefaultDepositDenom, 1000e8)})
+	newProposalMsg := gov.NewMsgSubmitProposal("Test", "test", gov.ProposalTypeText, addrs[0], sdk.Coins{sdk.NewCoin(gov.DefaultDepositDenom, 1000e8)})
 
 	res := govHandler(ctx, newProposalMsg)
 	require.True(t, res.IsOK())
 	var proposalID int64
-	keeper.cdc.UnmarshalBinaryBare(res.Data, &proposalID)
+	mapp.Cdc.UnmarshalBinaryBare(res.Data, &proposalID)
 
 	newHeader := ctx.BlockHeader()
 	newHeader.Time = ctx.BlockHeader().Time.Add(time.Duration(1) * time.Second)
 	ctx = ctx.WithBlockHeader(newHeader)
 
-	newDepositMsg := NewMsgDeposit(addrs[1], proposalID, sdk.Coins{sdk.NewCoin(DefaultDepositDenom, 1000e8)})
+	newDepositMsg := gov.NewMsgDeposit(addrs[1], proposalID, sdk.Coins{sdk.NewCoin(gov.DefaultDepositDenom, 1000e8)})
 	res = govHandler(ctx, newDepositMsg)
 	require.True(t, res.IsOK())
-	EndBlocker(ctx, keeper)
+	gov.EndBlocker(ctx, keeper)
 
 	// pass voting period
 	newHeader = ctx.BlockHeader()
 	newHeader.Time = ctx.BlockHeader().Time.Add(keeper.GetVotingProcedure(ctx).VotingPeriod)
 	ctx = ctx.WithBlockHeader(newHeader)
 
-	require.True(t, shouldPopActiveProposalQueue(ctx, keeper))
+	require.True(t, gov.ShouldPopActiveProposalQueue(ctx, keeper))
 	depositsIterator := keeper.GetDeposits(ctx, proposalID)
 	require.True(t, depositsIterator.Valid())
 	depositsIterator.Close()
-	require.Equal(t, StatusVotingPeriod, keeper.GetProposal(ctx, proposalID).GetStatus())
+	require.Equal(t, gov.StatusVotingPeriod, keeper.GetProposal(ctx, proposalID).GetStatus())
 
-	EndBlocker(ctx, keeper)
+	gov.EndBlocker(ctx, keeper)
 
 	require.Nil(t, keeper.ActiveProposalQueuePeek(ctx))
 	depositsIterator = keeper.GetDeposits(ctx, proposalID)
 	require.False(t, depositsIterator.Valid())
 	depositsIterator.Close()
-	require.Equal(t, StatusRejected, keeper.GetProposal(ctx, proposalID).GetStatus())
-	require.True(t, keeper.GetProposal(ctx, proposalID).GetTallyResult().Equals(EmptyTallyResult()))
+	require.Equal(t, gov.StatusRejected, keeper.GetProposal(ctx, proposalID).GetStatus())
+	require.True(t, keeper.GetProposal(ctx, proposalID).GetTallyResult().Equals(gov.EmptyTallyResult()))
 
 	// check distribute deposits to proposer
-	validatorCoins := keeper.ck.GetCoins(ctx, addrs[0])
-	require.Equal(t, validatorCoins, sdk.Coins{sdk.NewCoin(DefaultDepositDenom, 6000e8)})
+	validatorCoins := ck.GetCoins(ctx, addrs[0])
+	require.Equal(t, validatorCoins, sdk.Coins{sdk.NewCoin(gov.DefaultDepositDenom, 6000e8)})
 }
 
 func TestTickPassedVotingPeriodPassed(t *testing.T) {
-	mapp, keeper, stakeKeeper, addrs, pubKeys, _ := getMockApp(t, 3)
+	mapp, ck, keeper, stakeKeeper, addrs, pubKeys, _ := getMockApp(t, 3)
 
 	validator0 := stake.NewValidator(sdk.ValAddress(addrs[0]), pubKeys[0], stake.Description{})
 	mapp.BeginBlock(abci.RequestBeginBlock{})
@@ -234,63 +235,63 @@ func TestTickPassedVotingPeriodPassed(t *testing.T) {
 	// create and delegate validator
 	stakeKeeper.SetValidator(ctx, validator0)
 	stakeKeeper.SetValidatorByConsAddr(ctx, validator0)
-	stakeKeeper.Delegate(ctx, sdk.AccAddress(addrs[2]), sdk.NewCoin(DefaultDepositDenom, 1000), validator0, true)
+	stakeKeeper.Delegate(ctx, sdk.AccAddress(addrs[2]), sdk.NewCoin(gov.DefaultDepositDenom, 1000), validator0, true)
 
 	stakeKeeper.ApplyAndReturnValidatorSetUpdates(ctx)
 	validator0, _ = stakeKeeper.GetValidator(ctx, validator0.OperatorAddr)
 
-	govHandler := NewHandler(keeper)
+	govHandler := gov.NewHandler(keeper)
 
 	require.Nil(t, keeper.InactiveProposalQueuePeek(ctx))
-	require.False(t, shouldPopInactiveProposalQueue(ctx, keeper))
+	require.False(t, gov.ShouldPopInactiveProposalQueue(ctx, keeper))
 	require.Nil(t, keeper.ActiveProposalQueuePeek(ctx))
-	require.False(t, shouldPopActiveProposalQueue(ctx, keeper))
+	require.False(t, gov.ShouldPopActiveProposalQueue(ctx, keeper))
 
-	newProposalMsg := NewMsgSubmitProposal("Test", "test", ProposalTypeText, addrs[0], sdk.Coins{sdk.NewCoin(DefaultDepositDenom, 1000e8)})
+	newProposalMsg := gov.NewMsgSubmitProposal("Test", "test", gov.ProposalTypeText, addrs[0], sdk.Coins{sdk.NewCoin(gov.DefaultDepositDenom, 1000e8)})
 
 	res := govHandler(ctx, newProposalMsg)
 	require.True(t, res.IsOK())
 	var proposalID int64
-	keeper.cdc.UnmarshalBinaryBare(res.Data, &proposalID)
+	mapp.Cdc.UnmarshalBinaryBare(res.Data, &proposalID)
 
 	newHeader := ctx.BlockHeader()
 	newHeader.Time = ctx.BlockHeader().Time.Add(time.Duration(1) * time.Second)
 	ctx = ctx.WithBlockHeader(newHeader)
 
-	newDepositMsg := NewMsgDeposit(addrs[1], proposalID, sdk.Coins{sdk.NewCoin(DefaultDepositDenom, 1000e8)})
+	newDepositMsg := gov.NewMsgDeposit(addrs[1], proposalID, sdk.Coins{sdk.NewCoin(gov.DefaultDepositDenom, 1000e8)})
 	res = govHandler(ctx, newDepositMsg)
 	require.True(t, res.IsOK())
-	EndBlocker(ctx, keeper)
+	gov.EndBlocker(ctx, keeper)
 
 	newHeader = ctx.BlockHeader()
 	newHeader.Time = ctx.BlockHeader().Time.Add(time.Duration(1) * time.Second)
 	ctx = ctx.WithBlockHeader(newHeader)
-	newVoteMsg := NewMsgVote(addrs[0], proposalID, OptionYes)
+	newVoteMsg := gov.NewMsgVote(addrs[0], proposalID, gov.OptionYes)
 	res = govHandler(ctx, newVoteMsg)
 	println(res.Log)
 	require.True(t, res.IsOK())
-	EndBlocker(ctx, keeper)
+	gov.EndBlocker(ctx, keeper)
 
 	// pass voting period
 	newHeader = ctx.BlockHeader()
 	newHeader.Time = ctx.BlockHeader().Time.Add(keeper.GetVotingProcedure(ctx).VotingPeriod)
 	ctx = ctx.WithBlockHeader(newHeader)
 
-	require.True(t, shouldPopActiveProposalQueue(ctx, keeper))
+	require.True(t, gov.ShouldPopActiveProposalQueue(ctx, keeper))
 	depositsIterator := keeper.GetDeposits(ctx, proposalID)
 	require.True(t, depositsIterator.Valid())
 	depositsIterator.Close()
-	require.Equal(t, StatusVotingPeriod, keeper.GetProposal(ctx, proposalID).GetStatus())
+	require.Equal(t, gov.StatusVotingPeriod, keeper.GetProposal(ctx, proposalID).GetStatus())
 
-	EndBlocker(ctx, keeper)
+	gov.EndBlocker(ctx, keeper)
 
 	require.Nil(t, keeper.ActiveProposalQueuePeek(ctx))
 	depositsIterator = keeper.GetDeposits(ctx, proposalID)
 	require.False(t, depositsIterator.Valid())
 	depositsIterator.Close()
-	require.Equal(t, StatusPassed, keeper.GetProposal(ctx, proposalID).GetStatus())
+	require.Equal(t, gov.StatusPassed, keeper.GetProposal(ctx, proposalID).GetStatus())
 
 	// check refund deposits
-	validatorCoins := keeper.ck.GetCoins(ctx, addrs[0])
-	require.Equal(t, validatorCoins, sdk.Coins{sdk.NewCoin(DefaultDepositDenom, 5000e8)})
+	validatorCoins := ck.GetCoins(ctx, addrs[0])
+	require.Equal(t, validatorCoins, sdk.Coins{sdk.NewCoin(gov.DefaultDepositDenom, 5000e8)})
 }

--- a/x/gov/handler.go
+++ b/x/gov/handler.go
@@ -115,7 +115,7 @@ func EndBlocker(ctx sdk.Context, keeper Keeper) (resTags sdk.Tags) {
 	resTags = sdk.NewTags()
 
 	// Delete proposals that haven't met minDeposit
-	for shouldPopInactiveProposalQueue(ctx, keeper) {
+	for ShouldPopInactiveProposalQueue(ctx, keeper) {
 		inactiveProposal := keeper.InactiveProposalQueuePop(ctx)
 		if inactiveProposal.GetStatus() != StatusDepositPeriod {
 			continue
@@ -141,7 +141,7 @@ func EndBlocker(ctx sdk.Context, keeper Keeper) (resTags sdk.Tags) {
 	}
 
 	// Check if earliest Active Proposal ended voting period yet
-	for shouldPopActiveProposalQueue(ctx, keeper) {
+	for ShouldPopActiveProposalQueue(ctx, keeper) {
 		activeProposal := keeper.ActiveProposalQueuePop(ctx)
 
 		proposalStartTime := activeProposal.GetVotingStartTime()
@@ -150,7 +150,7 @@ func EndBlocker(ctx sdk.Context, keeper Keeper) (resTags sdk.Tags) {
 			continue
 		}
 
-		passes, tallyResults := tally(ctx, keeper, activeProposal)
+		passes, tallyResults := Tally(ctx, keeper, activeProposal)
 		proposalIDBytes := keeper.cdc.MustMarshalBinaryBare(activeProposal.GetProposalID())
 		var action []byte
 		if passes {
@@ -179,7 +179,7 @@ func EndBlocker(ctx sdk.Context, keeper Keeper) (resTags sdk.Tags) {
 
 	return resTags
 }
-func shouldPopInactiveProposalQueue(ctx sdk.Context, keeper Keeper) bool {
+func ShouldPopInactiveProposalQueue(ctx sdk.Context, keeper Keeper) bool {
 	depositProcedure := keeper.GetDepositProcedure(ctx)
 	peekProposal := keeper.InactiveProposalQueuePeek(ctx)
 
@@ -193,7 +193,7 @@ func shouldPopInactiveProposalQueue(ctx sdk.Context, keeper Keeper) bool {
 	return false
 }
 
-func shouldPopActiveProposalQueue(ctx sdk.Context, keeper Keeper) bool {
+func ShouldPopActiveProposalQueue(ctx sdk.Context, keeper Keeper) bool {
 	votingProcedure := keeper.GetVotingProcedure(ctx)
 	peekProposal := keeper.ActiveProposalQueuePeek(ctx)
 

--- a/x/gov/keeper.go
+++ b/x/gov/keeper.go
@@ -216,7 +216,7 @@ func (keeper Keeper) peekCurrentProposalID(ctx sdk.Context) (proposalID int64, e
 	return proposalID, nil
 }
 
-func (keeper Keeper) activateVotingPeriod(ctx sdk.Context, proposal Proposal) {
+func (keeper Keeper) ActivateVotingPeriod(ctx sdk.Context, proposal Proposal) {
 	proposal.SetVotingStartTime(ctx.BlockHeader().Time)
 	proposal.SetStatus(StatusVotingPeriod)
 	keeper.SetProposal(ctx, proposal)
@@ -370,7 +370,7 @@ func (keeper Keeper) AddDeposit(ctx sdk.Context, proposalID int64, depositerAddr
 	// Active voting period if so
 	activatedVotingPeriod := false
 	if proposal.GetStatus() == StatusDepositPeriod && proposal.GetTotalDeposit().IsGTE(keeper.GetDepositProcedure(ctx).MinDeposit) {
-		keeper.activateVotingPeriod(ctx, proposal)
+		keeper.ActivateVotingPeriod(ctx, proposal)
 		activatedVotingPeriod = true
 	}
 

--- a/x/gov/keeper_test.go
+++ b/x/gov/keeper_test.go
@@ -1,75 +1,76 @@
-package gov
+package gov_test
 
 import (
 	"testing"
 	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/gov"
 	"github.com/stretchr/testify/require"
 	abci "github.com/tendermint/tendermint/abci/types"
 )
 
 func TestGetSetProposal(t *testing.T) {
-	mapp, keeper, _, _, _, _ := getMockApp(t, 0)
+	mapp, _, keeper, _, _, _, _ := getMockApp(t, 0)
 	mapp.BeginBlock(abci.RequestBeginBlock{})
 	ctx := mapp.BaseApp.NewContext(sdk.RunTxModeDeliver, abci.Header{})
 
-	proposal := keeper.NewTextProposal(ctx, "Test", "description", ProposalTypeText)
+	proposal := keeper.NewTextProposal(ctx, "Test", "description", gov.ProposalTypeText)
 	proposalID := proposal.GetProposalID()
 	keeper.SetProposal(ctx, proposal)
 
 	gotProposal := keeper.GetProposal(ctx, proposalID)
-	require.True(t, ProposalEqual(proposal, gotProposal))
+	require.True(t, gov.ProposalEqual(proposal, gotProposal))
 }
 
 func TestIncrementProposalNumber(t *testing.T) {
-	mapp, keeper, _, _, _, _ := getMockApp(t, 0)
+	mapp, _, keeper, _, _, _, _ := getMockApp(t, 0)
 	mapp.BeginBlock(abci.RequestBeginBlock{})
 	ctx := mapp.BaseApp.NewContext(sdk.RunTxModeDeliver, abci.Header{})
 
-	keeper.NewTextProposal(ctx, "Test", "description", ProposalTypeText)
-	keeper.NewTextProposal(ctx, "Test", "description", ProposalTypeText)
-	keeper.NewTextProposal(ctx, "Test", "description", ProposalTypeText)
-	keeper.NewTextProposal(ctx, "Test", "description", ProposalTypeText)
-	keeper.NewTextProposal(ctx, "Test", "description", ProposalTypeText)
-	proposal6 := keeper.NewTextProposal(ctx, "Test", "description", ProposalTypeText)
+	keeper.NewTextProposal(ctx, "Test", "description", gov.ProposalTypeText)
+	keeper.NewTextProposal(ctx, "Test", "description", gov.ProposalTypeText)
+	keeper.NewTextProposal(ctx, "Test", "description", gov.ProposalTypeText)
+	keeper.NewTextProposal(ctx, "Test", "description", gov.ProposalTypeText)
+	keeper.NewTextProposal(ctx, "Test", "description", gov.ProposalTypeText)
+	proposal6 := keeper.NewTextProposal(ctx, "Test", "description", gov.ProposalTypeText)
 
 	require.Equal(t, int64(6), proposal6.GetProposalID())
 }
 
 func TestActivateVotingPeriod(t *testing.T) {
-	mapp, keeper, _, _, _, _ := getMockApp(t, 0)
+	mapp, _, keeper, _, _, _, _ := getMockApp(t, 0)
 	mapp.BeginBlock(abci.RequestBeginBlock{})
 	ctx := mapp.BaseApp.NewContext(sdk.RunTxModeDeliver, abci.Header{})
 
-	proposal := keeper.NewTextProposal(ctx, "Test", "description", ProposalTypeText)
+	proposal := keeper.NewTextProposal(ctx, "Test", "description", gov.ProposalTypeText)
 
 	require.True(t, proposal.GetVotingStartTime().Equal(time.Time{}))
 	require.Nil(t, keeper.ActiveProposalQueuePeek(ctx))
 
-	keeper.activateVotingPeriod(ctx, proposal)
+	keeper.ActivateVotingPeriod(ctx, proposal)
 
 	require.True(t, proposal.GetVotingStartTime().Equal(ctx.BlockHeader().Time))
 	require.Equal(t, proposal.GetProposalID(), keeper.ActiveProposalQueuePeek(ctx).GetProposalID())
 }
 
 func TestDeposits(t *testing.T) {
-	mapp, keeper, _, addrs, _, _ := getMockApp(t, 2)
+	mapp, ck, keeper, _, addrs, _, _ := getMockApp(t, 2)
 	SortAddresses(addrs)
 	mapp.BeginBlock(abci.RequestBeginBlock{})
 	ctx := mapp.BaseApp.NewContext(sdk.RunTxModeDeliver, abci.Header{})
 
-	proposal := keeper.NewTextProposal(ctx, "Test", "description", ProposalTypeText)
+	proposal := keeper.NewTextProposal(ctx, "Test", "description", gov.ProposalTypeText)
 	proposalID := proposal.GetProposalID()
 
-	fiveHundredSteak := sdk.Coins{sdk.NewCoin(DefaultDepositDenom, 500e8)}
-	oneThousandSteak := sdk.Coins{sdk.NewCoin(DefaultDepositDenom, 1000e8)}
+	fiveHundredSteak := sdk.Coins{sdk.NewCoin(gov.DefaultDepositDenom, 500e8)}
+	oneThousandSteak := sdk.Coins{sdk.NewCoin(gov.DefaultDepositDenom, 1000e8)}
 
-	addr0Initial := keeper.ck.GetCoins(ctx, addrs[0])
-	addr1Initial := keeper.ck.GetCoins(ctx, addrs[1])
+	addr0Initial := ck.GetCoins(ctx, addrs[0])
+	addr1Initial := ck.GetCoins(ctx, addrs[1])
 
 	// require.True(t, addr0Initial.IsEqual(sdk.Coins{sdk.NewCoin("steak", 42)}))
-	require.Equal(t, sdk.Coins{sdk.NewCoin(DefaultDepositDenom, 5000e8)}, addr0Initial)
+	require.Equal(t, sdk.Coins{sdk.NewCoin(gov.DefaultDepositDenom, 5000e8)}, addr0Initial)
 
 	require.True(t, proposal.GetTotalDeposit().IsEqual(sdk.Coins{}))
 
@@ -88,7 +89,7 @@ func TestDeposits(t *testing.T) {
 	require.Equal(t, fiveHundredSteak, deposit.Amount)
 	require.Equal(t, addrs[0], deposit.Depositer)
 	require.Equal(t, fiveHundredSteak, keeper.GetProposal(ctx, proposalID).GetTotalDeposit())
-	require.Equal(t, addr0Initial.Minus(fiveHundredSteak), keeper.ck.GetCoins(ctx, addrs[0]))
+	require.Equal(t, addr0Initial.Minus(fiveHundredSteak), ck.GetCoins(ctx, addrs[0]))
 
 	// Check a second deposit from same address
 	err, votingStarted = keeper.AddDeposit(ctx, proposalID, addrs[0], oneThousandSteak)
@@ -99,7 +100,7 @@ func TestDeposits(t *testing.T) {
 	require.Equal(t, fiveHundredSteak.Plus(oneThousandSteak), deposit.Amount)
 	require.Equal(t, addrs[0], deposit.Depositer)
 	require.Equal(t, fiveHundredSteak.Plus(oneThousandSteak), keeper.GetProposal(ctx, proposalID).GetTotalDeposit())
-	require.Equal(t, addr0Initial.Minus(fiveHundredSteak).Minus(oneThousandSteak), keeper.ck.GetCoins(ctx, addrs[0]))
+	require.Equal(t, addr0Initial.Minus(fiveHundredSteak).Minus(oneThousandSteak), ck.GetCoins(ctx, addrs[0]))
 
 	// Check third deposit from a new address
 	err, votingStarted = keeper.AddDeposit(ctx, proposalID, addrs[1], fiveHundredSteak)
@@ -110,7 +111,7 @@ func TestDeposits(t *testing.T) {
 	require.Equal(t, addrs[1], deposit.Depositer)
 	require.Equal(t, fiveHundredSteak, deposit.Amount)
 	require.Equal(t, fiveHundredSteak.Plus(oneThousandSteak).Plus(fiveHundredSteak), keeper.GetProposal(ctx, proposalID).GetTotalDeposit())
-	require.Equal(t, addr1Initial.Minus(fiveHundredSteak), keeper.ck.GetCoins(ctx, addrs[1]))
+	require.Equal(t, addr1Initial.Minus(fiveHundredSteak), ck.GetCoins(ctx, addrs[1]))
 
 	// Check that proposal moved to voting period
 	require.True(t, keeper.GetProposal(ctx, proposalID).GetVotingStartTime().Equal(ctx.BlockHeader().Time))
@@ -120,11 +121,11 @@ func TestDeposits(t *testing.T) {
 	// Test deposit iterator
 	depositsIterator := keeper.GetDeposits(ctx, proposalID)
 	require.True(t, depositsIterator.Valid())
-	keeper.cdc.MustUnmarshalBinary(depositsIterator.Value(), &deposit)
+	mapp.Cdc.MustUnmarshalBinary(depositsIterator.Value(), &deposit)
 	require.Equal(t, addrs[0], deposit.Depositer)
 	require.Equal(t, fiveHundredSteak.Plus(oneThousandSteak), deposit.Amount)
 	depositsIterator.Next()
-	keeper.cdc.MustUnmarshalBinary(depositsIterator.Value(), &deposit)
+	mapp.Cdc.MustUnmarshalBinary(depositsIterator.Value(), &deposit)
 	require.Equal(t, addrs[1], deposit.Depositer)
 	require.Equal(t, fiveHundredSteak, deposit.Amount)
 	depositsIterator.Next()
@@ -138,68 +139,68 @@ func TestDeposits(t *testing.T) {
 	keeper.RefundDeposits(ctx, proposalID)
 	deposit, found = keeper.GetDeposit(ctx, proposalID, addrs[1])
 	require.False(t, found)
-	require.Equal(t, addr0Initial, keeper.ck.GetCoins(ctx, addrs[0]))
-	require.Equal(t, addr1Initial, keeper.ck.GetCoins(ctx, addrs[1]))
+	require.Equal(t, addr0Initial, ck.GetCoins(ctx, addrs[0]))
+	require.Equal(t, addr1Initial, ck.GetCoins(ctx, addrs[1]))
 }
 
 func TestVotes(t *testing.T) {
-	mapp, keeper, _, addrs, _, _ := getMockApp(t, 2)
+	mapp, _, keeper, _, addrs, _, _ := getMockApp(t, 2)
 	SortAddresses(addrs)
 	mapp.BeginBlock(abci.RequestBeginBlock{})
 	ctx := mapp.BaseApp.NewContext(sdk.RunTxModeDeliver, abci.Header{})
 
-	proposal := keeper.NewTextProposal(ctx, "Test", "description", ProposalTypeText)
+	proposal := keeper.NewTextProposal(ctx, "Test", "description", gov.ProposalTypeText)
 	proposalID := proposal.GetProposalID()
 
-	proposal.SetStatus(StatusVotingPeriod)
+	proposal.SetStatus(gov.StatusVotingPeriod)
 	keeper.SetProposal(ctx, proposal)
 
 	// Test first vote
-	keeper.AddVote(ctx, proposalID, addrs[0], OptionAbstain)
+	keeper.AddVote(ctx, proposalID, addrs[0], gov.OptionAbstain)
 	vote, found := keeper.GetVote(ctx, proposalID, addrs[0])
 	require.True(t, found)
 	require.Equal(t, addrs[0], vote.Voter)
 	require.Equal(t, proposalID, vote.ProposalID)
-	require.Equal(t, OptionAbstain, vote.Option)
+	require.Equal(t, gov.OptionAbstain, vote.Option)
 
 	// Test change of vote
-	keeper.AddVote(ctx, proposalID, addrs[0], OptionYes)
+	keeper.AddVote(ctx, proposalID, addrs[0], gov.OptionYes)
 	vote, found = keeper.GetVote(ctx, proposalID, addrs[0])
 	require.True(t, found)
 	require.Equal(t, addrs[0], vote.Voter)
 	require.Equal(t, proposalID, vote.ProposalID)
-	require.Equal(t, OptionYes, vote.Option)
+	require.Equal(t, gov.OptionYes, vote.Option)
 
 	// Test second vote
-	keeper.AddVote(ctx, proposalID, addrs[1], OptionNoWithVeto)
+	keeper.AddVote(ctx, proposalID, addrs[1], gov.OptionNoWithVeto)
 	vote, found = keeper.GetVote(ctx, proposalID, addrs[1])
 	require.True(t, found)
 	require.Equal(t, addrs[1], vote.Voter)
 	require.Equal(t, proposalID, vote.ProposalID)
-	require.Equal(t, OptionNoWithVeto, vote.Option)
+	require.Equal(t, gov.OptionNoWithVeto, vote.Option)
 
 	// Test vote iterator
 	votesIterator := keeper.GetVotes(ctx, proposalID)
 	require.True(t, votesIterator.Valid())
-	keeper.cdc.MustUnmarshalBinary(votesIterator.Value(), &vote)
+	mapp.Cdc.MustUnmarshalBinary(votesIterator.Value(), &vote)
 	require.True(t, votesIterator.Valid())
 	require.Equal(t, addrs[0], vote.Voter)
 	require.Equal(t, proposalID, vote.ProposalID)
-	require.Equal(t, OptionYes, vote.Option)
+	require.Equal(t, gov.OptionYes, vote.Option)
 	votesIterator.Next()
 	require.True(t, votesIterator.Valid())
-	keeper.cdc.MustUnmarshalBinary(votesIterator.Value(), &vote)
+	mapp.Cdc.MustUnmarshalBinary(votesIterator.Value(), &vote)
 	require.True(t, votesIterator.Valid())
 	require.Equal(t, addrs[1], vote.Voter)
 	require.Equal(t, proposalID, vote.ProposalID)
-	require.Equal(t, OptionNoWithVeto, vote.Option)
+	require.Equal(t, gov.OptionNoWithVeto, vote.Option)
 	votesIterator.Next()
 	require.False(t, votesIterator.Valid())
 	votesIterator.Close()
 }
 
 func TestProposalQueues(t *testing.T) {
-	mapp, keeper, _, _, _, _ := getMockApp(t, 0)
+	mapp, _, keeper, _, _, _, _ := getMockApp(t, 0)
 	mapp.BeginBlock(abci.RequestBeginBlock{})
 	ctx := mapp.BaseApp.NewContext(sdk.RunTxModeDeliver, abci.Header{})
 	mapp.InitChainer(ctx, abci.RequestInitChain{})
@@ -208,10 +209,10 @@ func TestProposalQueues(t *testing.T) {
 	require.Nil(t, keeper.ActiveProposalQueuePeek(ctx))
 
 	// create test proposals
-	proposal := keeper.NewTextProposal(ctx, "Test", "description", ProposalTypeText)
-	proposal2 := keeper.NewTextProposal(ctx, "Test2", "description", ProposalTypeText)
-	proposal3 := keeper.NewTextProposal(ctx, "Test3", "description", ProposalTypeText)
-	proposal4 := keeper.NewTextProposal(ctx, "Test4", "description", ProposalTypeText)
+	proposal := keeper.NewTextProposal(ctx, "Test", "description", gov.ProposalTypeText)
+	proposal2 := keeper.NewTextProposal(ctx, "Test2", "description", gov.ProposalTypeText)
+	proposal3 := keeper.NewTextProposal(ctx, "Test3", "description", gov.ProposalTypeText)
+	proposal4 := keeper.NewTextProposal(ctx, "Test4", "description", gov.ProposalTypeText)
 
 	// test pushing to inactive proposal queue
 	keeper.InactiveProposalQueuePush(ctx, proposal)

--- a/x/gov/msgs_test.go
+++ b/x/gov/msgs_test.go
@@ -1,19 +1,21 @@
-package gov
+package gov_test
 
 import (
 	"testing"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/cosmos-sdk/x/mock"
 	"github.com/stretchr/testify/require"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/gov"
+	"github.com/cosmos/cosmos-sdk/x/mock"
 )
 
 var (
-	coinsPos         = sdk.Coins{sdk.NewCoin(DefaultDepositDenom, 1000)}
+	coinsPos         = sdk.Coins{sdk.NewCoin(gov.DefaultDepositDenom, 1000)}
 	coinsZero        = sdk.Coins{}
-	coinsNeg         = sdk.Coins{sdk.NewCoin(DefaultDepositDenom, -10000)}
+	coinsNeg         = sdk.Coins{sdk.NewCoin(gov.DefaultDepositDenom, -10000)}
 	coinsPosNotAtoms = sdk.Coins{sdk.NewCoin("foo", 10000)}
-	coinsMulti       = sdk.Coins{sdk.NewCoin("foo", 10000), sdk.NewCoin(DefaultDepositDenom, 1000)}
+	coinsMulti       = sdk.Coins{sdk.NewCoin("foo", 10000), sdk.NewCoin(gov.DefaultDepositDenom, 1000)}
 )
 
 // test ValidateBasic for MsgCreateValidator
@@ -21,25 +23,25 @@ func TestMsgSubmitProposal(t *testing.T) {
 	_, addrs, _, _ := mock.CreateGenAccounts(1, sdk.Coins{})
 	tests := []struct {
 		title, description string
-		proposalType       ProposalKind
+		proposalType       gov.ProposalKind
 		proposerAddr       sdk.AccAddress
 		initialDeposit     sdk.Coins
 		expectPass         bool
 	}{
-		{"Test Proposal", "the purpose of this proposal is to test", ProposalTypeText, addrs[0], coinsPos, true},
-		{"", "the purpose of this proposal is to test", ProposalTypeText, addrs[0], coinsPos, false},
-		{"Test Proposal", "", ProposalTypeText, addrs[0], coinsPos, false},
-		{"Test Proposal", "the purpose of this proposal is to test", ProposalTypeParameterChange, addrs[0], coinsPos, true},
-		{"Test Proposal", "the purpose of this proposal is to test", ProposalTypeSoftwareUpgrade, addrs[0], coinsPos, true},
+		{"Test Proposal", "the purpose of this proposal is to test", gov.ProposalTypeText, addrs[0], coinsPos, true},
+		{"", "the purpose of this proposal is to test", gov.ProposalTypeText, addrs[0], coinsPos, false},
+		{"Test Proposal", "", gov.ProposalTypeText, addrs[0], coinsPos, false},
+		{"Test Proposal", "the purpose of this proposal is to test", gov.ProposalTypeParameterChange, addrs[0], coinsPos, true},
+		{"Test Proposal", "the purpose of this proposal is to test", gov.ProposalTypeSoftwareUpgrade, addrs[0], coinsPos, true},
 		{"Test Proposal", "the purpose of this proposal is to test", 0x05, addrs[0], coinsPos, false},
-		{"Test Proposal", "the purpose of this proposal is to test", ProposalTypeText, sdk.AccAddress{}, coinsPos, false},
-		{"Test Proposal", "the purpose of this proposal is to test", ProposalTypeText, addrs[0], coinsZero, true},
-		{"Test Proposal", "the purpose of this proposal is to test", ProposalTypeText, addrs[0], coinsNeg, false},
-		{"Test Proposal", "the purpose of this proposal is to test", ProposalTypeText, addrs[0], coinsMulti, true},
+		{"Test Proposal", "the purpose of this proposal is to test", gov.ProposalTypeText, sdk.AccAddress{}, coinsPos, false},
+		{"Test Proposal", "the purpose of this proposal is to test", gov.ProposalTypeText, addrs[0], coinsZero, true},
+		{"Test Proposal", "the purpose of this proposal is to test", gov.ProposalTypeText, addrs[0], coinsNeg, false},
+		{"Test Proposal", "the purpose of this proposal is to test", gov.ProposalTypeText, addrs[0], coinsMulti, true},
 	}
 
 	for i, tc := range tests {
-		msg := NewMsgSubmitProposal(tc.title, tc.description, tc.proposalType, tc.proposerAddr, tc.initialDeposit)
+		msg := gov.NewMsgSubmitProposal(tc.title, tc.description, tc.proposalType, tc.proposerAddr, tc.initialDeposit)
 		if tc.expectPass {
 			require.Nil(t, msg.ValidateBasic(), "test: %v", i)
 		} else {
@@ -66,7 +68,7 @@ func TestMsgDeposit(t *testing.T) {
 	}
 
 	for i, tc := range tests {
-		msg := NewMsgDeposit(tc.depositerAddr, tc.proposalID, tc.depositAmount)
+		msg := gov.NewMsgDeposit(tc.depositerAddr, tc.proposalID, tc.depositAmount)
 		if tc.expectPass {
 			require.Nil(t, msg.ValidateBasic(), "test: %v", i)
 		} else {
@@ -81,20 +83,20 @@ func TestMsgVote(t *testing.T) {
 	tests := []struct {
 		proposalID int64
 		voterAddr  sdk.AccAddress
-		option     VoteOption
+		option     gov.VoteOption
 		expectPass bool
 	}{
-		{0, addrs[0], OptionYes, true},
-		{-1, addrs[0], OptionYes, false},
-		{0, sdk.AccAddress{}, OptionYes, false},
-		{0, addrs[0], OptionNo, true},
-		{0, addrs[0], OptionNoWithVeto, true},
-		{0, addrs[0], OptionAbstain, true},
-		{0, addrs[0], VoteOption(0x13), false},
+		{0, addrs[0], gov.OptionYes, true},
+		{-1, addrs[0], gov.OptionYes, false},
+		{0, sdk.AccAddress{}, gov.OptionYes, false},
+		{0, addrs[0], gov.OptionNo, true},
+		{0, addrs[0], gov.OptionNoWithVeto, true},
+		{0, addrs[0], gov.OptionAbstain, true},
+		{0, addrs[0], gov.VoteOption(0x13), false},
 	}
 
 	for i, tc := range tests {
-		msg := NewMsgVote(tc.voterAddr, tc.proposalID, tc.option)
+		msg := gov.NewMsgVote(tc.voterAddr, tc.proposalID, tc.option)
 		if tc.expectPass {
 			require.Nil(t, msg.ValidateBasic(), "test: %v", i)
 		} else {

--- a/x/gov/proposals_test.go
+++ b/x/gov/proposals_test.go
@@ -1,16 +1,18 @@
-package gov
+package gov_test
 
 import (
 	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/cosmos/cosmos-sdk/x/gov"
 )
 
 func TestProposalKind_Format(t *testing.T) {
-	typeText, _ := ProposalTypeFromString("Text")
+	typeText, _ := gov.ProposalTypeFromString("Text")
 	tests := []struct {
-		pt                   ProposalKind
+		pt                   gov.ProposalKind
 		sprintFArgs          string
 		expectedStringOutput string
 	}{
@@ -24,9 +26,9 @@ func TestProposalKind_Format(t *testing.T) {
 }
 
 func TestProposalStatus_Format(t *testing.T) {
-	statusDepositPeriod, _ := ProposalStatusFromString("DepositPeriod")
+	statusDepositPeriod, _ := gov.ProposalStatusFromString("DepositPeriod")
 	tests := []struct {
-		pt                   ProposalStatus
+		pt                   gov.ProposalStatus
 		sprintFArgs          string
 		expectedStringOutput string
 	}{

--- a/x/gov/queryable.go
+++ b/x/gov/queryable.go
@@ -1,9 +1,10 @@
 package gov
 
 import (
+	abci "github.com/tendermint/tendermint/abci/types"
+
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	abci "github.com/tendermint/tendermint/abci/types"
 )
 
 // query endpoints supported by the governance Querier
@@ -218,7 +219,7 @@ func queryTally(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Ke
 	} else if proposal.GetStatus() == StatusPassed || proposal.GetStatus() == StatusRejected {
 		tallyResult = proposal.GetTallyResult()
 	} else {
-		_, tallyResult = tally(ctx, keeper, proposal)
+		_, tallyResult = Tally(ctx, keeper, proposal)
 	}
 
 	bz, err2 := codec.MarshalJSONIndent(keeper.cdc, tallyResult)

--- a/x/gov/tally.go
+++ b/x/gov/tally.go
@@ -13,7 +13,7 @@ type validatorGovInfo struct {
 	Vote            VoteOption     // Vote of the validator
 }
 
-func tally(ctx sdk.Context, keeper Keeper, proposal Proposal) (passes bool, tallyResults TallyResult) {
+func Tally(ctx sdk.Context, keeper Keeper, proposal Proposal) (passes bool, tallyResults TallyResult) {
 	results := make(map[VoteOption]sdk.Dec)
 	results[OptionYes] = sdk.ZeroDec()
 	results[OptionAbstain] = sdk.ZeroDec()


### PR DESCRIPTION
Because we want to integrate stake with gov, but gov plugin import stake package in tests. so we change package of tests to gov_test to avoid import cycle.
