### PR TITLE
#49 async_local_client lock may not release in case of panic

### DIFF
--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -543,6 +543,7 @@ func (app *BaseApp) CheckTx(txBytes []byte) (res abci.ResponseCheckTx) {
 	tx, ok := app.GetTxFromCache(txBytes)
 	if ok {
 		txHash := cmn.HexBytes(tmhash.Sum(txBytes)).String()
+		app.Logger.Debug("Handle CheckTx", "Tx", txHash)
 		result = app.RunTx(sdk.RunTxModeCheckAfterPre, txBytes, tx, txHash)
 	} else {
 		tx, err := app.TxDecoder(txBytes)
@@ -551,6 +552,7 @@ func (app *BaseApp) CheckTx(txBytes []byte) (res abci.ResponseCheckTx) {
 		} else {
 			app.txMsgCache.Add(string(txBytes), tx) // for recheck
 			txHash := cmn.HexBytes(tmhash.Sum(txBytes)).String()
+			app.Logger.Debug("Handle CheckTx", "Tx", txHash)
 			result = app.RunTx(sdk.RunTxModeCheck, txBytes, tx, txHash)
 		}
 	}
@@ -569,7 +571,7 @@ func (app *BaseApp) CheckTx(txBytes []byte) (res abci.ResponseCheckTx) {
 
 func (app *BaseApp) preCheck(txBytes []byte, mode sdk.RunTxMode) sdk.Result {
 	var res sdk.Result
-	if app.preChecker != nil {
+	if app.preChecker != nil && !app.txMsgCache.Contains(string(txBytes)) {
 		var tx, err = app.TxDecoder(txBytes)
 		if err != nil {
 			res = err.Result()
@@ -630,6 +632,7 @@ func (app *BaseApp) DeliverTx(txBytes []byte) (res abci.ResponseDeliverTx) {
 		// here means either the tx has passed PreDeliverTx or CheckTx,
 		// no need to verify signature
 		txHash := cmn.HexBytes(tmhash.Sum(txBytes)).String()
+		app.Logger.Debug("Handle DeliverTx", "Tx", txHash)
 		result = app.RunTx(sdk.RunTxModeDeliverAfterPre, txBytes, tx, txHash)
 	} else {
 		var tx, err = app.TxDecoder(txBytes)
@@ -637,6 +640,7 @@ func (app *BaseApp) DeliverTx(txBytes []byte) (res abci.ResponseDeliverTx) {
 			result = err.Result()
 		} else {
 			txHash := cmn.HexBytes(tmhash.Sum(txBytes)).String()
+			app.Logger.Debug("Handle DeliverTx", "Tx", txHash)
 			result = app.RunTx(sdk.RunTxModeDeliver, txBytes, tx, txHash)
 		}
 	}

--- a/server/concurrent/async_local_client_test.go
+++ b/server/concurrent/async_local_client_test.go
@@ -104,7 +104,7 @@ func TestNewAsyncLocalClient(t *testing.T) {
 	cli.SetResponseCallback(func(*types.Request, *types.Response) {})
 	assert.NotNil(cli, "Failed to create AsyncLocalClient")
 	tx := make([]byte, 8)
-	// if all are sequential, it needs 800ms
+	// if all are sequential, it needs 300ms
 	expectStop := time.Now().Add(time.Millisecond * 300)
 	nonExpectShort := time.Now().Add(time.Millisecond * 25)
 	for i := 0; i < 2; i++ {

--- a/server/start.go
+++ b/server/start.go
@@ -5,6 +5,8 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
+	"github.com/cosmos/cosmos-sdk/server/concurrent"
+
 	"github.com/tendermint/tendermint/abci/server"
 	tcmd "github.com/tendermint/tendermint/cmd/tendermint/commands"
 	cmn "github.com/tendermint/tendermint/libs/common"
@@ -12,8 +14,6 @@ import (
 	"github.com/tendermint/tendermint/p2p"
 	pvm "github.com/tendermint/tendermint/privval"
 	"github.com/tendermint/tendermint/proxy"
-
-	"github.com/cosmos/cosmos-sdk/server/concurrent"
 )
 
 const (


### PR DESCRIPTION
For #49 

main changes:

1. defer unlock
2. enhance log with txHash (previous first 7 bytes of txBytes are almost same)
3. skip prechecker if tx already in txCache

All are come from comments of https://github.com/binance-chain/bnc-cosmos-sdk/pull/28, marked thumb of coped comments