### PR TITLE
[R4R] enhance validate basic

### DIFF
--- a/x/slashing/msg.go
+++ b/x/slashing/msg.go
@@ -52,8 +52,8 @@ func (msg MsgUnjail) GetSignBytes() []byte {
 
 // quick validity check
 func (msg MsgUnjail) ValidateBasic() sdk.Error {
-	if msg.ValidatorAddr == nil {
-		return ErrBadValidatorAddr(DefaultCodespace)
+	if len(msg.ValidatorAddr) != sdk.AddrLen {
+		return sdk.ErrInvalidAddress(fmt.Sprintf("Expected validator address length is %d, actual length is %d", sdk.AddrLen, len(msg.ValidatorAddr)))
 	}
 	return nil
 }
@@ -95,8 +95,8 @@ func (msg MsgSideChainUnjail) GetSignBytes() []byte {
 
 // quick validity check
 func (msg MsgSideChainUnjail) ValidateBasic() sdk.Error {
-	if msg.ValidatorAddr == nil {
-		return ErrBadValidatorAddr(DefaultCodespace)
+	if len(msg.ValidatorAddr) != sdk.AddrLen {
+		return sdk.ErrInvalidAddress(fmt.Sprintf("Expected validator address length is %d, actual length is %d", sdk.AddrLen, len(msg.ValidatorAddr)))
 	}
 	if len(msg.SideChainId) == 0 || len(msg.SideChainId) > types.MaxSideChainIdLength {
 		return ErrInvalidInput(DefaultCodespace, fmt.Sprintf("side chain id must be included and max length is %d bytes", types.MaxSideChainIdLength))

--- a/x/stake/types/msg.go
+++ b/x/stake/types/msg.go
@@ -387,11 +387,11 @@ func (msg MsgBeginUnbonding) GetSignBytes() []byte {
 
 // quick validity check
 func (msg MsgBeginUnbonding) ValidateBasic() sdk.Error {
-	if msg.DelegatorAddr == nil {
-		return ErrNilDelegatorAddr(DefaultCodespace)
+	if len(msg.DelegatorAddr) != sdk.AddrLen {
+		return sdk.ErrInvalidAddress(fmt.Sprintf("Expected delegator address length is %d, actual length is %d", sdk.AddrLen, len(msg.DelegatorAddr)))
 	}
-	if msg.ValidatorAddr == nil {
-		return ErrNilValidatorAddr(DefaultCodespace)
+	if len(msg.ValidatorAddr) != sdk.AddrLen {
+		return sdk.ErrInvalidAddress(fmt.Sprintf("Expected validator address length is %d, actual length is %d", sdk.AddrLen, len(msg.ValidatorAddr)))
 	}
 	if msg.SharesAmount.LTE(sdk.ZeroDec()) {
 		return ErrBadSharesAmount(DefaultCodespace)


### PR DESCRIPTION
### Description

This pr enhances checks in `ValidateBasic` function of MsgBeginUnbonding/MsgUnjail/MsgBeginUnbonding.

### Rationale

To align the checks of addresses in other delegation messages.

### Example

n/a

### Changes

- update checks
