### PR TITLE
[R4R] update tendermint version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -143,7 +143,7 @@ require (
 replace (
 	github.com/tendermint/go-amino => github.com/bnb-chain/bnc-go-amino v0.14.1-binance.2
 	github.com/tendermint/iavl => github.com/bnb-chain/bnc-tendermint-iavl v0.12.0-binance.4
-	github.com/tendermint/tendermint => github.com/bnb-chain/bnc-tendermint v0.32.3-binance.6
+	github.com/tendermint/tendermint => github.com/bnb-chain/bnc-tendermint v0.32.3-binance.7
 	github.com/zondax/ledger-cosmos-go => github.com/bnb-chain/ledger-cosmos-go v0.9.9-binance.3
 	golang.org/x/crypto => github.com/tendermint/crypto v0.0.0-20190823183015-45b1026d81ae
 )

--- a/go.sum
+++ b/go.sum
@@ -26,8 +26,8 @@ github.com/binance-chain/tss-lib v1.0.0 h1:r6Yj8g8zwiVwOAdVBu2D36Nvbxeq9qPWdVi+p
 github.com/binance-chain/tss-lib v1.0.0/go.mod h1:5mmPQOOkBIjHxyGVesSUB2AemcZj5YkMJ+HPZY4Jd38=
 github.com/bnb-chain/bnc-go-amino v0.14.1-binance.2 h1:iAlp9gqG0f2LGAauf3ZiijWlT6NI+W2r9y70HH9LI3k=
 github.com/bnb-chain/bnc-go-amino v0.14.1-binance.2/go.mod h1:LiCO7jev+3HwLGAiN9gpD0z+jTz95RqgSavbse55XOY=
-github.com/bnb-chain/bnc-tendermint v0.32.3-binance.6 h1:6H6b/+Yk1hzfF4iHLe6ACv7eZ+vNZC8jk663O2gzkT8=
-github.com/bnb-chain/bnc-tendermint v0.32.3-binance.6/go.mod h1:+5NnQZbpAijzpby/yOYlBwJjzvkXZKr6MGWZ9oI0p4Y=
+github.com/bnb-chain/bnc-tendermint v0.32.3-binance.7 h1:wJBrhLAm9P+Jjm/clTxynAZJl63xD7LatKmL5e3YzbY=
+github.com/bnb-chain/bnc-tendermint v0.32.3-binance.7/go.mod h1:EJSMv0Dh5v91CiHn+2pOnl1a3sdRVjpdekJ20AyYmlQ=
 github.com/bnb-chain/bnc-tendermint-iavl v0.12.0-binance.4 h1:w8pAAx1N0lmVf0Lxs1prYuDikXwirOb9T7y2yw8zOBw=
 github.com/bnb-chain/bnc-tendermint-iavl v0.12.0-binance.4/go.mod h1:Zmh8GRdNJB8DULIOBar3JCZp6tSpcvM1NGKfE9U2EzA=
 github.com/bnb-chain/ledger-cosmos-go v0.9.9-binance.3 h1:a+QLVLaP32v9gfRDKHH2AcRkzYLTWbC8UxYTJkXRSec=


### PR DESCRIPTION
### Description

This pr upgrades Tendermint version to v0.32.3-binance.7.

### Rationale

[The new release of BNC Tendermint ](https://github.com/binance-chain/bnc-tendermint/releases/tag/v0.32.3-binance.7) includes some bug fixes and enhancements. 

### Example

n/a

### Changes

- changed go.mod to apply the upgrades
