### PR TITLE
check address length

### DIFF
--- a/types/address.go
+++ b/types/address.go
@@ -50,6 +50,9 @@ func AccAddressFromHex(address string) (addr AccAddress, err error) {
 		return nil, err
 	}
 
+	if len(bz) != AddrLen {
+		return nil, fmt.Errorf("invalid address length, %s", address)
+	}
 	return AccAddress(bz), nil
 }
 
@@ -61,6 +64,9 @@ func AccAddressFromBech32(address string) (addr AccAddress, err error) {
 		return nil, err
 	}
 
+	if len(bz) != AddrLen {
+		return nil, fmt.Errorf("invalid address length, %s", address)
+	}
 	return AccAddress(bz), nil
 }
 

--- a/x/bank/msgs.go
+++ b/x/bank/msgs.go
@@ -96,7 +96,7 @@ type Input struct {
 
 // ValidateBasic - validate transaction input
 func (in Input) ValidateBasic() sdk.Error {
-	if len(in.Address) == 0 {
+	if len(in.Address) != sdk.AddrLen {
 		return sdk.ErrInvalidAddress(in.Address.String())
 	}
 	if !in.Coins.IsValid() {
@@ -128,7 +128,7 @@ type Output struct {
 
 // ValidateBasic - validate transaction output
 func (out Output) ValidateBasic() sdk.Error {
-	if len(out.Address) == 0 {
+	if len(out.Address) != sdk.AddrLen {
 		return sdk.ErrInvalidAddress(out.Address.String())
 	}
 	if !out.Coins.IsValid() {


### PR DESCRIPTION
### Description

always check the length of address

### Rationale

we have assumed the address length is 20 in many logics. like gov, stake, etc.

### Example

### Changes

Notable changes: 
* 

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [ ] integration tests passed (`make integration_test`)
- [ ] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

