### PR TITLE
[R4R] stake: add feeAddr for validator

### DIFF
--- a/x/stake/handler.go
+++ b/x/stake/handler.go
@@ -160,7 +160,9 @@ func handleMsgCreateValidator(ctx sdk.Context, msg MsgCreateValidator, k keeper.
 		return ErrBadDenom(k.Codespace()).Result()
 	}
 
-	validator := NewValidator(msg.ValidatorAddr, msg.PubKey, msg.Description)
+	// self-delegate address will be used to collect fees.
+	feeAddr := msg.DelegatorAddr
+	validator := NewValidatorWithFeeAddr(feeAddr, msg.ValidatorAddr, msg.PubKey, msg.Description)
 	commission := NewCommissionWithTime(
 		msg.Commission.Rate, msg.Commission.MaxRate,
 		msg.Commission.MaxChangeRate, ctx.BlockHeader().Time,

--- a/x/stake/stake.go
+++ b/x/stake/stake.go
@@ -66,16 +66,17 @@ var (
 	KeyMaxValidators  = types.KeyMaxValidators
 	KeyBondDenom      = types.KeyBondDenom
 
-	DefaultParams         = types.DefaultParams
-	InitialPool           = types.InitialPool
-	NewValidator          = types.NewValidator
-	NewDescription        = types.NewDescription
-	NewCommission         = types.NewCommission
-	NewCommissionMsg      = types.NewCommissionMsg
-	NewCommissionWithTime = types.NewCommissionWithTime
-	NewGenesisState       = types.NewGenesisState
-	DefaultGenesisState   = types.DefaultGenesisState
-	RegisterCodec         = types.RegisterCodec
+	DefaultParams           = types.DefaultParams
+	InitialPool             = types.InitialPool
+	NewValidator            = types.NewValidator
+	NewValidatorWithFeeAddr = types.NewValidatorWithFeeAddr
+	NewDescription          = types.NewDescription
+	NewCommission           = types.NewCommission
+	NewCommissionMsg        = types.NewCommissionMsg
+	NewCommissionWithTime   = types.NewCommissionWithTime
+	NewGenesisState         = types.NewGenesisState
+	DefaultGenesisState     = types.DefaultGenesisState
+	RegisterCodec           = types.RegisterCodec
 
 	NewMsgCreateValidator           = types.NewMsgCreateValidator
 	NewMsgRemoveValidator           = types.NewMsgRemoveValidator


### PR DESCRIPTION
### Description

we need split the fee address and validator's operator address, that means the responsibility is split. 
Totally, the validator has three addresses. 
1. One is the consensus address which is used in consensus. 
2. One is the operator address which is used to vote for governance
3. The last one is fee address which is used to hold fees.

So when creating a validator, either from the genesis block or from the tx, the candidate needs to provide these three address/pubKey. 

### Rationale

### Example

### Changes

Notable changes: 
* 

### Preflight checks

- [x] build passed (`make build`)
- [x] tests passed (`make test`)
- [ ] integration tests passed (`make integration_test`)
- [ ] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

