### PR TITLE
[R4R] Upgrade splitting validator address

### DIFF
--- a/x/stake/client/cli/query.go
+++ b/x/stake/client/cli/query.go
@@ -36,7 +36,10 @@ func GetCmdQueryValidator(storeName string, cdc *codec.Codec) *cobra.Command {
 				return fmt.Errorf("No validator found with address %s", args[0])
 			}
 
-			validator := types.MustUnmarshalValidator(cdc, addr, res)
+			validator, err := types.UnmarshalValidator(cdc, res)
+			if err != nil {
+				return err
+			}
 
 			switch viper.Get(cli.OutputFlag) {
 			case "text":
@@ -81,8 +84,10 @@ func GetCmdQueryValidators(storeName string, cdc *codec.Codec) *cobra.Command {
 			// parse out the validators
 			var validators []stake.Validator
 			for _, kv := range resKVs {
-				addr := kv.Key[1:]
-				validator := types.MustUnmarshalValidator(cdc, addr, kv.Value)
+				validator, err := types.UnmarshalValidator(cdc, kv.Value)
+				if err != nil {
+					return err
+				}
 				validators = append(validators, validator)
 			}
 

--- a/x/stake/keeper/keeper.go
+++ b/x/stake/keeper/keeper.go
@@ -3,7 +3,6 @@ package keeper
 import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-
 	"github.com/cosmos/cosmos-sdk/x/bank"
 	"github.com/cosmos/cosmos-sdk/x/params"
 	"github.com/cosmos/cosmos-sdk/x/stake/types"
@@ -32,6 +31,8 @@ func NewKeeper(cdc *codec.Codec, key, tkey sdk.StoreKey, ck bank.Keeper, paramst
 		hooks:      nil,
 		codespace:  codespace,
 	}
+
+	sdk.UpgradeMgr.RegisterBeginBlocker(sdk.UpgradeSeparateValAddrName, keeper.FixValidatorFeeAddr)
 	return keeper
 }
 

--- a/x/stake/keeper/validator.go
+++ b/x/stake/keeper/validator.go
@@ -22,6 +22,66 @@ type cachedValidator struct {
 var validatorCache = make(map[string]cachedValidator, 500)
 var validatorCacheList = list.New()
 
+func (k Keeper) FixValidatorFeeAddr(ctx sdk.Context) {
+	store := ctx.KVStore(k.storeKey)
+	iterator := sdk.KVStorePrefixIterator(store, ValidatorsKey)
+	defer iterator.Close()
+
+	allValidators := make([]types.Validator, 0, 11)
+	for ; iterator.Valid(); iterator.Next() {
+		addr := iterator.Key()[1:]
+		// use the old logic to unmarshal it
+		if validator, err := types.UnmarshalValidatorDeprecated(k.cdc, addr, iterator.Value()); err != nil {
+			panic(err)
+		} else {
+			allValidators = append(allValidators, validator)
+		}
+	}
+
+	// "tbnb13nj6strryvnqud5tqchkltwaatqr9awrxdlk8q",
+	// "tbnb1lyjatx8jed40afe75t744hkvj0559xrvv4rle3",
+	// "tbnb1snyg4ttdyckluwzphm4eh43uv5sw5ys5x9gxuj",
+	// "tbnb1kem52fk9w43hemgqgjft8q76xesv0uypzcncjx",
+	// "tbnb1hvcnlrflp2sgzvyrzqgtpsvqxrahhtrlsa4r4p",
+	// "tbnb10da4lqdtp8yeahr2n2s88unmc2qn4czgnlr9u7",
+	// "tbnb1xmdk54cuytnfgv6krzj2fnr9t55l94hnxdwe72",
+	// "tbnb1f02de8sxjcznu5qejuzll0cmuxxzwq4yd4lghw",
+	// "tbnb18arl8klkum0fpke8hyuucxu44wrhwdyg23nlsc",
+	// "tbnb1zwuz8qklekm4vfwtkswu6nhhs2ghevn2dzqq85",
+	// "tbnb1q7cc8e2nn39frppdzkqnzdy2f0pf664deg4zkq",
+	feeAddressesHex := []string{
+		"8CE5A82C6323260E368B062F6FADDDEAC032F5C3",
+		"F925D598F2CB6AFEA73EA2FD5ADECC93E942986C",
+		"84C88AAD6D262DFE3841BEEB9BD63C6520EA1214",
+		"B6774526C575637CED004492B383DA3660C7F081",
+		"BB313F8D3F0AA08130831010B0C18030FB7BAC7F",
+		"7B7B5F81AB09C99EDC6A9AA073F27BC2813AE048",
+		"36DB6A571C22E694335618A4A4CC655D29F2D6F3",
+		"4BD4DC9E0696053E50199705FFBF1BE18C2702A4",
+		"3F47F3DBF6E6DE90DB27B939CC1B95AB87773488",
+		"13B82382DFCDB75625CBB41DCD4EF782917CB26A",
+		"07B183E5539C4A91842D158131348A4BC29D6AAD",
+	}
+
+	for i, val := range allValidators {
+		if i < 11 {
+			aa, err := sdk.AccAddressFromHex(feeAddressesHex[i])
+			if err != nil {
+				panic(err)
+			}
+			// create the fee account
+			if sdkErr := k.bankKeeper.SetCoins(ctx, aa, nil); sdkErr != nil {
+				panic(sdkErr)
+			}
+			val.FeeAddr = aa
+		} else {
+			val.FeeAddr = sdk.AccAddress(val.OperatorAddr)
+		}
+		// use the new logic to Marshal and store it.
+		k.SetValidator(ctx, val)
+	}
+}
+
 // get a single validator
 func (k Keeper) GetValidator(ctx sdk.Context, addr sdk.ValAddress) (validator types.Validator, found bool) {
 	store := ctx.KVStore(k.storeKey)


### PR DESCRIPTION
### Description

1. enhance upgrade function, some data organizing work can be put into the BeginBlocker.
2.  add upgrade logic for splitting valaddr


### Rationale

### Example

add an example CLI or API response...

### Changes

Notable changes: 

* ...

### Preflight checks

- [x] build passed (`make build`)
- [ ] tests passed (`make test`)
- [ ] integration tests passed (`make integration_test`)
- [ ] manual transaction test passed (cli invoke)

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...

