### PR TITLE
export runTx/reRunTx methods in baseapp

### DIFF
--- a/baseapp/helpers.go
+++ b/baseapp/helpers.go
@@ -4,22 +4,26 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/tendermint/tendermint/abci/server"
 	abci "github.com/tendermint/tendermint/abci/types"
+	"github.com/tendermint/tendermint/crypto/tmhash"
 	cmn "github.com/tendermint/tendermint/libs/common"
 )
 
 // nolint - Mostly for testing
 func (app *BaseApp) Check(tx sdk.Tx) (result sdk.Result) {
-	return app.runTx(sdk.RunTxModeCheck, nil, tx)
+	txHash := cmn.HexBytes(tmhash.Sum(nil)).String()
+	return app.RunTx(sdk.RunTxModeCheck, nil, tx, txHash)
 }
 
 // nolint - full tx execution
 func (app *BaseApp) Simulate(tx sdk.Tx) (result sdk.Result) {
-	return app.runTx(sdk.RunTxModeSimulate, nil, tx)
+	txHash := cmn.HexBytes(tmhash.Sum(nil)).String()
+	return app.RunTx(sdk.RunTxModeSimulate, nil, tx, txHash)
 }
 
 // nolint
 func (app *BaseApp) Deliver(tx sdk.Tx) (result sdk.Result) {
-	return app.runTx(sdk.RunTxModeDeliver, nil, tx)
+	txHash := cmn.HexBytes(tmhash.Sum(nil)).String()
+	return app.RunTx(sdk.RunTxModeDeliver, nil, tx, txHash)
 }
 
 // RunForever - BasecoinApp execution and cleanup


### PR DESCRIPTION
### Description

export runTx/reRunTx to make the app easily override the CheckTx/DeliverTx

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

