### PR TITLE
use go json to marshal MsgSend, remove MsgIssue

### DIFF
--- a/x/bank/codec.go
+++ b/x/bank/codec.go
@@ -7,7 +7,6 @@ import (
 // Register concrete types on codec codec
 func RegisterCodec(cdc *codec.Codec) {
 	cdc.RegisterConcrete(MsgSend{}, "cosmos-sdk/Send", nil)
-	cdc.RegisterConcrete(MsgIssue{}, "cosmos-sdk/Issue", nil)
 }
 
 var msgCdc = codec.New()

--- a/x/bank/handler.go
+++ b/x/bank/handler.go
@@ -10,8 +10,6 @@ func NewHandler(k Keeper) sdk.Handler {
 		switch msg := msg.(type) {
 		case MsgSend:
 			return handleMsgSend(ctx, k, msg)
-		case MsgIssue:
-			return handleMsgIssue(ctx, k, msg)
 		default:
 			errMsg := "Unrecognized bank Msg type: %s" + msg.Type()
 			return sdk.ErrUnknownRequest(errMsg).Result()
@@ -31,9 +29,4 @@ func handleMsgSend(ctx sdk.Context, k Keeper, msg MsgSend) sdk.Result {
 	return sdk.Result{
 		Tags: tags,
 	}
-}
-
-// Handle MsgIssue.
-func handleMsgIssue(ctx sdk.Context, k Keeper, msg MsgIssue) sdk.Result {
-	panic("not implemented yet")
 }

--- a/x/bank/msgs_test.go
+++ b/x/bank/msgs_test.go
@@ -187,7 +187,7 @@ func TestMsgSendGetSignBytes(t *testing.T) {
 	}
 	res := msg.GetSignBytes()
 
-	expected := `{"inputs":[{"address":"cosmos1d9h8qat57ljhcm","coins":[{"amount":"10","denom":"atom"}]}],"outputs":[{"address":"cosmos1da6hgur4wsmpnjyg","coins":[{"amount":"10","denom":"atom"}]}]}`
+	expected := `{"inputs":[{"address":"cosmos1d9h8qat57ljhcm","coins":[{"denom":"atom","amount":10}]}],"outputs":[{"address":"cosmos1da6hgur4wsmpnjyg","coins":[{"denom":"atom","amount":10}]}]}`
 	require.Equal(t, expected, string(res))
 }
 
@@ -223,48 +223,3 @@ func TestMsgSendSigners(t *testing.T) {
 	require.Equal(t, signers, tx.Signers())
 }
 */
-
-// ----------------------------------------
-// MsgIssue Tests
-
-func TestNewMsgIssue(t *testing.T) {
-	// TODO
-}
-
-func TestMsgIssueRoute(t *testing.T) {
-	// Construct an MsgIssue
-	addr := sdk.AccAddress([]byte("loan-from-bank"))
-	coins := sdk.Coins{sdk.NewCoin("atom", 10)}
-	var msg = MsgIssue{
-		Banker:  sdk.AccAddress([]byte("input")),
-		Outputs: []Output{NewOutput(addr, coins)},
-	}
-
-	// TODO some failures for bad result
-	require.Equal(t, msg.Route(), "bank")
-}
-
-func TestMsgIssueValidation(t *testing.T) {
-	// TODO
-}
-
-func TestMsgIssueGetSignBytes(t *testing.T) {
-	addr := sdk.AccAddress([]byte("loan-from-bank"))
-	coins := sdk.Coins{sdk.NewCoin("atom", 10)}
-	var msg = MsgIssue{
-		Banker:  sdk.AccAddress([]byte("input")),
-		Outputs: []Output{NewOutput(addr, coins)},
-	}
-	res := msg.GetSignBytes()
-
-	expected := `{"banker":"cosmos1d9h8qat57ljhcm","outputs":[{"address":"cosmos1d3hkzm3dveex7mfdvfsku6cjngpcj","coins":[{"amount":"10","denom":"atom"}]}]}`
-	require.Equal(t, expected, string(res))
-}
-
-func TestMsgIssueGetSigners(t *testing.T) {
-	var msg = MsgIssue{
-		Banker: sdk.AccAddress([]byte("onlyone")),
-	}
-	res := msg.GetSigners()
-	require.Equal(t, fmt.Sprintf("%v", res), "[6F6E6C796F6E65]")
-}

--- a/x/ibc/ibc_test.go
+++ b/x/ibc/ibc_test.go
@@ -50,7 +50,6 @@ func makeCodec() *codec.Codec {
 	// Register Msgs
 	cdc.RegisterInterface((*sdk.Msg)(nil), nil)
 	cdc.RegisterConcrete(bank.MsgSend{}, "test/ibc/Send", nil)
-	cdc.RegisterConcrete(bank.MsgIssue{}, "test/ibc/Issue", nil)
 	cdc.RegisterConcrete(IBCTransferMsg{}, "test/ibc/IBCTransferMsg", nil)
 	cdc.RegisterConcrete(IBCReceiveMsg{}, "test/ibc/IBCReceiveMsg", nil)
 

--- a/x/stake/keeper/test_common.go
+++ b/x/stake/keeper/test_common.go
@@ -58,7 +58,6 @@ func MakeTestCodec() *codec.Codec {
 	// Register Msgs
 	cdc.RegisterInterface((*sdk.Msg)(nil), nil)
 	cdc.RegisterConcrete(bank.MsgSend{}, "test/stake/Send", nil)
-	cdc.RegisterConcrete(bank.MsgIssue{}, "test/stake/Issue", nil)
 	cdc.RegisterConcrete(types.MsgCreateValidator{}, "test/stake/CreateValidator", nil)
 	cdc.RegisterConcrete(types.MsgEditValidator{}, "test/stake/EditValidator", nil)
 	cdc.RegisterConcrete(types.MsgBeginUnbonding{}, "test/stake/BeginUnbonding", nil)


### PR DESCRIPTION
### Description

The amino json marshaling will make the int64 as a string which is not consistent with go json marshaling. For all msgs except `MsgSend`, we used go json lib. So this PR will make all msgs have the same behavior.

Also, MsgIssue is removed by the new version of official cosmos-sdk.

### Rationale

### Example

### Changes

Notable changes: 
* remove MsgIssue
* replace amino json by go json when marshaling msgs.

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

