### PR TITLE
R4R: hot fix for hard fork in get signers

### DIFF
--- a/x/auth/stdtx.go
+++ b/x/auth/stdtx.go
@@ -43,11 +43,6 @@ func (tx StdTx) GetMsgs() []sdk.Msg { return tx.Msgs }
 // in the order they appear in tx.GetMsgs().
 // Duplicate addresses will be omitted.
 func (tx StdTx) GetSigners() []sdk.AccAddress {
-	// shortcut for most cases
-	if len(tx.GetMsgs()) == 1 {
-		return tx.GetMsgs()[0].GetSigners()
-	}
-
 	seen := map[string]bool{}
 	var signers []sdk.AccAddress
 	for _, msg := range tx.GetMsgs() {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/develop/CONTRIBUTING.md#pr-targeting))

Our change in [stdTx getSigner](https://github.com/binance-chain/bnc-cosmos-sdk/pull/165) results in hard fork.
```
panic: Failed to process committed block (49387831:B184FA9527DECA4EB8AD21441AF1C5424BB94AC1940F88B3C678BE306EE4B048): Wrong Block.Header.AppHash.  Expected 9F2DAA547207513C012F40D91C67417E697491926C22594E392CA09CE01738D0, got 388A6182067F05DE9BFC505426AAABADB2743A0724B6C81DF7E8984C9F9F2C00

goroutine 49027 [running]:
github.com/tendermint/tendermint/blockchain/v0.(*BlockchainReactor).poolRoutine(0xc000a16b60)
    /home/suyu/go/pkg/mod/github.com/binance-chain/bnc-tendermint@v0.32.3-binance.1/blockchain/v0/reactor.go:399 +0x1bf0
created by github.com/tendermint/tendermint/blockchain/v0.(*BlockchainReactor).OnStart
    /home/suyu/go/pkg/mod/github.com/binance-chain/bnc-tendermint@v0.32.3-binance.1/blockchain/v0/reactor.go:126 +0x84
```

https://explorer.binance.org/tx/21CCBAE89356D79EB4B9BCF406000B49F27C34E8B75B7B1D00C335ECA64AE790