### PR TITLE
fix: update cross chain logic of native stake

### DIFF
--- a/x/stake/keeper/distribute_sidechain.go
+++ b/x/stake/keeper/distribute_sidechain.go
@@ -142,7 +142,7 @@ func (k Keeper) DistributeInBreathBlock(ctx sdk.Context, sideChainId string) sdk
 		totalRewardDec := sdk.ZeroDec()
 		commission := sdk.ZeroDec()
 		rewards := make([]types.PreReward, 0)
-		crossStakeSetMap := make(map[string]bool)
+		crossStake := make(map[string]bool)
 		if totalReward > 0 {
 			delegations, found := k.GetSimplifiedDelegations(ctx, height, validator.OperatorAddr)
 			if !found {
@@ -150,7 +150,7 @@ func (k Keeper) DistributeInBreathBlock(ctx sdk.Context, sideChainId string) sdk
 			}
 			for _, del := range delegations {
 				if del.CrossStake {
-					crossStakeSetMap[del.DelegatorAddr.String()] = true
+					crossStake[del.DelegatorAddr.String()] = true
 				}
 			}
 			totalRewardDec = sdk.NewDec(totalReward)
@@ -180,7 +180,7 @@ func (k Keeper) DistributeInBreathBlock(ctx sdk.Context, sideChainId string) sdk
 					AccAddr:    rewards[i].AccAddr,
 					Tokens:     tokens,
 					Amount:     rewards[i].Amount,
-					CrossStake: crossStakeSetMap[rewards[i].AccAddr.String()],
+					CrossStake: crossStake[rewards[i].AccAddr.String()],
 				}
 				toSaveRewards = append(toSaveRewards, toSaveReward)
 			}
@@ -266,10 +266,10 @@ func (k Keeper) distributeSingleBatch(ctx sdk.Context, sideChainId string) sdk.E
 		valDistAddrMap[valDist.Validator.String()] = valDist.DistributeAddr
 	}
 
-	distAddrBalanceMap := make(map[string]int64) // track distribute address balance changes
-	crossStakeAddrSet := make(map[string]bool)   // record cross stake address
-	var toPublish []types.DistributionData       // data to be published in blocks
-	var toPublishRewards []types.Reward          // rewards to be published in blocks
+	distAddrBalanceMap := make(map[string]int64)   // track distribute address balance changes
+	crossStakeAddrSet := make([]sdk.AccAddress, 0) // record cross stake address
+	var toPublish []types.DistributionData         // data to be published in blocks
+	var toPublishRewards []types.Reward            // rewards to be published in blocks
 
 	var changedAddrs []sdk.AccAddress //changed addresses
 
@@ -285,7 +285,7 @@ func (k Keeper) distributeSingleBatch(ctx sdk.Context, sideChainId string) sdk.E
 
 		if reward.CrossStake && sdk.IsUpgrade(sdk.BEP153) {
 			rewardCAoB := types.GetStakeCAoB(reward.AccAddr.Bytes(), types.RewardCAoBSalt)
-			crossStakeAddrSet[rewardCAoB.String()] = true
+			crossStakeAddrSet = append(crossStakeAddrSet, rewardCAoB)
 			reward.AccAddr = rewardCAoB
 		}
 
@@ -309,14 +309,10 @@ func (k Keeper) distributeSingleBatch(ctx sdk.Context, sideChainId string) sdk.E
 	}
 
 	// cross distribute reward
