### PR TITLE
R4R: Add chain-id check for sign command

### DIFF
--- a/x/auth/client/cli/sign.go
+++ b/x/auth/client/cli/sign.go
@@ -57,6 +57,9 @@ func makeSignCmd(cdc *amino.Codec, decoder auth.AccountDecoder) func(cmd *cobra.
 		name := viper.GetString(client.FlagName)
 		cliCtx := context.NewCLIContext().WithCodec(cdc).WithAccountDecoder(decoder)
 		txBldr := authtxb.NewTxBuilderFromCLI()
+		if len(txBldr.ChainID) == 0 {
+			return fmt.Errorf("chain-id is missing")
+		}
 
 		newTx, err := utils.SignStdTx(txBldr, cliCtx, name, stdTx, viper.GetBool(flagAppend), viper.GetBool(flagOffline))
 		if err != nil {


### PR DESCRIPTION
Users may forget to fill chain-id for sign command. As a result, the transaction will be failed for invalid signature which is very confusing.
I add a checker for chain-id. If chain-id is missing, an error will be returned.