### PR TITLE
WIP: Remove tendermint btcec

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -643,13 +643,6 @@
   version = "v2.2.1"
 
 [[projects]]
-  digest = "1:605b6546f3f43745695298ec2d342d3e952b6d91cdf9f349bea9315f677d759f"
-  name = "github.com/tendermint/btcd"
-  packages = ["btcec"]
-  pruneopts = "UT"
-  revision = "e5840949ff4fff0c56f9b6a541e22b63581ea9df"
-
-[[projects]]
   digest = "1:b73f5e117bc7c6e8fc47128f20db48a873324ad5cfeeebfc505e85c58682b5e4"
   name = "github.com/zondax/hid"
   packages = ["."]

--- a/crypto/ledger_secp256k1.go
+++ b/crypto/ledger_secp256k1.go
@@ -11,7 +11,6 @@ import (
 	ledgergo "github.com/zondax/ledger-cosmos-go"
 
 	"github.com/pkg/errors"
-	tmbtcec "github.com/tendermint/btcd/btcec"
 	tmcrypto "github.com/tendermint/tendermint/crypto"
 	tmsecp256k1 "github.com/tendermint/tendermint/crypto/secp256k1"
 )
@@ -160,7 +159,7 @@ func convertDERtoBER(signatureDER []byte) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	sigBER := tmbtcec.Signature{R: sigDER.R, S: sigDER.S}
+	sigBER := btcec.Signature{R: sigDER.R, S: sigDER.S}
 	return sigBER.Serialize(), nil
 }
 


### PR DESCRIPTION
`github.com/tendermint/btcd` is forked from `github.com/btcsuite/btcd`