### PR TITLE
R4R: Add ledger nano X support

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -551,8 +551,9 @@
   name = "github.com/zondax/ledger-go"
   packages = ["."]
   pruneopts = "UT"
-  revision = "94455688b6fac63ee05a4a61f44d5a4095317f74"
-  version = "v0.9.0"
+  revision = "6d4c92579518a79bb50589cc1c35995f610832f5"
+  source = "https://github.com/binance-chain/ledger-go"
+  version = "v0.9.1"
 
 [[projects]]
   digest = "1:6f6dc6060c4e9ba73cf28aa88f12a69a030d3d19d518ef8e931879eaa099628d"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -73,6 +73,11 @@
   revision = "52158e4697b87de16ed390e1bdaf813e581008fa"
 
 [[constraint]]
+  name = "github.com/zondax/ledger-go"
+  source = "https://github.com/binance-chain/ledger-go"
+  version = "v0.9.1"
+
+[[constraint]]
   name = "github.com/zondax/ledger-cosmos-go"
   source = "https://github.com/binance-chain/ledger-cosmos-go"
   version = "v0.9.9-binance.1"


### PR DESCRIPTION
Update ledger-go dependency to support ledger nano X. The main change in ledger-go is this:
https://github.com/binance-chain/ledger-go/commit/6d4c92579518a79bb50589cc1c35995f610832f5