### PR TITLE
R4R: add error log in stake endblock

### DIFF
--- a/x/stake/handler.go
+++ b/x/stake/handler.go
@@ -59,7 +59,7 @@ func NewStakeHandler(k Keeper) sdk.Handler {
 // Called every block, update validator set
 func EndBlocker(ctx sdk.Context, k keeper.Keeper) (ValidatorUpdates []abci.ValidatorUpdate, completedUnbondingDelegations []types.UnbondingDelegation) {
 	endBlockerTags := sdk.EmptyTags()
-	logger := ctx.Logger()
+	logger := ctx.Logger().With("module", "stake")
 
 	k.UnbondAllMatureValidatorQueue(ctx)
 


### PR DESCRIPTION
Now stake endblocker does nothing when an error happens. As endblocker panic will stop the blockchain consensus engine, so I just add log when an error happens.