### PR TITLE
register seq-abci flag

### DIFF
--- a/server/start.go
+++ b/server/start.go
@@ -47,6 +47,7 @@ func StartCmd(ctx *Context, appCreator AppCreator) *cobra.Command {
 	cmd.Flags().Bool(flagWithTendermint, true, "Run abci app embedded in-process with tendermint")
 	cmd.Flags().String(flagAddress, "tcp://0.0.0.0:26658", "Listen address")
 	cmd.Flags().String(flagTraceStore, "", "Enable KVStore tracing to an output file")
+	cmd.Flags().Bool(flagSequentialABCI, false, "Run abci app in sync mode")
 	cmd.Flags().String(flagPruning, "syncable", "Pruning strategy: syncable, nothing, everything")
 
 	// add support for all Tendermint-specific command line options


### PR DESCRIPTION
otherwise we cannot disable async client on command line