### PR TITLE
WIP: fix cli sign issue

### DIFF
--- a/types/utils.go
+++ b/types/utils.go
@@ -17,7 +17,8 @@ import (
 func SortJSON(toSortJSON []byte) ([]byte, error) {
 	var c interface{}
 	var err error
-	if !IsUpgrade(FixSignBytesOverflow) {
+	_, ok := UpgradeMgr.Config.HeightMap[FixSignBytesOverflow]
+	if ok && !IsUpgrade(FixSignBytesOverflow) {
 		err = json.Unmarshal(toSortJSON, &c)
 	} else {
 		decoder := json.NewDecoder(bytes.NewReader(toSortJSON))


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

When we try to set account flag to a very large value, such as `0x1111111111111111`, the transaction will return signature failure. Previous fix in https://github.com/binance-chain/bnc-cosmos-sdk/pull/168 doesn't fix the sign bytes issue in command line.

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/develop/CONTRIBUTING.md#pr-targeting))

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added entries in `PENDING.md` with issue # 
- [ ] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
