### PR TITLE
[R4R] types/coin: allow tx hash suffix on coin denom

### DIFF
--- a/types/coin.go
+++ b/types/coin.go
@@ -285,10 +285,11 @@ func (coins Coins) Sort() Coins {
 // Parsing
 
 var (
-	// Denominations can be 3 ~ 16 characters long.
-	reDnm  = `[[:alnum:]]{3,16}`
+	// Denominations can be 3 ~ 10 characters long (8 + .B suffix).
+	// Extra token symbol tx hash suffix can be 2 ~ 6 characters long.
 	reAmt  = `[[:digit:]]+`
 	reSpc  = `\:`
+	reDnm  = `[[:alnum:]]{3,8}(\.[[:alpha:]])?(-[0-9A-Z]{2,6})?`
 	reCoin = regexp.MustCompile(fmt.Sprintf(`^(%s)%s(%s)$`, reAmt, reSpc, reDnm))
 )
 

--- a/types/coin_test.go
+++ b/types/coin_test.go
@@ -294,6 +294,10 @@ func TestParse(t *testing.T) {
 		{"", true, nil},
 		{"1:foo", true, Coins{{"foo", one}}},
 		{"10:bar", true, Coins{{"bar", 10}}},
+		{"10:bar.B", true, Coins{{"bar.B", 10}}},
+		{"10:bar-1B", true, Coins{{"bar-1B", 10}}},
+		{"10:bar-1BCDEF", true, Coins{{"bar-1BCDEF", 10}}},
+		{"10:bar.B-1BCDEF", true, Coins{{"bar.B-1BCDEF", 10}}},
 		{"99:bar,1:foo", true, Coins{{"bar", 99}, {"foo", one}}},
 		{"98:bar , 1:foo  ", true, Coins{{"bar", 98}, {"foo", one}}},
 		{"  55:bling\n", true, Coins{{"bling", 55}}},
@@ -303,6 +307,7 @@ func TestParse(t *testing.T) {
 		{"11me:coin, 12you:coin", false, nil},                     // no spaces in coin names
 		{"1.2:btc", false, nil},                                   // amount must be integer
 		{"5:foo-bar", false, nil},                                 // once more, only letters in coin name
+		{"5:foo-12BCDEF", false, nil},                             // incorrect tx suffix lens
 	}
 
 	for tcIndex, tc := range cases {


### PR DESCRIPTION
Changes the coin denom regex to allow for an optional 6 char hex prefix on the end. Some valid coin denoms are now: `BNB`, `BNB.B`, `BTC-ABCDEF`, `BTC.B-ABCDEF`.

The max denom symbol length has been changed to `8` to match the Binance Chain spec.

See the "Issuance" part of the spec for more info.

This is for BiJie/BinanceChain#344 and should be merged together, but this can be merged first with no problems