-	for addr := range crossStakeAddrSet {
-		rewardCAoB, err := sdk.AccAddressFromBech32(addr)
-		if err != nil {
-			panic(err)
-		}
-		balance := k.BankKeeper.GetCoins(ctx, rewardCAoB).AmountOf(bondDenom)
+	for _, addr := range crossStakeAddrSet {
+		balance := k.BankKeeper.GetCoins(ctx, addr).AmountOf(bondDenom)
 		if balance >= types.MinRewardThreshold {
-			event, err := crossDistributeReward(k, ctx, rewardCAoB, balance)
+			event, err := crossDistributeReward(k, ctx, addr, balance)
 			if err != nil {
 				panic(err)
 			}

--- a/x/stake/types/cross_stake.go
+++ b/x/stake/types/cross_stake.go
@@ -90,8 +90,8 @@ const (
 
 type CrossStakeRefundPackage struct {
 	EventType CrossStakeEventType
-	Amount    *big.Int
 	Recipient sdk.SmartChainAddress
+	Amount    *big.Int
 	ErrorCode RefundError
 }
 

--- a/x/stake/types/cross_stake.go
+++ b/x/stake/types/cross_stake.go
@@ -3,12 +3,12 @@ package types
 import (
 	"math/big"
 
-	"github.com/cosmos/cosmos-sdk/bsc"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/tendermint/tendermint/crypto/tmhash"
 )
 
 type CrossStakeEventType uint8
+type CrossStakeStatus uint8
 
 const (
 	CrossStakeChannel = "crossStake"
@@ -21,6 +21,9 @@ const (
 
 	CrossDistributeRewardRelayFee      = "crossDistributeRewardRelayFee"
 	CrossDistributeUndelegatedRelayFee = "crossDistributeUndelegatedRelayFee"
+
+	CrossStakeFailed  CrossStakeStatus = 0
+	CrossStakeSuccess CrossStakeStatus = 1
 
 	CrossStakeTypeDelegate              CrossStakeEventType = 1
 	CrossStakeTypeUndelegate            CrossStakeEventType = 2
@@ -40,40 +43,22 @@ const (
 	MinRewardThreshold int64 = 1e8
 )
 
+type CrossStakeAckPackage struct {
+	Status    CrossStakeStatus
+	ErrorCode uint8
+	PackBytes []byte
+}
+
 type CrossStakeDelegateSynPackage struct {
 	DelAddr   sdk.SmartChainAddress
 	Validator sdk.ValAddress
 	Amount    *big.Int
 }
 
-type CrossStakeDelegateAckPackage struct {
-	EventType CrossStakeEventType
-	DelAddr   sdk.SmartChainAddress
-	Validator sdk.ValAddress
-	Amount    *big.Int
-	ErrorCode uint8
-}
-
-func NewCrossStakeDelegationAckPackage(synPack *CrossStakeDelegateSynPackage, eventType CrossStakeEventType, errCode uint8) *CrossStakeDelegateAckPackage {
-	return &CrossStakeDelegateAckPackage{eventType, synPack.DelAddr, synPack.Validator, bsc.ConvertBCAmountToBSCAmount(synPack.Amount.Int64()), errCode}
-}
-
 type CrossStakeUndelegateSynPackage struct {
 	DelAddr   sdk.SmartChainAddress
 	Validator sdk.ValAddress
 	Amount    *big.Int
-}
-
-type CrossStakeUndelegateAckPackage struct {
-	EventType CrossStakeEventType
-	DelAddr   sdk.SmartChainAddress
-	Validator sdk.ValAddress
-	Amount    *big.Int
-	ErrorCode uint8
-}
-
-func NewCrossStakeUndelegateAckPackage(synPack *CrossStakeUndelegateSynPackage, eventType CrossStakeEventType, errCode uint8) *CrossStakeUndelegateAckPackage {
-	return &CrossStakeUndelegateAckPackage{eventType, synPack.DelAddr, synPack.Validator, bsc.ConvertBCAmountToBSCAmount(synPack.Amount.Int64()), errCode}
 }
 
 type CrossStakeRedelegateSynPackage struct {
@@ -83,30 +68,17 @@ type CrossStakeRedelegateSynPackage struct {
 	Amount  *big.Int
 }
 
-type CrossStakeRedelegateAckPackage struct {
-	EventType CrossStakeEventType
-	DelAddr   sdk.SmartChainAddress
-	ValSrc    sdk.ValAddress
-	ValDst    sdk.ValAddress
-	Amount    *big.Int
-	ErrorCode uint8
-}
-
-func NewCrossStakeRedelegationAckPackage(synPack *CrossStakeRedelegateSynPackage, eventType CrossStakeEventType, errCode uint8) *CrossStakeRedelegateAckPackage {
-	return &CrossStakeRedelegateAckPackage{eventType, synPack.DelAddr, synPack.ValSrc, synPack.ValDst, bsc.ConvertBCAmountToBSCAmount(synPack.Amount.Int64()), errCode}
-}
-
 type CrossStakeDistributeRewardSynPackage struct {
 	EventType CrossStakeEventType
-	Amount    *big.Int
 	Recipient sdk.SmartChainAddress
+	Amount    *big.Int
 }
 
 type CrossStakeDistributeUndelegatedSynPackage struct {
 	EventType CrossStakeEventType
-	Amount    *big.Int
 	Recipient sdk.SmartChainAddress
 	Validator sdk.ValAddress
+	Amount    *big.Int
 }
 
 type RefundError uint32

--- a/x/stake/types/cross_stake_test.go
+++ b/x/stake/types/cross_stake_test.go
@@ -2,11 +2,8 @@ package types
 
 import (
 	"fmt"
-	"log"
-	"math/big"
 	"testing"
 
-	"github.com/cosmos/cosmos-sdk/bsc/rlp"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -19,35 +16,5 @@ func TestGetStakeCAoB(t *testing.T) {
 	fmt.Println(stakeCAoB.String())
 	if delAddr := GetStakeCAoB(stakeCAoB.Bytes(), DelegateCAoBSalt); delAddr.String() != exp.String() {
 		t.Fatal()
-	}
-}
-
-func TestAckRLP(t *testing.T) {
-	delAddr, _ := sdk.NewSmartChainAddress("91D7deA99716Cbb247E81F1cfB692009164a967E")
-
-	bcAddr := "bnb1dmrarep5fawa89shw0048syv3ek4tcm28tmqp6"
-
-	bz, _ := sdk.GetFromBech32(bcAddr, "bnb")
-	valAddr := sdk.ValAddress(bz)
-	synPack := CrossStakeDelegateSynPackage{
-		DelAddr:   delAddr,
-		Validator: valAddr,
-		Amount:    big.NewInt(1000),
-	}
-
-	ackPack := NewCrossStakeDelegationAckPackage(&synPack, CrossStakeTypeDelegate, 1)
-	ackBytes, _ := rlp.EncodeToBytes(ackPack)
-
-	type AckPackage struct {
-		EventType CrossStakeEventType
-		DelAddr   sdk.SmartChainAddress
-		Validator sdk.ValAddress
-		Amount    *big.Int
-		ErrorCode uint8
-	}
-	var pack AckPackage
-	err := rlp.DecodeBytes(ackBytes, &pack)
-	if err != nil {
-		log.Fatal(err)
 	}
 }


### PR DESCRIPTION
### Description

There may be some vulnerability in previous native staking design. 

### Rationale

N/A

### Example

For example, if a user sends the `delegate` transaction with invalid validator, execute the `undelegate` transaction immediately before receiving the AckPackage of the last delegate transaction, the token from the last delegate transaction will be locked.

### Changes

For now, every request from BSC to BC will have an ack package to inform the status of the request. State changes will be done only after the ack package with success status is received.
