### PR TITLE
use ParseInt instead of Atoi

### DIFF
--- a/types/coin.go
+++ b/types/coin.go
@@ -305,12 +305,12 @@ func ParseCoin(coinStr string) (coin Coin, err error) {
 	}
 	denomStr, amountStr := matches[2], matches[1]
 
-	amount, err := strconv.Atoi(amountStr)
+	amount, err := strconv.ParseInt(amountStr, 10, 64)
 	if err != nil {
 		return
 	}
 
-	return Coin{denomStr, int64(amount)}, nil
+	return Coin{denomStr, amount}, nil
 }
 
 // ParseCoins will parse out a list of coins separated by commas.


### PR DESCRIPTION
### Description

Ref: #44 

### Rationale



### Example



### Changes

Notable changes: 
* use ParseInt instead of Atoi


### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [ ] integration tests passed (`make integration_test`)
- [ ] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

