### PR TITLE
[R4R]add interest txs to pool

### DIFF
--- a/baseapp/baseapp_test.go
+++ b/baseapp/baseapp_test.go
@@ -37,7 +37,7 @@ func newBaseApp(name string, options ...func(*BaseApp)) *BaseApp {
 	db := dbm.NewMemDB()
 	codec := codec.New()
 	registerTestCodec(codec)
-	return NewBaseApp(name, logger, db, testTxDecoder(codec), false, options...)
+	return NewBaseApp(name, logger, db, testTxDecoder(codec), sdk.CollectConfig{}, options...)
 }
 
 func registerTestCodec(cdc *codec.Codec) {
@@ -101,8 +101,8 @@ func (app *MockBaseApp) initFromStore(mainKey sdk.StoreKey) error {
 	return nil
 }
 
-func NewMockBaseApp(name string, logger log.Logger, db dbm.DB, txDecoder sdk.TxDecoder, isPublish bool, options ...func(*BaseApp)) *MockBaseApp {
-	return &MockBaseApp{NewBaseApp(name, logger, db, txDecoder, isPublish, options...)}
+func NewMockBaseApp(name string, logger log.Logger, db dbm.DB, txDecoder sdk.TxDecoder, collect sdk.CollectConfig, options ...func(*BaseApp)) *MockBaseApp {
+	return &MockBaseApp{NewBaseApp(name, logger, db, txDecoder, collect, options...)}
 }
 
 //------------------------------------------------------------------------------------------
@@ -124,7 +124,7 @@ func TestLoadVersion(t *testing.T) {
 	logger := defaultLogger()
 	db := dbm.NewMemDB()
 	name := t.Name()
-	app := NewMockBaseApp(name, logger, db, nil, false)
+	app := NewMockBaseApp(name, logger, db, nil, sdk.CollectConfig{})
 
 	// make a cap key and mount the store
 	capKey := sdk.NewKVStoreKey("main")
@@ -153,7 +153,7 @@ func TestLoadVersion(t *testing.T) {
 	commitID2 := sdk.CommitID{2, res.Data}
 
 	// reload with LoadLatestVersion
-	app = NewMockBaseApp(name, logger, db, nil, false)
+	app = NewMockBaseApp(name, logger, db, nil, sdk.CollectConfig{})
 	app.MountStoresIAVL(capKey)
 	err = app.LoadLatestVersion(capKey)
 	require.Nil(t, err)
@@ -161,7 +161,7 @@ func TestLoadVersion(t *testing.T) {
 
 	// reload with LoadVersion, see if you can commit the same block and get
 	// the same result
-	app = NewMockBaseApp(name, logger, db, nil, false)
+	app = NewMockBaseApp(name, logger, db, nil, sdk.CollectConfig{})
 	app.MountStoresIAVL(capKey)
 	err = app.LoadVersion(1, capKey)
 	require.Nil(t, err)
@@ -181,7 +181,7 @@ func testLoadVersionHelper(t *testing.T, app *MockBaseApp, expectedHeight int64,
 func TestOptionFunction(t *testing.T) {
 	logger := defaultLogger()
 	db := dbm.NewMemDB()
-	bap := NewMockBaseApp("starting name", logger, db, nil, false, testChangeNameHelper("new name"))
+	bap := NewMockBaseApp("starting name", logger, db, nil, sdk.CollectConfig{}, testChangeNameHelper("new name"))
 	require.Equal(t, bap.name, "new name", "BaseApp should have had name changed via option function")
 }
 
@@ -253,7 +253,7 @@ func TestInitChainer(t *testing.T) {
 	// we can reload the same  app later
 	db := dbm.NewMemDB()
 	logger := defaultLogger()
-	app := NewMockBaseApp(name, logger, db, nil, false)
+	app := NewMockBaseApp(name, logger, db, nil, sdk.CollectConfig{})
 	capKey := sdk.NewKVStoreKey("main")
 	capKey2 := sdk.NewKVStoreKey("key2")
 	app.MountStoresIAVL(capKey, capKey2)
@@ -297,7 +297,7 @@ func TestInitChainer(t *testing.T) {
 	require.Equal(t, value, res.Value)
 
 	// reload app
-	app = NewMockBaseApp(name, logger, db, nil, false)
+	app = NewMockBaseApp(name, logger, db, nil, sdk.CollectConfig{})
 	app.SetInitChainer(initChainer)
 	app.MountStoresIAVL(capKey, capKey2)
 	err = app.LoadLatestVersion(capKey) // needed to make stores non-nil

--- a/cmd/gaia/app/app.go
+++ b/cmd/gaia/app/app.go
@@ -75,7 +75,7 @@ type GaiaApp struct {
 func NewGaiaApp(logger log.Logger, db dbm.DB, traceStore io.Writer, baseAppOptions ...func(*bam.BaseApp)) *GaiaApp {
 	cdc := MakeCodec()
 
-	bApp := bam.NewBaseApp(appName, logger, db, auth.DefaultTxDecoder(cdc), false, baseAppOptions...)
+	bApp := bam.NewBaseApp(appName, logger, db, auth.DefaultTxDecoder(cdc), sdk.CollectConfig{}, baseAppOptions...)
 	bApp.SetCommitMultiStoreTracer(traceStore)
 
 	var app = &GaiaApp{

--- a/cmd/gaia/app/app_test.go
+++ b/cmd/gaia/app/app_test.go
@@ -34,7 +34,7 @@ type MockGaiaApp struct {
 func NewMockGaiaApp(logger log.Logger, db dbm.DB, traceStore io.Writer, baseAppOptions ...func(*bam.BaseApp)) *MockGaiaApp {
 	cdc := MakeCodec()
 
-	bApp := bam.NewBaseApp(appName, logger, db, auth.DefaultTxDecoder(cdc), false, baseAppOptions...)
+	bApp := bam.NewBaseApp(appName, logger, db, auth.DefaultTxDecoder(cdc), sdk.CollectConfig{}, baseAppOptions...)
 	bApp.SetCommitMultiStoreTracer(traceStore)
 
 	gApp := &GaiaApp{

--- a/cmd/gaia/cmd/gaiadebug/hack.go
+++ b/cmd/gaia/cmd/gaiadebug/hack.go
@@ -148,7 +148,7 @@ type GaiaApp struct {
 func NewGaiaApp(logger log.Logger, db dbm.DB, baseAppOptions ...func(*bam.BaseApp)) *GaiaApp {
 	cdc := MakeCodec()
 
-	bApp := bam.NewBaseApp(appName, logger, db, auth.DefaultTxDecoder(cdc), false, baseAppOptions...)
+	bApp := bam.NewBaseApp(appName, logger, db, auth.DefaultTxDecoder(cdc), sdk.CollectConfig{}, baseAppOptions...)
 	bApp.SetCommitMultiStoreTracer(os.Stdout)
 
 	// create your application object

--- a/docs/sdk/core/examples/app1.go
+++ b/docs/sdk/core/examples/app1.go
@@ -18,7 +18,7 @@ const (
 func NewApp1(logger log.Logger, db dbm.DB) *bapp.BaseApp {
 
 	// Create the base application object.
-	app := bapp.NewBaseApp(app1Name, logger, db, tx1Decoder, false)
+	app := bapp.NewBaseApp(app1Name, logger, db, tx1Decoder, sdk.CollectConfig{})
 
 	// Create a key for accessing the account store.
 	keyAccount := sdk.NewKVStoreKey("acc")

--- a/docs/sdk/core/examples/app2.go
+++ b/docs/sdk/core/examples/app2.go
@@ -39,7 +39,7 @@ func NewApp2(logger log.Logger, db dbm.DB) *bapp.BaseApp {
 	cdc := NewCodec()
 
 	// Create the base application object.
-	app := bapp.NewBaseApp(app2Name, logger, db, tx2Decoder(cdc), false)
+	app := bapp.NewBaseApp(app2Name, logger, db, tx2Decoder(cdc), sdk.CollectConfig{})
 
 	// Create a key for accessing the account store.
 	keyAccount := sdk.NewKVStoreKey("acc")

--- a/docs/sdk/core/examples/app3.go
+++ b/docs/sdk/core/examples/app3.go
@@ -23,7 +23,7 @@ func NewApp3(logger log.Logger, db dbm.DB) *bapp.BaseApp {
 	cdc := UpdatedCodec()
 
 	// Create the base application object.
-	app := bapp.NewBaseApp(app3Name, logger, db, auth.DefaultTxDecoder(cdc), false)
+	app := bapp.NewBaseApp(app3Name, logger, db, auth.DefaultTxDecoder(cdc), sdk.CollectConfig{})
 
 	// Create a key for accessing the account store.
 	keyAccount := sdk.NewKVStoreKey("acc")

--- a/docs/sdk/core/examples/app4.go
+++ b/docs/sdk/core/examples/app4.go
@@ -22,7 +22,7 @@ func NewApp4(logger log.Logger, db dbm.DB) *bapp.BaseApp {
 	cdc := UpdatedCodec()
 
 	// Create the base application object.
-	app := bapp.NewBaseApp(app4Name, logger, db, auth.DefaultTxDecoder(cdc), false)
+	app := bapp.NewBaseApp(app4Name, logger, db, auth.DefaultTxDecoder(cdc), sdk.CollectConfig{})
 
 	// Create a key for accessing the account store.
 	keyAccount := sdk.NewKVStoreKey("acc")

--- a/server/mock/app.go
+++ b/server/mock/app.go
@@ -30,7 +30,7 @@ func NewApp(rootDir string, logger log.Logger) (abci.Application, error) {
 	capKeyMainStore := sdk.NewKVStoreKey("main")
 
 	// Create BaseApp.
-	baseApp := bam.NewBaseApp("kvstore", logger, db, decodeTx, false)
+	baseApp := bam.NewBaseApp("kvstore", logger, db, decodeTx, sdk.CollectConfig{})
 
 	// Set mounts for BaseApp's MultiStore.
 	baseApp.MountStoresIAVL(capKeyMainStore)

--- a/types/config.go
+++ b/types/config.go
@@ -103,3 +103,9 @@ func (config *Config) GetBech32ValidatorPubPrefix() string {
 func (config *Config) GetBech32ConsensusPubPrefix() string {
 	return config.bech32AddressPrefix["consensus_pub"]
 }
+
+// CollectConfig is the structure that holds configuration parameters whether to collect specified info during apply blocks.
+type CollectConfig struct {
+	CollectAccountBalance bool
+	CollectTxs            bool
+}

--- a/types/pool.go
+++ b/types/pool.go
@@ -11,6 +11,15 @@ import (
 // deliver state
 type Pool struct {
 	accounts sync.Map // save tx/gov related addresses (string wrapped bytes) to be published
+	txs      sync.Map
+}
+
+func (p *Pool) AddTx(tx Tx, txHash string) {
+	p.txs.Store(txHash, tx)
+}
+
+func (p Pool) GetTxs() sync.Map{
+	return p.txs
 }
 
 func (p *Pool) AddAddrs(addrs []AccAddress) {
@@ -28,6 +37,7 @@ func (p Pool) TxRelatedAddrs() []string {
 	return addrs
 }
 
-func (p *Pool) ClearTxRelatedAddrs() {
+func (p *Pool) Clear() {
 	p.accounts = sync.Map{}
+	p.txs = sync.Map{}
 }

--- a/x/mock/app.go
+++ b/x/mock/app.go
@@ -49,7 +49,7 @@ func NewApp() *App {
 
 	// Create your application object
 	app := &App{
-		BaseApp:          bam.NewBaseApp("mock", logger, db, auth.DefaultTxDecoder(cdc), false),
+		BaseApp:          bam.NewBaseApp("mock", logger, db, auth.DefaultTxDecoder(cdc), sdk.CollectConfig{}),
 		Cdc:              cdc,
 		KeyMain:          sdk.NewKVStoreKey("main"),
 		KeyAccount:       sdk.NewKVStoreKey("acc"),


### PR DESCRIPTION
### Description
We give a option to witness node to publish transfer message to kafka.

### Rationale

we want to deploy a witness node in  Binance primary station for risk management.

Risk management need trade message and transfer message. The later one is not supported for now.

### Example



### Changes


### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [x] integration tests passed (`make integration_test`)
- [x] manual transaction test passed (cli invoke)

### Already reviewed by


### Related issues
https://github.com/binance-chain/node/pull/403

