### PR TITLE
[R4R] fix state_sync 

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -445,12 +445,12 @@
   version = "v0.14.1"
 
 [[projects]]
-  branch = "add_set_version"
   digest = "1:1d88f1320e234cdf1627b9025a5b565bceb597795e76db163af5e298cc715cae"
   name = "github.com/tendermint/iavl"
   packages = ["."]
   pruneopts = "UT"
-  revision = "df2579cea9dde3c1b79dec98893e38766576f386"
+  revision = ""
+  version = "v0.12.0-binance.1"
   source = "github.com/binance-chain/bnc-tendermint-iavl"
 
 [[projects]]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -50,8 +50,7 @@
 [[override]]
   name = "github.com/tendermint/iavl"
   source = "github.com/binance-chain/bnc-tendermint-iavl"
-  branch = "add_set_version"
-#  version = "=v0.12.0-binance.0"
+  version = "=v0.12.0-binance.1"
 
 [[override]]
   name = "github.com/tendermint/tendermint"

--- a/store/statesync_helper.go
+++ b/store/statesync_helper.go
@@ -98,7 +98,7 @@ func (helper *StateSyncHelper) getCommitedSortedStoreKeys() []sdk.StoreKey {
 	kvStores := helper.commitMS.GetCommitKVStores()
 	names := make([]string, 0, len(kvStores))
 	nameToKey := make(map[string]sdk.StoreKey, len(kvStores))
-	for key, store := range helper.commitMS.GetCommitKVStores() {
+	for key, store := range kvStores {
 		if !sdk.ShouldCommitStore(key.Name()) {
 			continue
 		}


### PR DESCRIPTION
This fixes newly added store might broken statesync.

This fix makes state sync helper no longer cache mounted stores (as they may dynamically change according to upgrade) and load needed stores according to upgrade height. 

cosmos build and unit test can pass
node manually test (state sync before and after upgrade) can pass