### PR TITLE
[R4R] #62 functional pruning strategy implementation

### DIFF
--- a/baseapp/options.go
+++ b/baseapp/options.go
@@ -14,19 +14,20 @@ import (
 
 // SetPruning sets a pruning option on the multistore associated with the app
 func SetPruning(pruning string) func(*BaseApp) {
-	var pruningEnum sdk.PruningStrategy
+	var pruningStrategy sdk.PruningStrategy
 	switch pruning {
 	case "nothing":
-		pruningEnum = sdk.PruneNothing
+		pruningStrategy = sdk.PruneNothing{}
 	case "everything":
-		pruningEnum = sdk.PruneEverything
+		pruningStrategy = sdk.PruneEverything{}
 	case "syncable":
-		pruningEnum = sdk.PruneSyncable
+		// TODO: make these parameters configurable
+		pruningStrategy = sdk.PruneSyncable{NumRecent: 100, StoreEvery: 10000}
 	default:
 		panic(fmt.Sprintf("invalid pruning strategy: %s", pruning))
 	}
 	return func(bap *BaseApp) {
-		bap.cms.SetPruning(pruningEnum)
+		bap.cms.SetPruning(pruningStrategy)
 	}
 }
 

--- a/store/iavlstore_test.go
+++ b/store/iavlstore_test.go
@@ -47,7 +47,7 @@ func newTree(t *testing.T, db dbm.DB) (*iavl.MutableTree, CommitID) {
 func TestIAVLStoreGetSetHasDelete(t *testing.T) {
 	db := dbm.NewMemDB()
 	tree, _ := newTree(t, db)
-	iavlStore := newIAVLStore(tree, numRecent, storeEvery)
+	iavlStore := newIAVLStore(tree, sdk.PruneSyncable{numRecent, storeEvery})
 
 	key := "hello"
 
@@ -72,7 +72,7 @@ func TestIAVLStoreGetSetHasDelete(t *testing.T) {
 func TestIAVLIterator(t *testing.T) {
 	db := dbm.NewMemDB()
 	tree, _ := newTree(t, db)
-	iavlStore := newIAVLStore(tree, numRecent, storeEvery)
+	iavlStore := newIAVLStore(tree, sdk.PruneSyncable{numRecent, storeEvery})
 	iter := iavlStore.Iterator([]byte("aloha"), []byte("hellz"))
 	expected := []string{"aloha", "hello"}
 	var i int
@@ -145,7 +145,7 @@ func TestIAVLIterator(t *testing.T) {
 func TestIAVLSubspaceIterator(t *testing.T) {
 	db := dbm.NewMemDB()
 	tree, _ := newTree(t, db)
-	iavlStore := newIAVLStore(tree, numRecent, storeEvery)
+	iavlStore := newIAVLStore(tree, sdk.PruneSyncable{numRecent, storeEvery})
 
 	iavlStore.Set([]byte("test1"), []byte("test1"))
 	iavlStore.Set([]byte("test2"), []byte("test2"))
@@ -207,7 +207,7 @@ func TestIAVLSubspaceIterator(t *testing.T) {
 func TestIAVLReverseSubspaceIterator(t *testing.T) {
 	db := dbm.NewMemDB()
 	tree, _ := newTree(t, db)
-	iavlStore := newIAVLStore(tree, numRecent, storeEvery)
+	iavlStore := newIAVLStore(tree, sdk.PruneSyncable{numRecent, storeEvery})
 
 	iavlStore.Set([]byte("test1"), []byte("test1"))
 	iavlStore.Set([]byte("test2"), []byte("test2"))
@@ -326,7 +326,7 @@ type pruneState struct {
 func testPruning(t *testing.T, numRecent int64, storeEvery int64, states []pruneState) {
 	db := dbm.NewMemDB()
 	tree := iavl.NewMutableTree(db, cacheSize)
-	iavlStore := newIAVLStore(tree, numRecent, storeEvery)
+	iavlStore := newIAVLStore(tree, sdk.PruneSyncable{numRecent, storeEvery})
 	for step, state := range states {
 		for _, ver := range state.stored {
 			require.True(t, iavlStore.VersionExists(ver),
@@ -345,7 +345,7 @@ func testPruning(t *testing.T, numRecent int64, storeEvery int64, states []prune
 func TestIAVLNoPrune(t *testing.T) {
 	db := dbm.NewMemDB()
 	tree := iavl.NewMutableTree(db, cacheSize)
-	iavlStore := newIAVLStore(tree, numRecent, int64(1))
+	iavlStore := newIAVLStore(tree, sdk.PruneSyncable{numRecent, 1})
 	nextVersion(iavlStore)
 	for i := 1; i < 100; i++ {
 		for j := 1; j <= i; j++ {
@@ -360,7 +360,7 @@ func TestIAVLNoPrune(t *testing.T) {
 func TestIAVLPruneEverything(t *testing.T) {
 	db := dbm.NewMemDB()
 	tree := iavl.NewMutableTree(db, cacheSize)
-	iavlStore := newIAVLStore(tree, int64(0), int64(0))
+	iavlStore := newIAVLStore(tree, sdk.PruneEverything{})
 	nextVersion(iavlStore)
 	for i := 1; i < 100; i++ {
 		for j := 1; j < i; j++ {
@@ -378,7 +378,7 @@ func TestIAVLPruneEverything(t *testing.T) {
 func TestIAVLStoreQuery(t *testing.T) {
 	db := dbm.NewMemDB()
 	tree := iavl.NewMutableTree(db, cacheSize)
-	iavlStore := newIAVLStore(tree, numRecent, storeEvery)
+	iavlStore := newIAVLStore(tree, sdk.PruneSyncable{numRecent, storeEvery})
 
 	k1, v1 := []byte("key1"), []byte("val1")
 	k2, v2 := []byte("key2"), []byte("val2")
@@ -474,7 +474,7 @@ func BenchmarkIAVLIteratorNext(b *testing.B) {
 		value := cmn.RandBytes(50)
 		tree.Set(key, value)
 	}
-	iavlStore := newIAVLStore(tree, numRecent, storeEvery)
+	iavlStore := newIAVLStore(tree, sdk.PruneSyncable{numRecent, storeEvery})
 	iterators := make([]Iterator, b.N/treeSize)
 	for i := 0; i < len(iterators); i++ {
 		iterators[i] = iavlStore.Iterator([]byte{0}, []byte{255, 255, 255, 255, 255})

--- a/store/multistoreproof_test.go
+++ b/store/multistoreproof_test.go
@@ -13,7 +13,7 @@ import (
 func TestVerifyIAVLStoreQueryProof(t *testing.T) {
 	// Create main tree for testing.
 	db := dbm.NewMemDB()
-	iStore, err := LoadIAVLStore(db, CommitID{}, sdk.PruneNothing)
+	iStore, err := LoadIAVLStore(db, CommitID{}, sdk.PruneNothing{})
 	store := iStore.(*iavlStore)
 	require.Nil(t, err)
 	store.Set([]byte("MYKEY"), []byte("MYVALUE"))

--- a/store/prefixstore_test.go
+++ b/store/prefixstore_test.go
@@ -76,7 +76,7 @@ func testPrefixStore(t *testing.T, baseStore KVStore, prefix []byte) {
 func TestIAVLStorePrefix(t *testing.T) {
 	db := dbm.NewMemDB()
 	tree := iavl.NewMutableTree(db, cacheSize)
-	iavlStore := newIAVLStore(tree, numRecent, storeEvery)
+	iavlStore := newIAVLStore(tree, sdk.PruneSyncable{numRecent, storeEvery})
 
 	testPrefixStore(t, iavlStore, []byte("test"))
 }

--- a/store/rootmultistore.go
+++ b/store/rootmultistore.go
@@ -40,6 +40,7 @@ var _ Queryable = (*rootMultiStore)(nil)
 func NewCommitMultiStore(db dbm.DB) *rootMultiStore {
 	return &rootMultiStore{
 		db:           db,
+		pruning:      sdk.PruneNothing{},
 		storesParams: make(map[StoreKey]storeParams),
 		stores:       make(map[StoreKey]CommitStore),
 		keysByName:   make(map[string]StoreKey),


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺ 
v                            ✰  Thanks for opening an issue! ✰    
v    Before smashing the submit button please review the template.
v    Word of caution: poorly thought-out proposals may be rejected 
v                     without deliberation 
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  --> 

This PR is for issue #62 and only for easy review
Once this get approved, I will close this PR, cherry pick changes into https://github.com/binance-chain/bnc-cosmos-sdk/pull/61 and merge that one.


## Summary
<!-- Short, concise description of the proposed feature --> 
We need change existing pruning code
```
	// Release an old version of history, if not a sync waypoint.
	previous := version - 1
	if st.numRecent < previous {
		toRelease := previous - st.numRecent
		if st.storeEvery == 0 || toRelease%st.storeEvery != 0 {
			err := st.Tree.DeleteVersion(toRelease)
			if err != nil && err.(cmn.Error).Data() != iavl.ErrVersionDoesNotExist {
				panic(err)
			}
		}
	}
```

into proposal here https://docs.google.com/document/d/15MFsQtNA0MGBv7F096FFWRDzQ1vR6_dics5Y49vF8JU/edit?usp=sharing:
```
	type PruningStrategy interface {
		Prune(version, latestVersion uint64) bool
	}

	func (tree *VersionTree) Prune(ps PruningStrategy) {
	for _, v := tree.versions {
		if ps.Prune(v, tree.latestVersion) {
			tree.DeleteVersion(v)
		}
	}
```

To support more flexible app pruning logic. This is required by our application's state syncing. (we only save some state once per day, (height between two days might different), we need make those height syncable.

also proposed at https://github.com/cosmos/cosmos-sdk/issues/3480
____
#### For Admin Use
 - [ ] Not duplicate issue
 - [ ] Appropriate labels applied
 - [ ] Appropriate contributors tagged
 - [ ] Contributor assigned/self-assigned
