### PR TITLE
[R4R]change default saved recent iavl version from 10K to 100K

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,5 @@
 # Changelog
 
-##v0.25.0-binance.26
-* [stake] [\#259](https://github.com/bnb-chain/bnc-cosmos-sdk/pull/259) Improve staking reward distribution
-
 ##v0.25.0-binance.25
 * [sdk] [\#260](https://github.com/binance-chain/bnc-cosmos-sdk/pull/260) Bug fixes (e.g., unclosed iterator)
 * [stake] [\#261](https://github.com/binance-chain/bnc-cosmos-sdk/pull/261) Remove GetValidator caching to fix concurrency error 

--- a/store/iavlstore.go
+++ b/store/iavlstore.go
@@ -118,8 +118,8 @@ func (st *IavlStore) SetPruning(pruning sdk.PruningStrategy) {
 	case sdk.PruneNothing:
 		st.storeEvery = 1
 	case sdk.PruneSyncable:
-		st.numRecent = 10000 // fork github.com/cosmos/cosmos-sdk/blob/9a16e2675f392b083dd1074ff92ff1f9fbda750d/store/types/pruning.go#L34
-		st.storeEvery = 10000
+		st.numRecent = 100000 // fork github.com/cosmos/cosmos-sdk/blob/9a16e2675f392b083dd1074ff92ff1f9fbda750d/store/types/pruning.go#L34
+		st.storeEvery = 100000
 	}
 }
 


### PR DESCRIPTION
### Description
Many of the data-seeds enable the state sync reactor to provide state sync data for external peers. It means these nodes need to persist the snapshot on breathblock, as the state grows in the mainnet, it takes more than 1 hour to do it.

While the IAVL tree only keeps the recent 10K version, which is about 1 hour, so it the snapshot can not be done before it is been pruned.

### Rationale
We raised the recent keep IAVL versions to save enough time for snaphshot.

### Example

n/a

### Changes
