### PR TITLE
[R4R]: power store invariant

### DIFF
--- a/types/stake.go
+++ b/types/stake.go
@@ -68,7 +68,11 @@ type ValidatorSet interface {
 		func(index int64, validator Validator) (stop bool))
 
 	// iterate through bonded validators by operator address, execute func for each validator
-	IterateValidatorsBonded(Context,
+	IterateBondedValidatorsByPower(Context,
+		func(index int64, validator Validator) (stop bool))
+
+	// iterate through the consensus validator set of the last block by operator address, execute func for each validator
+	IterateLastValidators(Context,
 		func(index int64, validator Validator) (stop bool))
 
 	Validator(Context, ValAddress) Validator            // get a particular validator by operator address

--- a/x/gov/tally.go
+++ b/x/gov/tally.go
@@ -23,7 +23,7 @@ func Tally(ctx sdk.Context, keeper Keeper, proposal Proposal) (passes bool, refu
 	totalVotingPower := sdk.ZeroDec()
 	currValidators := make(map[string]validatorGovInfo)
 
-	keeper.vs.IterateValidatorsBonded(ctx, func(index int64, validator sdk.Validator) (stop bool) {
+	keeper.vs.IterateBondedValidatorsByPower(ctx, func(index int64, validator sdk.Validator) (stop bool) {
 		currValidators[validator.GetOperator().String()] = validatorGovInfo{
 			Address:             validator.GetOperator(),
 			Power:               validator.GetPower(),

--- a/x/stake/genesis.go
+++ b/x/stake/genesis.go
@@ -72,7 +72,7 @@ func WriteGenesis(ctx sdk.Context, keeper Keeper) types.GenesisState {
 
 // WriteValidators returns a slice of bonded genesis validators.
 func WriteValidators(ctx sdk.Context, keeper Keeper) (vals []tmtypes.GenesisValidator) {
-	keeper.IterateValidatorsBonded(ctx, func(_ int64, validator sdk.Validator) (stop bool) {
+	keeper.IterateLastValidators(ctx, func(_ int64, validator sdk.Validator) (stop bool) {
 		vals = append(vals, tmtypes.GenesisValidator{
 			PubKey: validator.GetConsPubKey(),
 			Power:  validator.GetPower().RawInt(),

--- a/x/stake/keeper/validator.go
+++ b/x/stake/keeper/validator.go
@@ -464,3 +464,17 @@ func (k Keeper) UnbondAllMatureValidatorQueue(ctx sdk.Context) {
 		store.Delete(validatorTimesliceIterator.Key())
 	}
 }
+
+// returns an iterator for the consensus validators in the last block
+func (k Keeper) LastValidatorsIterator(ctx sdk.Context) (iterator sdk.Iterator) {
+	store := ctx.KVStore(k.storeKey)
+	iterator = sdk.KVStorePrefixIterator(store, LastValidatorPowerKey)
+	return iterator
+}
+
+// returns an iterator for the current validator power store
+func (k Keeper) ValidatorsPowerStoreIterator(ctx sdk.Context) (iterator sdk.Iterator) {
+	store := ctx.KVStore(k.storeKey)
+	iterator = sdk.KVStoreReversePrefixIterator(store, ValidatorsByPowerIndexKey)
+	return iterator
+}


### PR DESCRIPTION
### Description

This pr fixes an issue of the usage of IterateValidatorsBonded.

### Rationale

Currently, IterateValidatorsBonded is iterating over the last block's validator set, not the current one. 

### Example

n/a

### Changes

- function IterateValidatorsBonded is renamed/updated to use the current block's validator set
- function IterateLastBlockConsValidators created to use the last block's validator set
