### PR TITLE
[R4R]: update validators through gov

### DIFF
--- a/cmd/gaia/app/app.go
+++ b/cmd/gaia/app/app.go
@@ -150,7 +150,7 @@ func NewGaiaApp(logger log.Logger, db dbm.DB, traceStore io.Writer, baseAppOptio
 	// register message routes
 	app.Router().
 		AddRoute("bank", bank.NewHandler(app.bankKeeper)).
-		AddRoute("stake", stake.NewHandler(app.stakeKeeper)).
+		AddRoute("stake", stake.NewStakeHandler(app.stakeKeeper)).
 		AddRoute("distr", distr.NewHandler(app.distrKeeper)).
 		AddRoute("slashing", slashing.NewHandler(app.slashingKeeper)).
 		AddRoute("gov", gov.NewHandler(app.govKeeper))

--- a/cmd/gaia/app/app_test.go
+++ b/cmd/gaia/app/app_test.go
@@ -106,7 +106,7 @@ func NewMockGaiaApp(logger log.Logger, db dbm.DB, traceStore io.Writer, baseAppO
 	// register message routes
 	app.Router().
 		AddRoute("bank", bank.NewHandler(app.bankKeeper)).
-		AddRoute("stake", stake.NewHandler(app.stakeKeeper)).
+		AddRoute("stake", stake.NewHandler(app.stakeKeeper, app.govKeeper)).
 		AddRoute("distr", distr.NewHandler(app.distrKeeper)).
 		AddRoute("slashing", slashing.NewHandler(app.slashingKeeper)).
 		AddRoute("gov", gov.NewHandler(app.govKeeper))

--- a/cmd/gaia/cmd/gaiadebug/hack.go
+++ b/cmd/gaia/cmd/gaiadebug/hack.go
@@ -180,7 +180,7 @@ func NewGaiaApp(logger log.Logger, db dbm.DB, baseAppOptions ...func(*bam.BaseAp
 	// register message routes
 	app.Router().
 		AddRoute("bank", bank.NewHandler(app.bankKeeper)).
-		AddRoute("stake", stake.NewHandler(app.stakeKeeper))
+		AddRoute("stake", stake.NewStakeHandler(app.stakeKeeper))
 
 	// initialize BaseApp
 	app.SetInitChainer(app.initChainer)

--- a/x/distribution/keeper/allocation_test.go
+++ b/x/distribution/keeper/allocation_test.go
@@ -13,7 +13,7 @@ func TestAllocateTokensBasic(t *testing.T) {
 
 	// no community tax on inputs
 	ctx, _, keeper, sk, fck := CreateTestInputAdvanced(t, false, sdk.NewDecWithoutFra(100).RawInt(), sdk.ZeroDec())
-	stakeHandler := stake.NewHandler(sk)
+	stakeHandler := stake.NewStakeHandler(sk)
 	denom := sk.GetParams(ctx).BondDenom
 
 	//first make a validator
@@ -55,7 +55,7 @@ func TestAllocateTokensBasic(t *testing.T) {
 func TestAllocateTokensWithCommunityTax(t *testing.T) {
 	communityTax := sdk.NewDecWithPrec(1, 2) //1%
 	ctx, _, keeper, sk, fck := CreateTestInputAdvanced(t, false, sdk.NewDecWithoutFra(100).RawInt(), communityTax)
-	stakeHandler := stake.NewHandler(sk)
+	stakeHandler := stake.NewStakeHandler(sk)
 	denom := sk.GetParams(ctx).BondDenom
 
 	//first make a validator
@@ -83,7 +83,7 @@ func TestAllocateTokensWithCommunityTax(t *testing.T) {
 func TestAllocateTokensWithPartialPrecommitPower(t *testing.T) {
 	communityTax := sdk.NewDecWithPrec(1, 2)
 	ctx, _, keeper, sk, fck := CreateTestInputAdvanced(t, false, sdk.NewDecWithoutFra(100).RawInt(), communityTax)
-	stakeHandler := stake.NewHandler(sk)
+	stakeHandler := stake.NewStakeHandler(sk)
 	denom := sk.GetParams(ctx).BondDenom
 
 	//first make a validator

--- a/x/distribution/keeper/delegation_test.go
+++ b/x/distribution/keeper/delegation_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestWithdrawDelegationRewardBasic(t *testing.T) {
 	ctx, accMapper, keeper, sk, fck := CreateTestInputAdvanced(t, false, sdk.NewDecWithoutFra(100).RawInt(), sdk.ZeroDec())
-	stakeHandler := stake.NewHandler(sk)
+	stakeHandler := stake.NewStakeHandler(sk)
 	denom := sk.GetParams(ctx).BondDenom
 
 	//first make a validator
@@ -45,7 +45,7 @@ func TestWithdrawDelegationRewardBasic(t *testing.T) {
 
 func TestWithdrawDelegationRewardWithCommission(t *testing.T) {
 	ctx, accMapper, keeper, sk, fck := CreateTestInputAdvanced(t, false, sdk.NewDecWithoutFra(100).RawInt(), sdk.ZeroDec())
-	stakeHandler := stake.NewHandler(sk)
+	stakeHandler := stake.NewStakeHandler(sk)
 	denom := sk.GetParams(ctx).BondDenom
 
 	//first make a validator with 10% commission
@@ -79,7 +79,7 @@ func TestWithdrawDelegationRewardWithCommission(t *testing.T) {
 
 func TestWithdrawDelegationRewardTwoDelegators(t *testing.T) {
 	ctx, accMapper, keeper, sk, fck := CreateTestInputAdvanced(t, false, sdk.NewDecWithoutFra(100).RawInt(), sdk.ZeroDec())
-	stakeHandler := stake.NewHandler(sk)
+	stakeHandler := stake.NewStakeHandler(sk)
 	denom := sk.GetParams(ctx).BondDenom
 
 	//first make a validator with 10% commission
@@ -121,7 +121,7 @@ func TestWithdrawDelegationRewardTwoDelegators(t *testing.T) {
 // with different rewards in the end
 func TestWithdrawDelegationRewardTwoDelegatorsUneven(t *testing.T) {
 	ctx, accMapper, keeper, sk, fck := CreateTestInputAdvanced(t, false, sdk.NewDecWithoutFra(100).RawInt(), sdk.ZeroDec())
-	stakeHandler := stake.NewHandler(sk)
+	stakeHandler := stake.NewStakeHandler(sk)
 	denom := sk.GetParams(ctx).BondDenom
 
 	//first make a validator with no commission
@@ -188,7 +188,7 @@ func TestWithdrawDelegationRewardTwoDelegatorsUneven(t *testing.T) {
 
 func TestWithdrawDelegationRewardsAll(t *testing.T) {
 	ctx, accMapper, keeper, sk, fck := CreateTestInputAdvanced(t, false, sdk.NewDecWithoutFra(100).RawInt(), sdk.ZeroDec())
-	stakeHandler := stake.NewHandler(sk)
+	stakeHandler := stake.NewStakeHandler(sk)
 	denom := sk.GetParams(ctx).BondDenom
 
 	//make some  validators with different commissions

--- a/x/distribution/keeper/validator_test.go
+++ b/x/distribution/keeper/validator_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestWithdrawValidatorRewardsAllNoDelegator(t *testing.T) {
 	ctx, accMapper, keeper, sk, fck := CreateTestInputAdvanced(t, false, sdk.NewDecWithoutFra(100).RawInt(), sdk.ZeroDec())
-	stakeHandler := stake.NewHandler(sk)
+	stakeHandler := stake.NewStakeHandler(sk)
 	denom := sk.GetParams(ctx).BondDenom
 
 	//first make a validator
@@ -35,7 +35,7 @@ func TestWithdrawValidatorRewardsAllNoDelegator(t *testing.T) {
 
 func TestWithdrawValidatorRewardsAllDelegatorNoCommission(t *testing.T) {
 	ctx, accMapper, keeper, sk, fck := CreateTestInputAdvanced(t, false, sdk.NewDecWithoutFra(100).RawInt(), sdk.ZeroDec())
-	stakeHandler := stake.NewHandler(sk)
+	stakeHandler := stake.NewStakeHandler(sk)
 	denom := sk.GetParams(ctx).BondDenom
 
 	//first make a validator
@@ -67,7 +67,7 @@ func TestWithdrawValidatorRewardsAllDelegatorNoCommission(t *testing.T) {
 
 func TestWithdrawValidatorRewardsAllDelegatorWithCommission(t *testing.T) {
 	ctx, accMapper, keeper, sk, fck := CreateTestInputAdvanced(t, false, sdk.NewDecWithoutFra(100).RawInt(), sdk.ZeroDec())
-	stakeHandler := stake.NewHandler(sk)
+	stakeHandler := stake.NewStakeHandler(sk)
 	denom := sk.GetParams(ctx).BondDenom
 
 	//first make a validator
@@ -104,7 +104,7 @@ func TestWithdrawValidatorRewardsAllDelegatorWithCommission(t *testing.T) {
 
 func TestWithdrawValidatorRewardsAllMultipleValidator(t *testing.T) {
 	ctx, accMapper, keeper, sk, fck := CreateTestInputAdvanced(t, false, sdk.NewDecWithoutFra(100).RawInt(), sdk.ZeroDec())
-	stakeHandler := stake.NewHandler(sk)
+	stakeHandler := stake.NewStakeHandler(sk)
 	denom := sk.GetParams(ctx).BondDenom
 
 	//make some  validators with different commissions
@@ -147,7 +147,7 @@ func TestWithdrawValidatorRewardsAllMultipleValidator(t *testing.T) {
 
 func TestWithdrawValidatorRewardsAllMultipleDelegator(t *testing.T) {
 	ctx, accMapper, keeper, sk, fck := CreateTestInputAdvanced(t, false, sdk.NewDecWithoutFra(100).RawInt(), sdk.ZeroDec())
-	stakeHandler := stake.NewHandler(sk)
+	stakeHandler := stake.NewStakeHandler(sk)
 	denom := sk.GetParams(ctx).BondDenom
 
 	//first make a validator with 10% commission

--- a/x/gov/proposals.go
+++ b/x/gov/proposals.go
@@ -118,6 +118,7 @@ const (
 	ProposalTypeListTradingPair ProposalKind = 0x04
 	// ProposalTypeFeeChange belongs to ProposalTypeParameterChange. We use this to make it easily to distinguish。
 	ProposalTypeFeeChange ProposalKind = 0x05
+	ProposalTypeCreateValidator ProposalKind = 0x06
 )
 
 // String to proposalType byte.  Returns ff if invalid.
@@ -133,6 +134,8 @@ func ProposalTypeFromString(str string) (ProposalKind, error) {
 		return ProposalTypeListTradingPair, nil
 	case "FeeChange":
 		return ProposalTypeFeeChange, nil
+	case "CreateValidator":
+		return ProposalTypeCreateValidator, nil
 	default:
 		return ProposalKind(0xff), errors.Errorf("'%s' is not a valid proposal type", str)
 	}
@@ -195,6 +198,8 @@ func (pt ProposalKind) String() string {
 		return "ListTradingPair"
 	case ProposalTypeFeeChange:
 		return "FeeChange"
+	case ProposalTypeCreateValidator:
+		return "CreateValidator"
 	default:
 		return ""
 	}
@@ -337,8 +342,8 @@ func EmptyTallyResult() TallyResult {
 
 // checks if two proposals are equal
 func (resultA TallyResult) Equals(resultB TallyResult) bool {
-	return (resultA.Yes.Equal(resultB.Yes) &&
-		resultA.Abstain.Equal(resultB.Abstain) &&
-		resultA.No.Equal(resultB.No) &&
-		resultA.NoWithVeto.Equal(resultB.NoWithVeto))
+	return resultA.Yes.Equal(resultB.Yes) &&
+			resultA.Abstain.Equal(resultB.Abstain) &&
+			resultA.No.Equal(resultB.No) &&
+			resultA.NoWithVeto.Equal(resultB.NoWithVeto)
 }

--- a/x/gov/tally_test.go
+++ b/x/gov/tally_test.go
@@ -37,7 +37,7 @@ func TestTallyNoOneVotes(t *testing.T) {
 	mapp, _, keeper, sk, addrs, _, _ := getMockApp(t, 10)
 	mapp.BeginBlock(abci.RequestBeginBlock{})
 	ctx := mapp.BaseApp.NewContext(sdk.RunTxModeDeliver, abci.Header{})
-	stakeHandler := stake.NewHandler(sk)
+	stakeHandler := stake.NewStakeHandler(sk)
 
 	valAddrs := make([]sdk.ValAddress, len(addrs[:2]))
 	for i, addr := range addrs[:2] {
@@ -62,7 +62,7 @@ func TestTallyOnlyValidatorsAllYes(t *testing.T) {
 	mapp, _, keeper, sk, addrs, _, _ := getMockApp(t, 10)
 	mapp.BeginBlock(abci.RequestBeginBlock{})
 	ctx := mapp.BaseApp.NewContext(sdk.RunTxModeDeliver, abci.Header{})
-	stakeHandler := stake.NewHandler(sk)
+	stakeHandler := stake.NewStakeHandler(sk)
 
 	valAddrs := make([]sdk.ValAddress, len(addrs[:2]))
 	for i, addr := range addrs[:2] {
@@ -92,7 +92,7 @@ func TestTallyOnlyValidators51No(t *testing.T) {
 	mapp, _, keeper, sk, addrs, _, _ := getMockApp(t, 10)
 	mapp.BeginBlock(abci.RequestBeginBlock{})
 	ctx := mapp.BaseApp.NewContext(sdk.RunTxModeDeliver, abci.Header{})
-	stakeHandler := stake.NewHandler(sk)
+	stakeHandler := stake.NewStakeHandler(sk)
 
 	valAddrs := make([]sdk.ValAddress, len(addrs[:2]))
 	for i, addr := range addrs[:2] {
@@ -121,7 +121,7 @@ func TestTallyOnlyValidators51Yes(t *testing.T) {
 	mapp, _, keeper, sk, addrs, _, _ := getMockApp(t, 10)
 	mapp.BeginBlock(abci.RequestBeginBlock{})
 	ctx := mapp.BaseApp.NewContext(sdk.RunTxModeDeliver, abci.Header{})
-	stakeHandler := stake.NewHandler(sk)
+	stakeHandler := stake.NewStakeHandler(sk)
 
 	valAddrs := make([]sdk.ValAddress, len(addrs[:3]))
 	for i, addr := range addrs[:3] {
@@ -153,7 +153,7 @@ func TestTallyOnlyValidatorsVetoed(t *testing.T) {
 	mapp, _, keeper, sk, addrs, _, _ := getMockApp(t, 10)
 	mapp.BeginBlock(abci.RequestBeginBlock{})
 	ctx := mapp.BaseApp.NewContext(sdk.RunTxModeDeliver, abci.Header{})
-	stakeHandler := stake.NewHandler(sk)
+	stakeHandler := stake.NewStakeHandler(sk)
 
 	valAddrs := make([]sdk.ValAddress, len(addrs[:3]))
 	for i, addr := range addrs[:3] {
@@ -185,7 +185,7 @@ func TestTallyOnlyValidatorsAbstainPasses(t *testing.T) {
 	mapp, _, keeper, sk, addrs, _, _ := getMockApp(t, 10)
 	mapp.BeginBlock(abci.RequestBeginBlock{})
 	ctx := mapp.BaseApp.NewContext(sdk.RunTxModeDeliver, abci.Header{})
-	stakeHandler := stake.NewHandler(sk)
+	stakeHandler := stake.NewStakeHandler(sk)
 
 	valAddrs := make([]sdk.ValAddress, len(addrs[:3]))
 	for i, addr := range addrs[:3] {
@@ -217,7 +217,7 @@ func TestTallyOnlyValidatorsAbstainFails(t *testing.T) {
 	mapp, _, keeper, sk, addrs, _, _ := getMockApp(t, 10)
 	mapp.BeginBlock(abci.RequestBeginBlock{})
 	ctx := mapp.BaseApp.NewContext(sdk.RunTxModeDeliver, abci.Header{})
-	stakeHandler := stake.NewHandler(sk)
+	stakeHandler := stake.NewStakeHandler(sk)
 
 	valAddrs := make([]sdk.ValAddress, len(addrs[:3]))
 	for i, addr := range addrs[:3] {
@@ -249,7 +249,7 @@ func TestTallyOnlyValidatorsNonVoter(t *testing.T) {
 	mapp, _, keeper, sk, addrs, _, _ := getMockApp(t, 10)
 	mapp.BeginBlock(abci.RequestBeginBlock{})
 	ctx := mapp.BaseApp.NewContext(sdk.RunTxModeDeliver, abci.Header{})
-	stakeHandler := stake.NewHandler(sk)
+	stakeHandler := stake.NewStakeHandler(sk)
 
 	valAddrs := make([]sdk.ValAddress, len(addrs[:3]))
 	for i, addr := range addrs[:3] {
@@ -279,7 +279,7 @@ func TestTallyDelgatorOverride(t *testing.T) {
 	mapp, _, keeper, sk, addrs, _, _ := getMockApp(t, 10)
 	mapp.BeginBlock(abci.RequestBeginBlock{})
 	ctx := mapp.BaseApp.NewContext(sdk.RunTxModeDeliver, abci.Header{})
-	stakeHandler := stake.NewHandler(sk)
+	stakeHandler := stake.NewStakeHandler(sk)
 
 	valAddrs := make([]sdk.ValAddress, len(addrs[:3]))
 	for i, addr := range addrs[:3] {
@@ -316,7 +316,7 @@ func TestTallyDelgatorInherit(t *testing.T) {
 	mapp, _, keeper, sk, addrs, _, _ := getMockApp(t, 10)
 	mapp.BeginBlock(abci.RequestBeginBlock{})
 	ctx := mapp.BaseApp.NewContext(sdk.RunTxModeDeliver, abci.Header{})
-	stakeHandler := stake.NewHandler(sk)
+	stakeHandler := stake.NewStakeHandler(sk)
 
 	valAddrs := make([]sdk.ValAddress, len(addrs[:3]))
 	for i, addr := range addrs[:3] {
@@ -351,7 +351,7 @@ func TestTallyDelgatorMultipleOverride(t *testing.T) {
 	mapp, _, keeper, sk, addrs, _, _ := getMockApp(t, 10)
 	mapp.BeginBlock(abci.RequestBeginBlock{})
 	ctx := mapp.BaseApp.NewContext(sdk.RunTxModeDeliver, abci.Header{})
-	stakeHandler := stake.NewHandler(sk)
+	stakeHandler := stake.NewStakeHandler(sk)
 
 	valAddrs := make([]sdk.ValAddress, len(addrs[:3]))
 	for i, addr := range addrs[:3] {
@@ -390,7 +390,7 @@ func TestTallyDelgatorMultipleInherit(t *testing.T) {
 	mapp, _, keeper, sk, addrs, _, _ := getMockApp(t, 10)
 	mapp.BeginBlock(abci.RequestBeginBlock{})
 	ctx := mapp.BaseApp.NewContext(sdk.RunTxModeDeliver, abci.Header{})
-	stakeHandler := stake.NewHandler(sk)
+	stakeHandler := stake.NewStakeHandler(sk)
 
 	val1CreateMsg := stake.NewMsgCreateValidator(
 		sdk.ValAddress(addrs[0]), ed25519.GenPrivKey().PubKey(), sdk.NewCoin(gov.DefaultDepositDenom, 25), testDescription, testCommissionMsg,
@@ -437,7 +437,7 @@ func TestTallyJailedValidator(t *testing.T) {
 	mapp, _, keeper, sk, addrs, _, _ := getMockApp(t, 10)
 	mapp.BeginBlock(abci.RequestBeginBlock{})
 	ctx := mapp.BaseApp.NewContext(sdk.RunTxModeDeliver, abci.Header{})
-	stakeHandler := stake.NewHandler(sk)
+	stakeHandler := stake.NewStakeHandler(sk)
 
 	valAddrs := make([]sdk.ValAddress, len(addrs[:3]))
 	for i, addr := range addrs[:3] {

--- a/x/slashing/app_test.go
+++ b/x/slashing/app_test.go
@@ -36,7 +36,7 @@ func getMockApp(t *testing.T) (*mock.App, stake.Keeper, Keeper) {
 	paramsKeeper := params.NewKeeper(mapp.Cdc, keyParams, tkeyParams)
 	stakeKeeper := stake.NewKeeper(mapp.Cdc, keyStake, tkeyStake, bankKeeper, paramsKeeper.Subspace(stake.DefaultParamspace), mapp.RegisterCodespace(stake.DefaultCodespace))
 	keeper := NewKeeper(mapp.Cdc, keySlashing, stakeKeeper, paramsKeeper.Subspace(DefaultParamspace), mapp.RegisterCodespace(DefaultCodespace))
-	mapp.Router().AddRoute("stake", stake.NewHandler(stakeKeeper))
+	mapp.Router().AddRoute("stake", stake.NewStakeHandler(stakeKeeper))
 	mapp.Router().AddRoute("slashing", NewHandler(keeper))
 
 	mapp.SetEndBlocker(getEndBlocker(stakeKeeper))

--- a/x/slashing/handler_test.go
+++ b/x/slashing/handler_test.go
@@ -18,7 +18,7 @@ func TestCannotUnjailUnlessJailed(t *testing.T) {
 	amtInt := sdk.NewDecWithoutFra(100).RawInt()
 	addr, val, amt := addrs[0], pks[0], amtInt
 	msg := NewTestMsgCreateValidator(addr, val, amt)
-	got := stake.NewHandler(sk)(ctx, msg)
+	got := stake.NewStakeHandler(sk)(ctx, msg)
 	fmt.Println(got.Log)
 	require.True(t, got.IsOK())
 	stake.EndBlocker(ctx, sk)
@@ -44,7 +44,7 @@ func TestJailedValidatorDelegations(t *testing.T) {
 	valAddr, consAddr := addrs[1], sdk.ConsAddress(addrs[0])
 
 	msgCreateVal := NewTestMsgCreateValidator(valAddr, valPubKey, sdk.NewDecWithoutFra(bondAmount).RawInt())
-	got := stake.NewHandler(stakeKeeper)(ctx, msgCreateVal)
+	got := stake.NewStakeHandler(stakeKeeper)(ctx, msgCreateVal)
 	require.True(t, got.IsOK(), "expected create validator msg to be ok, got: %v", got)
 
 	// end block
@@ -62,14 +62,14 @@ func TestJailedValidatorDelegations(t *testing.T) {
 	// delegate tokens to the validator
 	delAddr := sdk.AccAddress(addrs[2])
 	msgDelegate := newTestMsgDelegate(delAddr, valAddr, sdk.NewDecWithoutFra(bondAmount).RawInt())
-	got = stake.NewHandler(stakeKeeper)(ctx, msgDelegate)
+	got = stake.NewStakeHandler(stakeKeeper)(ctx, msgDelegate)
 	require.True(t, got.IsOK(), "expected delegation to be ok, got %v", got)
 
 	unbondShares := sdk.NewDec(sdk.NewDecWithoutFra(10).RawInt())
 
 	// unbond validator total self-delegations (which should jail the validator)
 	msgBeginUnbonding := stake.NewMsgBeginUnbonding(sdk.AccAddress(valAddr), valAddr, unbondShares)
-	got = stake.NewHandler(stakeKeeper)(ctx, msgBeginUnbonding)
+	got = stake.NewStakeHandler(stakeKeeper)(ctx, msgBeginUnbonding)
 	require.True(t, got.IsOK(), "expected begin unbonding validator msg to be ok, got: %v", got)
 
 	err := stakeKeeper.CompleteUnbonding(ctx, sdk.AccAddress(valAddr), valAddr)
@@ -86,7 +86,7 @@ func TestJailedValidatorDelegations(t *testing.T) {
 
 	// self-delegate to validator
 	msgSelfDelegate := newTestMsgDelegate(sdk.AccAddress(valAddr), valAddr, sdk.NewDecWithoutFra(bondAmount).RawInt())
-	got = stake.NewHandler(stakeKeeper)(ctx, msgSelfDelegate)
+	got = stake.NewStakeHandler(stakeKeeper)(ctx, msgSelfDelegate)
 	require.True(t, got.IsOK(), "expected delegation to not be ok, got %v", got)
 
 	// verify the validator can now unjail itself

--- a/x/slashing/keeper_test.go
+++ b/x/slashing/keeper_test.go
@@ -32,7 +32,7 @@ func TestHandleDoubleSign(t *testing.T) {
 	ctx = ctx.WithBlockHeight(-1)
 	amtInt := sdk.NewDecWithoutFra(100).RawInt()
 	operatorAddr, val, amt := addrs[0], pks[0], amtInt
-	got := stake.NewHandler(sk)(ctx, NewTestMsgCreateValidator(operatorAddr, val, amt))
+	got := stake.NewStakeHandler(sk)(ctx, NewTestMsgCreateValidator(operatorAddr, val, amt))
 	require.True(t, got.IsOK())
 	validatorUpdates := stake.EndBlocker(ctx, sk)
 	keeper.AddValidators(ctx, validatorUpdates)
@@ -73,7 +73,7 @@ func TestSlashingPeriodCap(t *testing.T) {
 	amtInt := sdk.NewDecWithoutFra(100).RawInt()
 	operatorAddr, amt := addrs[0], amtInt
 	valConsPubKey, valConsAddr := pks[0], pks[0].Address()
-	got := stake.NewHandler(sk)(ctx, NewTestMsgCreateValidator(operatorAddr, valConsPubKey, amt))
+	got := stake.NewStakeHandler(sk)(ctx, NewTestMsgCreateValidator(operatorAddr, valConsPubKey, amt))
 	require.True(t, got.IsOK())
 	validatorUpdates := stake.EndBlocker(ctx, sk)
 	ctx = ctx.WithBlockHeight(ctx.BlockHeight() + 1)
@@ -137,7 +137,7 @@ func TestHandleAbsentValidator(t *testing.T) {
 	ctx, ck, sk, _, keeper := createTestInput(t, keeperTestParams())
 	amtInt := sdk.NewDecWithoutFra(100).RawInt()
 	addr, val, amt := addrs[0], pks[0], amtInt
-	sh := stake.NewHandler(sk)
+	sh := stake.NewStakeHandler(sk)
 	slh := NewHandler(keeper)
 	got := sh(ctx, NewTestMsgCreateValidator(addr, val, amt))
 	require.True(t, got.IsOK())
@@ -290,7 +290,7 @@ func TestHandleNewValidator(t *testing.T) {
 	// initial setup
 	ctx, ck, sk, _, keeper := createTestInput(t, keeperTestParams())
 	addr, val, amt := addrs[0], pks[0], sdk.NewDecWithoutFra(100).RawInt()
-	sh := stake.NewHandler(sk)
+	sh := stake.NewStakeHandler(sk)
 
 	// 1000 first blocks not a validator
 	ctx = ctx.WithBlockHeight(keeper.SignedBlocksWindow(ctx) + 1)
@@ -330,7 +330,7 @@ func TestHandleAlreadyJailed(t *testing.T) {
 	ctx, _, sk, _, keeper := createTestInput(t, DefaultParams())
 	amtInt := int64(100)
 	addr, val, amt := addrs[0], pks[0], amtInt
-	sh := stake.NewHandler(sk)
+	sh := stake.NewStakeHandler(sk)
 	got := sh(ctx, NewTestMsgCreateValidator(addr, val, sdk.NewDecWithoutFra(amt).RawInt()))
 	require.True(t, got.IsOK())
 	validatorUpdates := stake.EndBlocker(ctx, sk)
@@ -383,7 +383,7 @@ func TestValidatorDippingInAndOut(t *testing.T) {
 	amtInt := int64(100)
 	addr, val, amt := addrs[0], pks[0], amtInt
 	consAddr := sdk.ConsAddress(addr)
-	sh := stake.NewHandler(sk)
+	sh := stake.NewStakeHandler(sk)
 	got := sh(ctx, NewTestMsgCreateValidator(addr, val, sdk.NewDecWithoutFra(amt).RawInt()))
 	require.True(t, got.IsOK())
 	validatorUpdates := stake.EndBlocker(ctx, sk)

--- a/x/slashing/tick_test.go
+++ b/x/slashing/tick_test.go
@@ -17,7 +17,7 @@ func TestBeginBlocker(t *testing.T) {
 	addr, pk, amt := addrs[2], pks[2], sdk.NewDecWithoutFra(100).RawInt()
 
 	// bond the validator
-	got := stake.NewHandler(sk)(ctx, NewTestMsgCreateValidator(addr, pk, amt))
+	got := stake.NewStakeHandler(sk)(ctx, NewTestMsgCreateValidator(addr, pk, amt))
 	require.True(t, got.IsOK())
 	validatorUpdates := stake.EndBlocker(ctx, sk)
 	keeper.AddValidators(ctx, validatorUpdates)

--- a/x/stake/app_test.go
+++ b/x/stake/app_test.go
@@ -29,7 +29,7 @@ func getMockApp(t *testing.T) (*mock.App, Keeper) {
 
 	keeper := NewKeeper(mApp.Cdc, keyStake, tkeyStake, bankKeeper, pk.Subspace(DefaultParamspace), mApp.RegisterCodespace(DefaultCodespace))
 
-	mApp.Router().AddRoute("stake", NewHandler(keeper))
+	mApp.Router().AddRoute("stake", NewStakeHandler(keeper))
 	mApp.SetEndBlocker(getEndBlocker(keeper))
 	mApp.SetInitChainer(getInitChainer(mApp, keeper))
 

--- a/x/stake/client/cli/flags.go
+++ b/x/stake/client/cli/flags.go
@@ -30,6 +30,8 @@ const (
 	FlagNodeID        = "node-id"
 	FlagIP            = "ip"
 
+	FlagProposalID = "proposal-id"
+
 	FlagOutputDocument = "output-document" // inspired by wget -O
 )
 

--- a/x/stake/simulation/msgs.go
+++ b/x/stake/simulation/msgs.go
@@ -16,7 +16,7 @@ import (
 
 // SimulateMsgCreateValidator
 func SimulateMsgCreateValidator(m auth.AccountKeeper, k stake.Keeper) simulation.Operation {
-	handler := stake.NewHandler(k)
+	handler := stake.NewStakeHandler(k)
 	return func(r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context,
 		accs []simulation.Account, event func(string)) (
 		action string, fOp []simulation.FutureOperation, err error) {
@@ -73,7 +73,7 @@ func SimulateMsgCreateValidator(m auth.AccountKeeper, k stake.Keeper) simulation
 
 // SimulateMsgEditValidator
 func SimulateMsgEditValidator(k stake.Keeper) simulation.Operation {
-	handler := stake.NewHandler(k)
+	handler := stake.NewStakeHandler(k)
 	return func(r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context,
 		accs []simulation.Account, event func(string)) (
 		action string, fOp []simulation.FutureOperation, err error) {
@@ -113,7 +113,7 @@ func SimulateMsgEditValidator(k stake.Keeper) simulation.Operation {
 
 // SimulateMsgDelegate
 func SimulateMsgDelegate(m auth.AccountKeeper, k stake.Keeper) simulation.Operation {
-	handler := stake.NewHandler(k)
+	handler := stake.NewStakeHandler(k)
 	return func(r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context,
 		accs []simulation.Account, event func(string)) (
 		action string, fOp []simulation.FutureOperation, err error) {
@@ -151,7 +151,7 @@ func SimulateMsgDelegate(m auth.AccountKeeper, k stake.Keeper) simulation.Operat
 
 // SimulateMsgBeginUnbonding
 func SimulateMsgBeginUnbonding(m auth.AccountKeeper, k stake.Keeper) simulation.Operation {
-	handler := stake.NewHandler(k)
+	handler := stake.NewStakeHandler(k)
 	return func(r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context,
 		accs []simulation.Account, event func(string)) (
 		action string, fOp []simulation.FutureOperation, err error) {
@@ -189,7 +189,7 @@ func SimulateMsgBeginUnbonding(m auth.AccountKeeper, k stake.Keeper) simulation.
 
 // SimulateMsgBeginRedelegate
 func SimulateMsgBeginRedelegate(m auth.AccountKeeper, k stake.Keeper) simulation.Operation {
-	handler := stake.NewHandler(k)
+	handler := stake.NewStakeHandler(k)
 	return func(r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context,
 		accs []simulation.Account, event func(string)) (
 		action string, fOp []simulation.FutureOperation, err error) {

--- a/x/stake/simulation/sim_test.go
+++ b/x/stake/simulation/sim_test.go
@@ -35,7 +35,7 @@ func TestStakeWithRandomMessages(t *testing.T) {
 	paramstore := params.NewKeeper(mapp.Cdc, paramsKey, paramsTKey)
 	stakeKeeper := stake.NewKeeper(mapp.Cdc, stakeKey, stakeTKey, bankKeeper, paramstore.Subspace(stake.DefaultParamspace), stake.DefaultCodespace)
 	distrKeeper := distribution.NewKeeper(mapp.Cdc, distrKey, paramstore.Subspace(distribution.DefaultParamspace), bankKeeper, stakeKeeper, feeCollectionKeeper, distribution.DefaultCodespace)
-	mapp.Router().AddRoute("stake", stake.NewHandler(stakeKeeper))
+	mapp.Router().AddRoute("stake", stake.NewStakeHandler(stakeKeeper))
 	mapp.SetEndBlocker(func(ctx sdk.Context, req abci.RequestEndBlock) abci.ResponseEndBlock {
 		validatorUpdates := stake.EndBlocker(ctx, stakeKeeper)
 		return abci.ResponseEndBlock{

--- a/x/stake/stake.go
+++ b/x/stake/stake.go
@@ -9,24 +9,25 @@ import (
 )
 
 type (
-	Keeper               = keeper.Keeper
-	Validator            = types.Validator
-	Description          = types.Description
-	Commission           = types.Commission
-	Delegation           = types.Delegation
-	UnbondingDelegation  = types.UnbondingDelegation
-	Redelegation         = types.Redelegation
-	Params               = types.Params
-	Pool                 = types.Pool
-	MsgCreateValidator   = types.MsgCreateValidator
-	MsgEditValidator     = types.MsgEditValidator
-	MsgDelegate          = types.MsgDelegate
-	MsgBeginUnbonding    = types.MsgBeginUnbonding
-	MsgBeginRedelegate   = types.MsgBeginRedelegate
-	GenesisState         = types.GenesisState
-	QueryDelegatorParams = querier.QueryDelegatorParams
-	QueryValidatorParams = querier.QueryValidatorParams
-	QueryBondsParams     = querier.QueryBondsParams
+	Keeper                     = keeper.Keeper
+	Validator                  = types.Validator
+	Description                = types.Description
+	Commission                 = types.Commission
+	Delegation                 = types.Delegation
+	UnbondingDelegation        = types.UnbondingDelegation
+	Redelegation               = types.Redelegation
+	Params                     = types.Params
+	Pool                       = types.Pool
+	MsgCreateValidator         = types.MsgCreateValidator
+	MsgCreateValidatorProposal = types.MsgCreateValidatorProposal
+	MsgEditValidator           = types.MsgEditValidator
+	MsgDelegate                = types.MsgDelegate
+	MsgBeginUnbonding          = types.MsgBeginUnbonding
+	MsgBeginRedelegate         = types.MsgBeginRedelegate
+	GenesisState               = types.GenesisState
+	QueryDelegatorParams       = querier.QueryDelegatorParams
+	QueryValidatorParams       = querier.QueryValidatorParams
+	QueryBondsParams           = querier.QueryBondsParams
 )
 
 var (
@@ -117,6 +118,7 @@ var (
 	ErrValidatorOwnerExists  = types.ErrValidatorOwnerExists
 	ErrValidatorPubKeyExists = types.ErrValidatorPubKeyExists
 	ErrValidatorJailed       = types.ErrValidatorJailed
+	ErrInvalidProposal       = types.ErrInvalidProposal
 	ErrBadRemoveValidator    = types.ErrBadRemoveValidator
 	ErrDescriptionLength     = types.ErrDescriptionLength
 	ErrCommissionNegative    = types.ErrCommissionNegative

--- a/x/stake/types/codec.go
+++ b/x/stake/types/codec.go
@@ -7,6 +7,7 @@ import (
 // Register concrete types on codec codec
 func RegisterCodec(cdc *codec.Codec) {
 	cdc.RegisterConcrete(MsgCreateValidator{}, "cosmos-sdk/MsgCreateValidator", nil)
+	cdc.RegisterConcrete(MsgCreateValidatorProposal{}, "cosmos-sdk/MsgCreateValidatorProposal", nil)
 	cdc.RegisterConcrete(MsgEditValidator{}, "cosmos-sdk/MsgEditValidator", nil)
 	cdc.RegisterConcrete(MsgDelegate{}, "cosmos-sdk/MsgDelegate", nil)
 	cdc.RegisterConcrete(MsgBeginUnbonding{}, "cosmos-sdk/BeginUnbonding", nil)

--- a/x/stake/types/commission.go
+++ b/x/stake/types/commission.go
@@ -34,6 +34,12 @@ func NewCommissionMsg(rate, maxRate, maxChangeRate sdk.Dec) CommissionMsg {
 	}
 }
 
+func (c CommissionMsg) Equal(c2 CommissionMsg) bool {
+	return c.Rate.Equal(c2.Rate) &&
+		c.MaxRate.Equal(c2.MaxRate) &&
+		c.MaxChangeRate.Equal(c2.MaxChangeRate)
+}
+
 // NewCommission returns an initialized validator commission.
 func NewCommission(rate, maxRate, maxChangeRate sdk.Dec) Commission {
 	return Commission{

--- a/x/stake/types/errors.go
+++ b/x/stake/types/errors.go
@@ -17,6 +17,7 @@ const (
 	CodeInvalidDelegation CodeType = 102
 	CodeInvalidInput      CodeType = 103
 	CodeValidatorJailed   CodeType = 104
+	CodeInvalidProposal   CodeType = 105
 	CodeInvalidAddress    CodeType = sdk.CodeInvalidAddress
 	CodeUnauthorized      CodeType = sdk.CodeUnauthorized
 	CodeInternal          CodeType = sdk.CodeInternal
@@ -179,4 +180,8 @@ func ErrNeitherShareMsgsGiven(codespace sdk.CodespaceType) sdk.Error {
 
 func ErrMissingSignature(codespace sdk.CodespaceType) sdk.Error {
 	return sdk.NewError(codespace, CodeInvalidValidator, "missing signature")
+}
+
+func ErrInvalidProposal(codespace sdk.CodespaceType, reason string) sdk.Error {
+	return sdk.NewError(codespace, CodeInvalidProposal, "invalid proposal: %s", reason)
 }

--- a/x/stake/types/msg.go
+++ b/x/stake/types/msg.go
@@ -25,6 +25,11 @@ type MsgCreateValidator struct {
 	Delegation    sdk.Coin       `json:"delegation"`
 }
 
+type MsgCreateValidatorProposal struct {
+	MsgCreateValidator
+	ProposalId int64 `json:"proposal_id"`
+}
+
 // Default way to create validator. Delegator address and validator address are the same
 func NewMsgCreateValidator(valAddr sdk.ValAddress, pubkey crypto.PubKey,
 	selfDelegation sdk.Coin, description Description, commission CommissionMsg) MsgCreateValidator {
@@ -104,6 +109,18 @@ func (msg MsgCreateValidator) ValidateBasic() sdk.Error {
 	}
 
 	return nil
+}
+
+func (msg MsgCreateValidator) Equals(other MsgCreateValidator) bool {
+	if !msg.Commission.Equal(other.Commission) {
+		return false
+	}
+
+	return msg.Delegation.IsEqual(other.Delegation) &&
+		msg.DelegatorAddr.Equals(other.DelegatorAddr) &&
+		msg.ValidatorAddr.Equals(other.ValidatorAddr) &&
+		msg.PubKey.Equals(other.PubKey) &&
+		msg.Description.Equals(other.Description)
 }
 
 //______________________________________________________________________

--- a/x/stake/types/validator.go
+++ b/x/stake/types/validator.go
@@ -287,6 +287,13 @@ func (d Description) UpdateDescription(d2 Description) (Description, sdk.Error) 
 	}.EnsureLength()
 }
 
+func (d Description) Equals(d2 Description) bool {
+	return d.Details == d2.Details &&
+		d.Identity == d2.Identity &&
+		d.Moniker == d2.Moniker &&
+		d.Website == d2.Website
+}
+
 // EnsureLength ensures the length of a validator's description.
 func (d Description) EnsureLength() (Description, sdk.Error) {
 	if len(d.Moniker) > 70 {


### PR DESCRIPTION
### Description

The CreateValidator tx will send a proposal and need gov approve.

### Rationale

https://github.com/BiJie/BinanceChain/issues/316

### Example

**Proposal:**
> cli create-validator [parameters]

**After voting**
> cli create-validator --proposal-id=x [parameters]

### Changes

Notable changes: 
* add a parameter `proposal-id` in the CreateValidator cmd to indicate whether to create a proposal or send the actual CreateValidator tx.
* check the proposal before handling the MsgCreateValidator

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...


