### PR TITLE
export iavlStore's tree

### DIFF
--- a/store/codec.go
+++ b/store/codec.go
@@ -11,6 +11,7 @@ type (
 	Store            = types.Store
 	Committer        = types.Committer
 	CommitStore      = types.CommitStore
+	TreeStore        = types.TreeStore
 	MultiStore       = types.MultiStore
 	CacheMultiStore  = types.CacheMultiStore
 	CommitMultiStore = types.CommitMultiStore

--- a/store/iavlstore.go
+++ b/store/iavlstore.go
@@ -66,6 +66,10 @@ func newIAVLStore(tree *iavl.MutableTree, numRecent int64, storeEvery int64) *ia
 	return st
 }
 
+func (st *iavlStore) GetImmutableTree() *iavl.ImmutableTree {
+	return st.tree.ImmutableTree
+}
+
 // Implements Committer.
 func (st *iavlStore) Commit() CommitID {
 	// Save a new version.

--- a/types/store.go
+++ b/types/store.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/tendermint/iavl"
 	abci "github.com/tendermint/tendermint/abci/types"
 	cmn "github.com/tendermint/tendermint/libs/common"
 	dbm "github.com/tendermint/tendermint/libs/db"
@@ -41,6 +42,10 @@ type Committer interface {
 type CommitStore interface {
 	Committer
 	Store
+}
+
+type TreeStore interface {
+	GetImmutableTree() *iavl.ImmutableTree
 }
 
 // Queryable allows a Store to expose internal state to the abci.Query


### PR DESCRIPTION
### Description

export the underlying tree of iavl store

### Rationale

for db tool use

### Example

### Changes

Notable changes: 
* 
* ...

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [ ] integration tests passed (`make integration_test`)
- [ ] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

