### PR TITLE
R4R: print tx json in dry mode

### DIFF
--- a/client/utils/utils.go
+++ b/client/utils/utils.go
@@ -54,6 +54,13 @@ func CompleteAndBroadcastTxCli(txBldr authtxb.TxBuilder, cliCtx context.CLIConte
 	}
 
 	if cliCtx.Dry {
+		var tx auth.StdTx
+		if err = txBldr.Codec.UnmarshalBinaryLengthPrefixed(txBytes, &tx); err == nil {
+			json, err := txBldr.Codec.MarshalJSON(tx)
+			if err == nil {
+				fmt.Printf("TX JSON: %s\n", json)
+			}
+		}
 		hexBytes := make([]byte, len(txBytes)*2)
 		hex.Encode(hexBytes, txBytes)
 		txHash := cmn.HexBytes(tmhash.Sum(txBytes)).String()


### PR DESCRIPTION
In dry mode, the transaction json has't been printed out. This PR is just to print out transaction json.