### PR TITLE
[R4R] add ics23 proof support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.17
 require (
 	github.com/bartekn/go-bip39 v0.0.0-20171116152956-a05967ea095d
 	github.com/bgentry/speakeasy v0.1.0
+	github.com/bnb-chain/ics23 v0.0.0-20221021082321-d0a365dd9898
 	github.com/cosmos/go-bip39 v0.0.0-20180819234021-555e2067c45d
 	github.com/go-kit/kit v0.9.0
 	github.com/gorilla/mux v1.7.3

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/bartekn/go-bip39 v0.0.0-20171116152956-a05967ea095d
 	github.com/bgentry/speakeasy v0.1.0
-	github.com/bnb-chain/ics23 v0.0.0-20221021082321-d0a365dd9898
+	github.com/bnb-chain/ics23 v0.1.0
 	github.com/cosmos/go-bip39 v0.0.0-20180819234021-555e2067c45d
 	github.com/go-kit/kit v0.9.0
 	github.com/gorilla/mux v1.7.3
@@ -76,7 +76,7 @@ require (
 
 replace (
 	github.com/tendermint/go-amino => github.com/bnb-chain/bnc-go-amino v0.14.1-binance.2
-	github.com/tendermint/iavl => github.com/bnb-chain/bnc-tendermint-iavl v0.12.0-binance.4
+	github.com/tendermint/iavl => github.com/bnb-chain/bnc-tendermint-iavl v0.12.0-binance.5
 	github.com/tendermint/tendermint => github.com/bnb-chain/bnc-tendermint v0.32.3-bc.9
 	github.com/zondax/ledger-cosmos-go => github.com/bnb-chain/ledger-cosmos-go v0.9.10-0.20230201065744-d644bede1667
 	golang.org/x/crypto => github.com/tendermint/crypto v0.0.0-20190823183015-45b1026d81ae

--- a/go.sum
+++ b/go.sum
@@ -58,6 +58,8 @@ github.com/bnb-chain/bnc-tendermint v0.32.3-bc.9 h1:ubmtJkfE9SZfdDTzGBoXkXO8htHC
 github.com/bnb-chain/bnc-tendermint v0.32.3-bc.9/go.mod h1:q5x58ZV0f3ZImJnOjKYERhRMiPNzVMaO72HLUVmuxmI=
 github.com/bnb-chain/bnc-tendermint-iavl v0.12.0-binance.4 h1:w8pAAx1N0lmVf0Lxs1prYuDikXwirOb9T7y2yw8zOBw=
 github.com/bnb-chain/bnc-tendermint-iavl v0.12.0-binance.4/go.mod h1:Zmh8GRdNJB8DULIOBar3JCZp6tSpcvM1NGKfE9U2EzA=
+github.com/bnb-chain/ics23 v0.0.0-20221021082321-d0a365dd9898 h1:lnDi72nkJTb/3pihvIyz6F3YGqCcom9iP+kva3h0iyM=
+github.com/bnb-chain/ics23 v0.0.0-20221021082321-d0a365dd9898/go.mod h1:cU6lTGolbbLFsGCgceNB2AzplH1xecLp6+KXvxM32nI=
 github.com/bnb-chain/ledger-cosmos-go v0.9.10-0.20230201065744-d644bede1667 h1:0/dBO1McxuSjea9T/4mf7wcTgEgTs2GR2Cz4qktl+/o=
 github.com/bnb-chain/ledger-cosmos-go v0.9.10-0.20230201065744-d644bede1667/go.mod h1:NnMWSpPmLxWfVsPoTVlpmZ3g2uHi9N99qe2gxGv0uwQ=
 github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=
@@ -148,6 +150,7 @@ github.com/go-stack/stack v1.8.0 h1:5SgMzNM5HxrEjV0ww2lTmX6E2Izsfxas4+YHWRs3Lsk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
+github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
@@ -245,6 +248,7 @@ github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/X
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
+github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kkdai/bstream v0.0.0-20161212061736-f391b8402d23/go.mod h1:J+Gs4SYgM6CZQHDETBtE9HaSEkGmuNXF86RwHhHUvq4=
@@ -563,6 +567,7 @@ golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxb
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+golang.org/x/tools v0.0.0-20181030221726-6c7e314b6563/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=

--- a/go.sum
+++ b/go.sum
@@ -56,10 +56,11 @@ github.com/bnb-chain/bnc-go-amino v0.14.1-binance.2 h1:iAlp9gqG0f2LGAauf3ZiijWlT
 github.com/bnb-chain/bnc-go-amino v0.14.1-binance.2/go.mod h1:LiCO7jev+3HwLGAiN9gpD0z+jTz95RqgSavbse55XOY=
 github.com/bnb-chain/bnc-tendermint v0.32.3-bc.9 h1:ubmtJkfE9SZfdDTzGBoXkXO8htHCniH8vUL/lLhxd8A=
 github.com/bnb-chain/bnc-tendermint v0.32.3-bc.9/go.mod h1:q5x58ZV0f3ZImJnOjKYERhRMiPNzVMaO72HLUVmuxmI=
-github.com/bnb-chain/bnc-tendermint-iavl v0.12.0-binance.4 h1:w8pAAx1N0lmVf0Lxs1prYuDikXwirOb9T7y2yw8zOBw=
-github.com/bnb-chain/bnc-tendermint-iavl v0.12.0-binance.4/go.mod h1:Zmh8GRdNJB8DULIOBar3JCZp6tSpcvM1NGKfE9U2EzA=
-github.com/bnb-chain/ics23 v0.0.0-20221021082321-d0a365dd9898 h1:lnDi72nkJTb/3pihvIyz6F3YGqCcom9iP+kva3h0iyM=
+github.com/bnb-chain/bnc-tendermint-iavl v0.12.0-binance.5 h1:8trIShwwXvCUQz34DwIsgPz2yJgVlZRMv+2IwEuKjTM=
+github.com/bnb-chain/bnc-tendermint-iavl v0.12.0-binance.5/go.mod h1:4Kf0qoRDM4vc1ZTBSHqwiQyVniCPS+HAAY434oYzr6w=
 github.com/bnb-chain/ics23 v0.0.0-20221021082321-d0a365dd9898/go.mod h1:cU6lTGolbbLFsGCgceNB2AzplH1xecLp6+KXvxM32nI=
+github.com/bnb-chain/ics23 v0.1.0 h1:DvjGOts2FBfbxB48384CYD1LbcrfjThFz8kowY/7KxU=
+github.com/bnb-chain/ics23 v0.1.0/go.mod h1:cU6lTGolbbLFsGCgceNB2AzplH1xecLp6+KXvxM32nI=
 github.com/bnb-chain/ledger-cosmos-go v0.9.10-0.20230201065744-d644bede1667 h1:0/dBO1McxuSjea9T/4mf7wcTgEgTs2GR2Cz4qktl+/o=
 github.com/bnb-chain/ledger-cosmos-go v0.9.10-0.20230201065744-d644bede1667/go.mod h1:NnMWSpPmLxWfVsPoTVlpmZ3g2uHi9N99qe2gxGv0uwQ=
 github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=
@@ -108,6 +109,7 @@ github.com/cosmos/go-bip39 v0.0.0-20180819234021-555e2067c45d/go.mod h1:tSxLoYXy
 github.com/cosmos/ledger-go v0.9.2 h1:Nnao/dLwaVTk1Q5U9THldpUMMXU94BOTWPddSmVB6pI=
 github.com/cosmos/ledger-go v0.9.2/go.mod h1:oZJ2hHAZROdlHiwTg4t7kP+GKIIkBT+o6c9QWFanOyI=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
+github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v0.0.0-20171005155431-ecdeabc65495/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -182,7 +184,7 @@ github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
-github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.4 h1:yAGX7huGHXlcLOEtBnF4w7FQwA26wojNCwOYAEhLjQM=
 github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
@@ -233,7 +235,6 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
-github.com/jmhodges/levigo v0.0.0-20161115193449-c42d9e0ca023/go.mod h1:Q6Qx+uH3RAqyK4rFQroq9RL7mdkABMcfhEI+nNuzMJQ=
 github.com/jmhodges/levigo v1.0.0 h1:q5EC36kV79HWeTBWsod3mG11EgStG3qArTKcvlksN1U=
 github.com/jmhodges/levigo v1.0.0/go.mod h1:Q6Qx+uH3RAqyK4rFQroq9RL7mdkABMcfhEI+nNuzMJQ=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
@@ -255,11 +256,11 @@ github.com/kkdai/bstream v0.0.0-20161212061736-f391b8402d23/go.mod h1:J+Gs4SYgM6
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
-github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
-github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/libp2p/go-buffer-pool v0.0.2 h1:QNK2iAFa8gjAe1SPz6mHSMuCcjs+X1wlHzeOSqcmlfs=
 github.com/libp2p/go-buffer-pool v0.0.2/go.mod h1:MvaB6xw5vOrDl8rYZGLFdKAuk/hRoRZd1Vi32+RXyFM=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
@@ -280,12 +281,13 @@ github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3Rllmb
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
+github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
+github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nxadm/tail v1.4.4 h1:DQuhQpB1tVlglWS2hLQ5OV6B5r8aGxSrPc5Qo6uTN78=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
-github.com/onsi/ginkgo v1.10.3/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
 github.com/onsi/ginkgo v1.14.0 h1:2mOpI4JVVPBN+WQRa0WKH2eXR+Ey+uK4n7Zj0aYpIQA=
 github.com/onsi/ginkgo v1.14.0/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
@@ -378,7 +380,7 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/syndtr/goleveldb v0.0.0-20181105012736-f9080354173f/go.mod h1:Z4AUp2Km+PwemOoO/VB5AOx9XSsIItzFjoJlOSiYmn0=
+github.com/syndtr/goleveldb v1.0.1-0.20200815110645-5c35d600f0ca/go.mod h1:u2MKkTVTVJWe5D1rCvame8WqhBd88EuIwODJZ1VHCPM=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 h1:epCh84lMvA70Z7CTTCmYQn2CKbY8j86K7/FAIr141uY=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7/go.mod h1:q4W45IWZaF22tdD+VEXcAWRA037jwmWEB5VWYORlTpc=
 github.com/tendermint/btcd v0.1.1 h1:0VcxPfflS2zZ3RiOAHkBiFUcPvbtRj5O7zHmcJWHV7s=
@@ -477,6 +479,7 @@ golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
+golang.org/x/net v0.0.0-20220812174116-3211cb980234/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
 golang.org/x/net v0.5.0 h1:GyT4nK/YDHSqa1c4753ouYCDajOYKTja9Xb/OHtgvSw=
 golang.org/x/net v0.5.0/go.mod h1:DivGGAXEgPSlEBzxGzZI+ZLohi+xUj054jfeKui00ws=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -548,6 +551,8 @@ golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.4.0 h1:Zr2JFtRQNX3BCZ8YtxRE9hNJYC8J6I1MVbMg6owUp18=
 golang.org/x/sys v0.4.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
@@ -698,8 +703,9 @@ google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqw
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=
+gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=

--- a/store/iavlstore.go
+++ b/store/iavlstore.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"sync"
 
+	"github.com/bnb-chain/ics23"
 	"github.com/tendermint/iavl"
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/crypto/merkle"
@@ -244,6 +245,32 @@ func (st *IavlStore) Query(req abci.RequestQuery) (res abci.ResponseQuery) {
 		} else {
 			_, res.Value = tree.GetVersioned(key, res.Height)
 		}
+	case "/ics23-key":
+		key := req.Data // Data holds the key bytes
+		res.Key = key
+		if !st.VersionExists(res.Height) {
+			res.Log = cmn.ErrorWrap(iavl.ErrVersionDoesNotExist, "").Error()
+			break
+		}
+		_, res.Value = tree.GetVersioned(key, res.Height)
+
+		if !req.Prove {
+			break
+		}
+
+		// Continue to prove existence/absence of value
+		// Must convert store.Tree to iavl.MutableTree with given version to use in CreateProof
+		iTree, err := tree.GetImmutable(res.Height)
+		if err != nil {
+			// sanity check: If value for given version was retrieved, immutable tree must also be retrievable
+			panic(fmt.Sprintf("version exists in store but could not retrieve corresponding versioned tree in store, %s", err.Error()))
+		}
+		mtree := &iavl.MutableTree{
+			ImmutableTree: iTree,
+		}
+
+		// get proof from tree and convert to merkle.Proof before adding to result
+		res.Proof = getProofFromTree(mtree, req.Data, res.Value != nil)
 	case "/subspace":
 		subspace := req.Data
 		res.Key = subspace
@@ -259,6 +286,36 @@ func (st *IavlStore) Query(req abci.RequestQuery) (res abci.ResponseQuery) {
 		return sdk.ErrUnknownRequest(msg).QueryResult()
 	}
 	return
+}
+
+// Takes a MutableTree, a key, and a flag for creating existence or absence proof and returns the
+// appropriate merkle.Proof. Since this must be called after querying for the value, this function should never error
+// Thus, it will panic on error rather than returning it
+func getProofFromTree(tree *iavl.MutableTree, key []byte, exists bool) *merkle.Proof {
+	var (
+		commitmentProof *ics23.CommitmentProof
+		err             error
+	)
+
+	if exists {
+		// value was found
+		commitmentProof, err = tree.GetMembershipProof(key)
+		if err != nil {
+			// sanity check: If value was found, membership proof must be creatable
+			panic(fmt.Sprintf("unexpected value for empty proof: %s", err.Error()))
+		}
+	} else {
+		// value wasn't found
+		commitmentProof, err = tree.GetNonMembershipProof(key)
+		if err != nil {
+			// sanity check: If value wasn't found, nonmembership proof must be creatable
+			panic(fmt.Sprintf("unexpected error for nonexistence proof: %s", err.Error()))
+		}
+	}
+
+	op := NewIavlCommitmentOp(key, commitmentProof)
+
+	return &merkle.Proof{Ops: []merkle.ProofOp{op.ProofOp()}}
 }
 
 //----------------------------------------

--- a/store/multistoreproof.go
+++ b/store/multistoreproof.go
@@ -32,7 +32,7 @@ func RequireProof(subpath string) bool {
 	// XXX: create a better convention.
 	// Currently, only when query subpath is "/store" or "/key", will proof be included in response.
 	// If there are some changes about proof building in iavlstore.go, we must change code here to keep consistency with iavlstore.go:212
-	if subpath == "/store" || subpath == "/key" {
+	if subpath == "/store" || subpath == "/key" || subpath == "/ics23-key" {
 		return true
 	}
 	return false
@@ -132,6 +132,8 @@ func DefaultProofRuntime() (prt *merkle.ProofRuntime) {
 	prt = merkle.NewProofRuntime()
 	prt.RegisterOpDecoder(merkle.ProofOpSimpleValue, merkle.SimpleValueOpDecoder)
 	prt.RegisterOpDecoder(iavl.ProofOpIAVLValue, iavl.IAVLValueOpDecoder)
+	prt.RegisterOpDecoder(ProofOpIAVLCommitment, CommitmentOpDecoder)
+	prt.RegisterOpDecoder(ProofOpSimpleMerkleCommitment, CommitmentOpDecoder)
 	prt.RegisterOpDecoder(iavl.ProofOpIAVLAbsence, iavl.IAVLAbsenceOpDecoder)
 	prt.RegisterOpDecoder(ProofOpMultiStore, MultiStoreProofOpDecoder)
 	return

--- a/store/proof.go
+++ b/store/proof.go
@@ -184,6 +184,10 @@ func VerifyValue(prt *merkle.ProofRuntime, root []byte, version int64, proof *me
 	storeHash := storeInfo.Hash()
 
 	simplePo := poz[1]
+	if simplePo.ProofOp().Type != ProofOpSimpleMerkleCommitment {
+		return fmt.Errorf("invalid proof op type, should be  %s", ProofOpSimpleMerkleCommitment)
+	}
+
 	if !bytes.Equal(storeKey, simplePo.GetKey()) {
 		return fmt.Errorf("invalid proof of key, require %X, got %X", simplePo.GetKey(), storeKey)
 	}

--- a/store/proof.go
+++ b/store/proof.go
@@ -173,7 +173,7 @@ func VerifyValue(prt *merkle.ProofRuntime, root []byte, version int64, proof *me
 
 	// calculate store hash
 	storeInfo := StoreInfo{
-		Name: string(keys[1]),
+		Name: string(storeKey),
 		Core: StoreCore{
 			CommitID: CommitID{
 				Version: version,

--- a/store/proof.go
+++ b/store/proof.go
@@ -1,0 +1,200 @@
+package store
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/pkg/errors"
+
+	"github.com/bnb-chain/ics23"
+	"github.com/tendermint/tendermint/crypto/merkle"
+)
+
+const (
+	ProofOpIAVLCommitment         = "ics23:iavl"
+	ProofOpSimpleMerkleCommitment = "ics23:simple"
+)
+
+// CommitmentOp implements merkle.ProofOperator by wrapping an ics23 CommitmentProof
+// It also contains a Key field to determine which key the proof is proving.
+// NOTE: CommitmentProof currently can either be ExistenceProof or NonexistenceProof
+//
+// Type and Spec are classified by the kind of merkle proof it represents allowing
+// the code to be reused by more types. Spec is never on the wire, but mapped from type in the code.
+type CommitmentOp struct {
+	Type  string
+	Spec  *ics23.ProofSpec
+	Key   []byte
+	Proof *ics23.CommitmentProof
+}
+
+var _ merkle.ProofOperator = CommitmentOp{}
+
+func NewIavlCommitmentOp(key []byte, proof *ics23.CommitmentProof) CommitmentOp {
+	return CommitmentOp{
+		Type:  ProofOpIAVLCommitment,
+		Spec:  ics23.IavlSpec,
+		Key:   key,
+		Proof: proof,
+	}
+}
+
+func NewSimpleMerkleCommitmentOp(key []byte, proof *ics23.CommitmentProof) CommitmentOp {
+	return CommitmentOp{
+		Type:  ProofOpSimpleMerkleCommitment,
+		Spec:  ics23.TendermintSpec,
+		Key:   key,
+		Proof: proof,
+	}
+}
+
+// CommitmentOpDecoder takes a merkle.ProofOp and attempts to decode it into a CommitmentOp ProofOperator
+// The proofOp.Data is just a marshalled CommitmentProof. The Key of the CommitmentOp is extracted
+// from the unmarshalled proof.
+func CommitmentOpDecoder(pop merkle.ProofOp) (merkle.ProofOperator, error) {
+	var spec *ics23.ProofSpec
+	switch pop.Type {
+	case ProofOpIAVLCommitment:
+		spec = ics23.IavlSpec
+	case ProofOpSimpleMerkleCommitment:
+		spec = ics23.TendermintSpec
+	default:
+		return nil, fmt.Errorf("unexpected ProofOp.Type; got %s, want supported ics23 subtypes 'ProofOpIAVLCommitment' or 'ProofOpSimpleMerkleCommitment'", pop.Type)
+	}
+
+	proof := &ics23.CommitmentProof{}
+	err := proof.Unmarshal(pop.Data)
+	if err != nil {
+		return nil, err
+	}
+
+	op := CommitmentOp{
+		Type:  pop.Type,
+		Key:   pop.Key,
+		Spec:  spec,
+		Proof: proof,
+	}
+	return op, nil
+}
+
+func (op CommitmentOp) GetKey() []byte {
+	return op.Key
+}
+
+// Run takes in a list of arguments and attempts to run the proof op against these arguments.
+// Returns the root wrapped in [][]byte if the proof op succeeds with given args. If not,
+// it will return an error.
+//
+// CommitmentOp will accept args of length 1 or length 0
+// If length 1 args is passed in, then CommitmentOp will attempt to prove the existence of the key
+// with the value provided by args[0] using the embedded CommitmentProof and return the CommitmentRoot of the proof.
+// If length 0 args is passed in, then CommitmentOp will attempt to prove the absence of the key
+// in the CommitmentOp and return the CommitmentRoot of the proof.
+func (op CommitmentOp) Run(args [][]byte) ([][]byte, error) {
+	// calculate root from proof
+	root, err := op.Proof.Calculate()
+	if err != nil {
+		return nil, fmt.Errorf("could not calculate root for proof: %v", err)
+	}
+	// Only support an existence proof or nonexistence proof (batch proofs currently unsupported)
+	switch len(args) {
+	case 0:
+		// Args are nil, so we verify the absence of the key.
+		absent := ics23.VerifyNonMembership(op.Spec, root, op.Proof, op.Key)
+		if !absent {
+			return nil, fmt.Errorf("proof did not verify absence of key: %s", string(op.Key))
+		}
+
+	case 1:
+		// Args is length 1, verify existence of key with value args[0]
+		if !ics23.VerifyMembership(op.Spec, root, op.Proof, op.Key, args[0]) {
+			return nil, fmt.Errorf("proof did not verify existence of key %s with given value %x", op.Key, args[0])
+		}
+	default:
+		return nil, fmt.Errorf("args must be length 0 or 1, got: %d", len(args))
+	}
+
+	return [][]byte{root}, nil
+}
+
+// ProofOp implements ProofOperator interface and converts a CommitmentOp
+// into a merkle.ProofOp format that can later be decoded by CommitmentOpDecoder
+// back into a CommitmentOp for proof verification
+func (op CommitmentOp) ProofOp() merkle.ProofOp {
+	bz, err := op.Proof.Marshal()
+	if err != nil {
+		panic(err.Error())
+	}
+	return merkle.ProofOp{
+		Type: op.Type,
+		Key:  op.Key,
+		Data: bz,
+	}
+}
+
+func VerifyValue(prt *merkle.ProofRuntime, root []byte, version int64, proof *merkle.Proof, keyPath string, value []byte) error {
+	poz, err := prt.DecodeProof(proof)
+	if err != nil {
+		return errors.Wrap(err, "decoding proof")
+	}
+
+	if len(poz) != 2 {
+		return fmt.Errorf("length of proof ops should be 2")
+	}
+
+	keys, err := merkle.KeyPathToKeys(keyPath)
+	if err != nil {
+		return fmt.Errorf("get keys error, err=%s", err.Error())
+	}
+
+	if len(keys) != 2 {
+		return fmt.Errorf("length of keys should be 2")
+	}
+
+	storeKey, valueKey := keys[0], keys[1]
+
+	iavlPo := poz[0]
+	if iavlPo.ProofOp().Type != ProofOpIAVLCommitment {
+		return fmt.Errorf("invalid proof op type, should be  %s", ProofOpIAVLCommitment)
+	}
+
+	if !bytes.Equal(valueKey, iavlPo.GetKey()) {
+		return fmt.Errorf("invalid proof of key, require %X, got %X", iavlPo.GetKey(), valueKey)
+	}
+
+	iavlRoot, err := iavlPo.Run([][]byte{value})
+	if err != nil {
+		return fmt.Errorf("invalid iavl proof, err=%s", err.Error())
+	}
+
+	if len(iavlRoot) != 1 {
+		return fmt.Errorf("invalid return of iavl proof")
+	}
+
+	// calculate store hash
+	storeInfo := StoreInfo{
+		Name: string(keys[1]),
+		Core: StoreCore{
+			CommitID: CommitID{
+				Version: version,
+				Hash:    iavlRoot[0],
+			},
+		},
+	}
+	storeHash := storeInfo.Hash()
+
+	simplePo := poz[1]
+	if !bytes.Equal(storeKey, simplePo.GetKey()) {
+		return fmt.Errorf("invalid proof of key, require %X, got %X", simplePo.GetKey(), storeKey)
+	}
+
+	storeRoot, err := simplePo.Run([][]byte{storeHash})
+	if len(storeRoot) != 1 {
+		return fmt.Errorf("invald return of simple proof")
+	}
+
+	if !bytes.Equal(root, storeRoot[0]) {
+		return errors.Errorf("Calculated root hash is invalid: expected %+v but got %+v", root, storeRoot[0])
+	}
+	return nil
+}

--- a/store/proof.go
+++ b/store/proof.go
@@ -1,10 +1,7 @@
 package store
 
 import (
-	"bytes"
 	"fmt"
-
-	"github.com/pkg/errors"
 
 	"github.com/bnb-chain/ics23"
 	"github.com/tendermint/tendermint/crypto/merkle"
@@ -130,75 +127,4 @@ func (op CommitmentOp) ProofOp() merkle.ProofOp {
 		Key:  op.Key,
 		Data: bz,
 	}
-}
-
-func VerifyValue(prt *merkle.ProofRuntime, root []byte, version int64, proof *merkle.Proof, keyPath string, value []byte) error {
-	poz, err := prt.DecodeProof(proof)
-	if err != nil {
-		return errors.Wrap(err, "decoding proof")
-	}
-
-	if len(poz) != 2 {
-		return fmt.Errorf("length of proof ops should be 2")
-	}
-
-	keys, err := merkle.KeyPathToKeys(keyPath)
-	if err != nil {
-		return fmt.Errorf("get keys error, err=%s", err.Error())
-	}
-
-	if len(keys) != 2 {
-		return fmt.Errorf("length of keys should be 2")
-	}
-
-	storeKey, valueKey := keys[0], keys[1]
-
-	iavlPo := poz[0]
-	if iavlPo.ProofOp().Type != ProofOpIAVLCommitment {
-		return fmt.Errorf("invalid proof op type, should be  %s", ProofOpIAVLCommitment)
-	}
-
-	if !bytes.Equal(valueKey, iavlPo.GetKey()) {
-		return fmt.Errorf("invalid proof of key, require %X, got %X", iavlPo.GetKey(), valueKey)
-	}
-
-	iavlRoot, err := iavlPo.Run([][]byte{value})
-	if err != nil {
-		return fmt.Errorf("invalid iavl proof, err=%s", err.Error())
-	}
-
-	if len(iavlRoot) != 1 {
-		return fmt.Errorf("invalid return of iavl proof")
-	}
-
-	// calculate store hash
-	storeInfo := StoreInfo{
-		Name: string(storeKey),
-		Core: StoreCore{
-			CommitID: CommitID{
-				Version: version,
-				Hash:    iavlRoot[0],
-			},
-		},
-	}
-	storeHash := storeInfo.Hash()
-
-	simplePo := poz[1]
-	if simplePo.ProofOp().Type != ProofOpSimpleMerkleCommitment {
-		return fmt.Errorf("invalid proof op type, should be  %s", ProofOpSimpleMerkleCommitment)
-	}
-
-	if !bytes.Equal(storeKey, simplePo.GetKey()) {
-		return fmt.Errorf("invalid proof of key, require %X, got %X", simplePo.GetKey(), storeKey)
-	}
-
-	storeRoot, err := simplePo.Run([][]byte{storeHash})
-	if len(storeRoot) != 1 {
-		return fmt.Errorf("invald return of simple proof")
-	}
-
-	if !bytes.Equal(root, storeRoot[0]) {
-		return errors.Errorf("Calculated root hash is invalid: expected %+v but got %+v", root, storeRoot[0])
-	}
-	return nil
 }

--- a/store/proofs/convert.go
+++ b/store/proofs/convert.go
@@ -1,0 +1,98 @@
+package proofs
+
+import (
+	"fmt"
+	"math/bits"
+
+	"github.com/bnb-chain/ics23"
+	"github.com/tendermint/tendermint/crypto/merkle"
+)
+
+// ConvertExistenceProof will convert the given proof into a valid
+// existence proof, if that's what it is.
+//
+// This is the simplest case of the range proof and we will focus on
+// demoing compatibility here
+func ConvertExistenceProof(p *merkle.SimpleProof, key, value []byte) (*ics23.ExistenceProof, error) {
+	path, err := convertInnerOps(p)
+	if err != nil {
+		return nil, err
+	}
+
+	proof := &ics23.ExistenceProof{
+		Key:   key,
+		Value: value,
+		Leaf:  convertLeafOp(),
+		Path:  path,
+	}
+	return proof, nil
+}
+
+// this is adapted from merkle/hash.go:leafHash()
+// and merkle/simple_map.go:KVPair.Bytes()
+func convertLeafOp() *ics23.LeafOp {
+	prefix := []byte{0}
+
+	return &ics23.LeafOp{
+		Hash:         ics23.HashOp_SHA256,
+		PrehashKey:   ics23.HashOp_NO_HASH,
+		PrehashValue: ics23.HashOp_SHA256,
+		Length:       ics23.LengthOp_VAR_PROTO,
+		Prefix:       prefix,
+	}
+}
+
+func convertInnerOps(p *merkle.SimpleProof) ([]*ics23.InnerOp, error) {
+	inners := make([]*ics23.InnerOp, 0, len(p.Aunts))
+	path := buildPath(int64(p.Index), int64(p.Total))
+
+	if len(p.Aunts) != len(path) {
+		return nil, fmt.Errorf("calculated a path different length (%d) than provided by SimpleProof (%d)", len(path), len(p.Aunts))
+	}
+
+	for i, aunt := range p.Aunts {
+		auntRight := path[i]
+
+		// combine with: 0x01 || lefthash || righthash
+		inner := &ics23.InnerOp{Hash: ics23.HashOp_SHA256}
+		if auntRight {
+			inner.Prefix = []byte{1}
+			inner.Suffix = aunt
+		} else {
+			inner.Prefix = append([]byte{1}, aunt...)
+		}
+		inners = append(inners, inner)
+	}
+	return inners, nil
+}
+
+// buildPath returns a list of steps from leaf to root
+// in each step, true means index is left side, false index is right side
+// code adapted from merkle/simple_proof.go:computeHashFromAunts
+func buildPath(idx, total int64) []bool {
+	if total < 2 {
+		return nil
+	}
+	numLeft := getSplitPoint(total)
+	goLeft := idx < numLeft
+
+	// we put goLeft at the end of the array, as we recurse from top to bottom,
+	// and want the leaf to be first in array, root last
+	if goLeft {
+		return append(buildPath(idx, numLeft), goLeft)
+	}
+	return append(buildPath(idx-numLeft, total-numLeft), goLeft)
+}
+
+func getSplitPoint(length int64) int64 {
+	if length < 1 {
+		panic("Trying to split a tree with size < 1")
+	}
+	uLength := uint(length)
+	bitlen := bits.Len(uLength)
+	k := int64(1 << uint(bitlen-1))
+	if k == length {
+		k >>= 1
+	}
+	return k
+}

--- a/store/proofs/convert_test.go
+++ b/store/proofs/convert_test.go
@@ -1,0 +1,105 @@
+package proofs
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+)
+
+func TestLeafOp(t *testing.T) {
+	proof := GenerateRangeProof(20, Middle)
+
+	converted, err := ConvertExistenceProof(proof.Proof, proof.Key, proof.Value)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	leaf := converted.GetLeaf()
+	if leaf == nil {
+		t.Fatalf("Missing leaf node")
+	}
+
+	hash, err := leaf.Apply(converted.Key, converted.Value)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(hash, proof.Proof.LeafHash) {
+		t.Errorf("Calculated: %X\nExpected:   %X", hash, proof.Proof.LeafHash)
+	}
+}
+
+func TestBuildPath(t *testing.T) {
+	cases := map[string]struct {
+		idx      int64
+		total    int64
+		expected []bool
+	}{
+		"pair left": {
+			idx:      0,
+			total:    2,
+			expected: []bool{true},
+		},
+		"pair right": {
+			idx:      1,
+			total:    2,
+			expected: []bool{false},
+		},
+		"power of 2": {
+			idx:      3,
+			total:    8,
+			expected: []bool{false, false, true},
+		},
+		"size of 7 right most": {
+			idx:      6,
+			total:    7,
+			expected: []bool{false, false},
+		},
+		"size of 6 right-left (from top)": {
+			idx:      4,
+			total:    6,
+			expected: []bool{true, false},
+		},
+		"size of 6 left-right-left (from top)": {
+			idx:      2,
+			total:    7,
+			expected: []bool{true, false, true},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			path := buildPath(tc.idx, tc.total)
+			if len(path) != len(tc.expected) {
+				t.Fatalf("Got %v\nExpected %v", path, tc.expected)
+			}
+			for i := range path {
+				if path[i] != tc.expected[i] {
+					t.Fatalf("Differ at %d\nGot %v\nExpected %v", i, path, tc.expected)
+				}
+			}
+		})
+	}
+}
+
+func TestConvertProof(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		t.Run(fmt.Sprintf("Run %d", i), func(t *testing.T) {
+			proof := GenerateRangeProof(57, Left)
+
+			converted, err := ConvertExistenceProof(proof.Proof, proof.Key, proof.Value)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			calc, err := converted.Calculate()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !bytes.Equal(calc, proof.RootHash) {
+				t.Errorf("Calculated: %X\nExpected:   %X", calc, proof.RootHash)
+			}
+		})
+	}
+}

--- a/store/proofs/create.go
+++ b/store/proofs/create.go
@@ -1,0 +1,121 @@
+package proofs
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+
+	"github.com/tendermint/tendermint/crypto/merkle"
+
+	"github.com/bnb-chain/ics23"
+)
+
+var (
+	ErrEmptyKey       = errors.New("key is empty")
+	ErrEmptyKeyInData = errors.New("data contains empty key")
+)
+
+// TendermintSpec constrains the format from ics23-tendermint (crypto/merkle SimpleProof)
+var TendermintSpec = &ics23.ProofSpec{
+	LeafSpec: &ics23.LeafOp{
+		Prefix:       []byte{0},
+		Hash:         ics23.HashOp_SHA256,
+		PrehashValue: ics23.HashOp_SHA256,
+		Length:       ics23.LengthOp_VAR_PROTO,
+	},
+	InnerSpec: &ics23.InnerSpec{
+		ChildOrder:      []int32{0, 1},
+		MinPrefixLength: 1,
+		MaxPrefixLength: 1,  // fixed prefix + one child
+		ChildSize:       32, // (no length byte)
+		Hash:            ics23.HashOp_SHA256,
+	},
+}
+
+/*
+CreateMembershipProof will produce a CommitmentProof that the given key (and queries value) exists in the iavl tree.
+If the key doesn't exist in the tree, this will return an error.
+*/
+func CreateMembershipProof(data map[string][]byte, key []byte) (*ics23.CommitmentProof, error) {
+	if len(key) == 0 {
+		return nil, ErrEmptyKey
+	}
+	exist, err := createExistenceProof(data, key)
+	if err != nil {
+		return nil, err
+	}
+	proof := &ics23.CommitmentProof{
+		Proof: &ics23.CommitmentProof_Exist{
+			Exist: exist,
+		},
+	}
+	return proof, nil
+}
+
+/*
+CreateNonMembershipProof will produce a CommitmentProof that the given key doesn't exist in the iavl tree.
+If the key exists in the tree, this will return an error.
+*/
+func CreateNonMembershipProof(data map[string][]byte, key []byte) (*ics23.CommitmentProof, error) {
+	if len(key) == 0 {
+		return nil, ErrEmptyKey
+	}
+	// ensure this key is not in the store
+	if _, ok := data[string(key)]; ok {
+		return nil, fmt.Errorf("cannot create non-membership proof if key is in map")
+	}
+
+	keys := SortedKeys(data)
+	rightidx := sort.SearchStrings(keys, string(key))
+
+	var err error
+	nonexist := &ics23.NonExistenceProof{
+		Key: key,
+	}
+
+	// include left proof unless key is left of entire map
+	if rightidx >= 1 {
+		leftkey := keys[rightidx-1]
+		nonexist.Left, err = createExistenceProof(data, []byte(leftkey))
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// include right proof unless key is right of entire map
+	if rightidx < len(keys) {
+		rightkey := keys[rightidx]
+		nonexist.Right, err = createExistenceProof(data, []byte(rightkey))
+		if err != nil {
+			return nil, err
+		}
+
+	}
+
+	proof := &ics23.CommitmentProof{
+		Proof: &ics23.CommitmentProof_Nonexist{
+			Nonexist: nonexist,
+		},
+	}
+	return proof, nil
+}
+
+func createExistenceProof(data map[string][]byte, key []byte) (*ics23.ExistenceProof, error) {
+	for k := range data {
+		if k == "" {
+			return nil, ErrEmptyKeyInData
+		}
+	}
+	value, ok := data[string(key)]
+	if !ok {
+		return nil, fmt.Errorf("cannot make existence proof if key is not in map")
+	}
+
+	_, ics23, _ := merkle.SimpleProofsFromMap(data)
+	proof := ics23[string(key)]
+	if proof == nil {
+		return nil, fmt.Errorf("returned no proof for key")
+	}
+
+	return ConvertExistenceProof(proof, key, value)
+}

--- a/store/proofs/create_test.go
+++ b/store/proofs/create_test.go
@@ -1,0 +1,112 @@
+package proofs
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/bnb-chain/ics23"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateMembership(t *testing.T) {
+	cases := map[string]struct {
+		size int
+		loc  Where
+	}{
+		"small left":   {size: 100, loc: Left},
+		"small middle": {size: 100, loc: Middle},
+		"small right":  {size: 100, loc: Right},
+		"big left":     {size: 5431, loc: Left},
+		"big middle":   {size: 5431, loc: Middle},
+		"big right":    {size: 5431, loc: Right},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			data := BuildMap(tc.size)
+			allkeys := SortedKeys(data)
+			key := GetKey(allkeys, tc.loc)
+			val := data[key]
+			proof, err := CreateMembershipProof(data, []byte(key))
+			if err != nil {
+				t.Fatalf("Creating Proof: %+v", err)
+			}
+			if proof.GetExist() == nil {
+				t.Fatal("Unexpected proof format")
+			}
+
+			root := CalcRoot(data)
+			err = proof.GetExist().Verify(TendermintSpec, root, []byte(key), val)
+			if err != nil {
+				t.Fatalf("Verifying Proof: %+v", err)
+			}
+
+			valid := ics23.VerifyMembership(TendermintSpec, root, proof, []byte(key), val)
+			if !valid {
+				t.Fatalf("Membership Proof Invalid")
+			}
+		})
+	}
+}
+
+func TestCreateNonMembership(t *testing.T) {
+	cases := map[string]struct {
+		size int
+		loc  Where
+	}{
+		"small left":   {size: 100, loc: Left},
+		"small middle": {size: 100, loc: Middle},
+		"small right":  {size: 100, loc: Right},
+		"big left":     {size: 5431, loc: Left},
+		"big middle":   {size: 5431, loc: Middle},
+		"big right":    {size: 5431, loc: Right},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			data := BuildMap(tc.size)
+			allkeys := SortedKeys(data)
+			key := GetNonKey(allkeys, tc.loc)
+
+			proof, err := CreateNonMembershipProof(data, []byte(key))
+			if err != nil {
+				t.Fatalf("Creating Proof: %+v", err)
+			}
+			if proof.GetNonexist() == nil {
+				t.Fatal("Unexpected proof format")
+			}
+
+			root := CalcRoot(data)
+			err = proof.GetNonexist().Verify(TendermintSpec, root, []byte(key))
+			if err != nil {
+				t.Fatalf("Verifying Proof: %+v", err)
+			}
+
+			valid := ics23.VerifyNonMembership(TendermintSpec, root, proof, []byte(key))
+			if !valid {
+				t.Fatalf("Non Membership Proof Invalid")
+			}
+		})
+	}
+}
+
+func TestInvalidKey(t *testing.T) {
+	tests := []struct {
+		name string
+		f    func(data map[string][]byte, key []byte) (*ics23.CommitmentProof, error)
+		data map[string][]byte
+		key  []byte
+		err  error
+	}{
+		{"CreateMembershipProof empty key", CreateMembershipProof, map[string][]byte{"": nil}, []byte(""), ErrEmptyKey},
+		{"CreateMembershipProof empty key in data", CreateMembershipProof, map[string][]byte{"": nil, " ": nil}, []byte(" "), ErrEmptyKeyInData},
+		{"CreateNonMembershipProof empty key", CreateNonMembershipProof, map[string][]byte{" ": nil}, []byte(""), ErrEmptyKey},
+		{"CreateNonMembershipProof empty key in data", CreateNonMembershipProof, map[string][]byte{"": nil}, []byte(" "), ErrEmptyKeyInData},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := tc.f(tc.data, tc.key)
+			assert.True(t, errors.Is(err, tc.err))
+		})
+	}
+}

--- a/store/proofs/helpers.go
+++ b/store/proofs/helpers.go
@@ -1,0 +1,107 @@
+package proofs
+
+import (
+	"fmt"
+	"math/rand"
+	"sort"
+
+	"github.com/tendermint/tendermint/crypto/merkle"
+)
+
+// SimpleResult contains a merkle.SimpleProof along with all data needed to build the confio/proof
+type SimpleResult struct {
+	Key      []byte
+	Value    []byte
+	Proof    *merkle.SimpleProof
+	RootHash []byte
+}
+
+// GenerateRangeProof makes a tree of size and returns a range proof for one random element
+//
+// returns a range proof and the root hash of the tree
+func GenerateRangeProof(size int, loc Where) *SimpleResult {
+	data := BuildMap(size)
+	root, proofs, allkeys := merkle.SimpleProofsFromMap(data)
+
+	rootHash := merkle.SimpleHashFromMap(data)
+	fmt.Printf("rootHash: %X\n root: %X\n", rootHash, root)
+
+	key := GetKey(allkeys, loc)
+	proof := proofs[key]
+
+	res := &SimpleResult{
+		Key:      []byte(key),
+		Value:    toValue(key),
+		Proof:    proof,
+		RootHash: root,
+	}
+	return res
+}
+
+// Where selects a location for a key - Left, Right, or Middle
+type Where int
+
+const (
+	Left Where = iota
+	Right
+	Middle
+)
+
+func SortedKeys(data map[string][]byte) []string {
+	keys := make([]string, len(data))
+	i := 0
+	for k := range data {
+		keys[i] = k
+		i++
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func CalcRoot(data map[string][]byte) []byte {
+	root, _, _ := merkle.SimpleProofsFromMap(data)
+	return root
+}
+
+// GetKey this returns a key, on Left/Right/Middle
+func GetKey(allkeys []string, loc Where) string {
+	if loc == Left {
+		return allkeys[0]
+	}
+	if loc == Right {
+		return allkeys[len(allkeys)-1]
+	}
+	// select a random index between 1 and allkeys-2
+	idx := rand.Int()%(len(allkeys)-2) + 1
+	return allkeys[idx]
+}
+
+// GetNonKey returns a missing key - Left of all, Right of all, or in the Middle
+func GetNonKey(allkeys []string, loc Where) string {
+	if loc == Left {
+		return string([]byte{1, 1, 1, 1})
+	}
+	if loc == Right {
+		return string([]byte{0xff, 0xff, 0xff, 0xff})
+	}
+	// otherwise, next to an existing key (copy before mod)
+	key := GetKey(allkeys, loc)
+	key = key[:len(key)-2] + string([]byte{255, 255})
+	return key
+}
+
+func toValue(key string) []byte {
+	return []byte("value_for_" + key)
+}
+
+// BuildMap creates random key/values and stores in a map,
+// returns a list of all keys in sorted order
+func BuildMap(size int) map[string][]byte {
+	data := make(map[string][]byte)
+	// insert lots of info and store the bytes
+	for i := 0; i < size; i++ {
+		key := Str(20)
+		data[key] = toValue(key)
+	}
+	return data
+}

--- a/store/proofs/random.go
+++ b/store/proofs/random.go
@@ -1,0 +1,310 @@
+package proofs
+
+import (
+	crand "crypto/rand"
+	mrand "math/rand"
+	"sync"
+	"time"
+)
+
+const (
+	strChars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz" // 62 characters
+)
+
+// Rand is a prng, that is seeded with OS randomness.
+// The OS randomness is obtained from crypto/rand, however none of the provided
+// methods are suitable for cryptographic usage.
+// They all utilize math/rand's prng internally.
+//
+// All of the methods here are suitable for concurrent use.
+// This is achieved by using a mutex lock on all of the provided methods.
+type Rand struct {
+	sync.Mutex
+	rand *mrand.Rand
+}
+
+var grand *Rand
+
+func init() {
+	grand = NewRand()
+	grand.init()
+}
+
+func NewRand() *Rand {
+	rand := &Rand{}
+	rand.init()
+	return rand
+}
+
+func (r *Rand) init() {
+	bz := cRandBytes(8)
+	var seed uint64
+	for i := 0; i < 8; i++ {
+		seed |= uint64(bz[i])
+		seed <<= 8
+	}
+	r.reset(int64(seed))
+}
+
+func (r *Rand) reset(seed int64) {
+	r.rand = mrand.New(mrand.NewSource(seed)) //nolint:gosec // G404: Use of weak random number generator
+}
+
+//----------------------------------------
+// Global functions
+
+func Seed(seed int64) {
+	grand.Seed(seed)
+}
+
+func Str(length int) string {
+	return grand.Str(length)
+}
+
+func Uint16() uint16 {
+	return grand.Uint16()
+}
+
+func Uint32() uint32 {
+	return grand.Uint32()
+}
+
+func Uint64() uint64 {
+	return grand.Uint64()
+}
+
+func Uint() uint {
+	return grand.Uint()
+}
+
+func Int16() int16 {
+	return grand.Int16()
+}
+
+func Int32() int32 {
+	return grand.Int32()
+}
+
+func Int64() int64 {
+	return grand.Int64()
+}
+
+func Int() int {
+	return grand.Int()
+}
+
+func Int31() int32 {
+	return grand.Int31()
+}
+
+func Int31n(n int32) int32 {
+	return grand.Int31n(n)
+}
+
+func Int63() int64 {
+	return grand.Int63()
+}
+
+func Int63n(n int64) int64 {
+	return grand.Int63n(n)
+}
+
+func Bool() bool {
+	return grand.Bool()
+}
+
+func Float32() float32 {
+	return grand.Float32()
+}
+
+func Float64() float64 {
+	return grand.Float64()
+}
+
+func Time() time.Time {
+	return grand.Time()
+}
+
+func Bytes(n int) []byte {
+	return grand.Bytes(n)
+}
+
+func Intn(n int) int {
+	return grand.Intn(n)
+}
+
+func Perm(n int) []int {
+	return grand.Perm(n)
+}
+
+//----------------------------------------
+// Rand methods
+
+func (r *Rand) Seed(seed int64) {
+	r.Lock()
+	r.reset(seed)
+	r.Unlock()
+}
+
+// Str constructs a random alphanumeric string of given length.
+func (r *Rand) Str(length int) string {
+	if length <= 0 {
+		return ""
+	}
+
+	chars := []byte{}
+MAIN_LOOP:
+	for {
+		val := r.Int63()
+		for i := 0; i < 10; i++ {
+			v := int(val & 0x3f) // rightmost 6 bits
+			if v >= 62 {         // only 62 characters in strChars
+				val >>= 6
+				continue
+			} else {
+				chars = append(chars, strChars[v])
+				if len(chars) == length {
+					break MAIN_LOOP
+				}
+				val >>= 6
+			}
+		}
+	}
+
+	return string(chars)
+}
+
+func (r *Rand) Uint16() uint16 {
+	return uint16(r.Uint32() & (1<<16 - 1))
+}
+
+func (r *Rand) Uint32() uint32 {
+	r.Lock()
+	u32 := r.rand.Uint32()
+	r.Unlock()
+	return u32
+}
+
+func (r *Rand) Uint64() uint64 {
+	return uint64(r.Uint32())<<32 + uint64(r.Uint32())
+}
+
+func (r *Rand) Uint() uint {
+	r.Lock()
+	i := r.rand.Int()
+	r.Unlock()
+	return uint(i)
+}
+
+func (r *Rand) Int16() int16 {
+	return int16(r.Uint32() & (1<<16 - 1))
+}
+
+func (r *Rand) Int32() int32 {
+	return int32(r.Uint32())
+}
+
+func (r *Rand) Int64() int64 {
+	return int64(r.Uint64())
+}
+
+func (r *Rand) Int() int {
+	r.Lock()
+	i := r.rand.Int()
+	r.Unlock()
+	return i
+}
+
+func (r *Rand) Int31() int32 {
+	r.Lock()
+	i31 := r.rand.Int31()
+	r.Unlock()
+	return i31
+}
+
+func (r *Rand) Int31n(n int32) int32 {
+	r.Lock()
+	i31n := r.rand.Int31n(n)
+	r.Unlock()
+	return i31n
+}
+
+func (r *Rand) Int63() int64 {
+	r.Lock()
+	i63 := r.rand.Int63()
+	r.Unlock()
+	return i63
+}
+
+func (r *Rand) Int63n(n int64) int64 {
+	r.Lock()
+	i63n := r.rand.Int63n(n)
+	r.Unlock()
+	return i63n
+}
+
+func (r *Rand) Float32() float32 {
+	r.Lock()
+	f32 := r.rand.Float32()
+	r.Unlock()
+	return f32
+}
+
+func (r *Rand) Float64() float64 {
+	r.Lock()
+	f64 := r.rand.Float64()
+	r.Unlock()
+	return f64
+}
+
+func (r *Rand) Time() time.Time {
+	return time.Unix(int64(r.Uint64()), 0)
+}
+
+// Bytes returns n random bytes generated from the internal
+// prng.
+func (r *Rand) Bytes(n int) []byte {
+	// cRandBytes isn't guaranteed to be fast so instead
+	// use random bytes generated from the internal PRNG
+	bs := make([]byte, n)
+	for i := 0; i < len(bs); i++ {
+		bs[i] = byte(r.Int() & 0xFF)
+	}
+	return bs
+}
+
+// Intn returns, as an int, a uniform pseudo-random number in the range [0, n).
+// It panics if n <= 0.
+func (r *Rand) Intn(n int) int {
+	r.Lock()
+	i := r.rand.Intn(n)
+	r.Unlock()
+	return i
+}
+
+// Bool returns a uniformly random boolean
+func (r *Rand) Bool() bool {
+	// See https://github.com/golang/go/issues/23804#issuecomment-365370418
+	// for reasoning behind computing like this
+	return r.Int63()%2 == 0
+}
+
+// Perm returns a pseudo-random permutation of n integers in [0, n).
+func (r *Rand) Perm(n int) []int {
+	r.Lock()
+	perm := r.rand.Perm(n)
+	r.Unlock()
+	return perm
+}
+
+// NOTE: This relies on the os's random number generator.
+// For real security, we should salt that with some seed.
+// See github.com/tendermint/tendermint/crypto for a more secure reader.
+func cRandBytes(numBytes int) []byte {
+	b := make([]byte, numBytes)
+	_, err := crand.Read(b)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}

--- a/store/rootmultistore.go
+++ b/store/rootmultistore.go
@@ -421,7 +421,7 @@ func (si StoreInfo) GetHash() []byte {
 // Hash returns the simple merkle root hash of the stores sorted by name.
 func (ci CommitInfo) Hash() []byte {
 	m := make(map[string][]byte, len(ci.StoreInfos))
-	if sdk.IsUpgrade(sdk.BEP154) {
+	if sdk.IsUpgrade(sdk.BEP171) {
 		for _, storeInfo := range ci.StoreInfos {
 			m[storeInfo.Name] = storeInfo.GetHash()
 		}
@@ -443,7 +443,7 @@ func (ci CommitInfo) CommitID() CommitID {
 
 func (ci CommitInfo) toMap() map[string][]byte {
 	m := make(map[string][]byte, len(ci.StoreInfos))
-	if sdk.IsUpgrade(sdk.BEP154) {
+	if sdk.IsUpgrade(sdk.BEP171) {
 		for _, storeInfo := range ci.StoreInfos {
 			m[storeInfo.Name] = storeInfo.Core.CommitID.Hash
 		}

--- a/store/rootmultistore.go
+++ b/store/rootmultistore.go
@@ -409,12 +409,23 @@ type CommitInfo struct {
 	StoreInfos []StoreInfo
 }
 
+// GetHash returns the GetHash from the CommitID.
+// This is used in CommitInfo.Hash()
+//
+// When we commit to this in a merkle proof, we create a map of storeInfo.Name -> storeInfo.GetHash()
+// and build a merkle proof from that.
+// This is then chained with the substore proof, so we prove the root hash from the substore before this
+// and need to pass that (unmodified) as the leaf value of the multistore proof.
+func (si StoreInfo) GetHash() []byte {
+	return si.Core.CommitID.Hash
+}
+
 // Hash returns the simple merkle root hash of the stores sorted by name.
 func (ci CommitInfo) Hash() []byte {
 	m := make(map[string][]byte, len(ci.StoreInfos))
 	if sdk.IsUpgrade(sdk.BEP154) {
 		for _, storeInfo := range ci.StoreInfos {
-			m[storeInfo.Name] = storeInfo.Core.CommitID.Hash
+			m[storeInfo.Name] = storeInfo.GetHash()
 		}
 	} else {
 		for _, storeInfo := range ci.StoreInfos {

--- a/store/rootmultistore.go
+++ b/store/rootmultistore.go
@@ -5,15 +5,13 @@ import (
 	"io"
 	"strings"
 
-	sdkproofs "github.com/cosmos/cosmos-sdk/store/proofs"
-
 	"github.com/bnb-chain/ics23"
-
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/crypto/merkle"
 	"github.com/tendermint/tendermint/crypto/tmhash"
 	dbm "github.com/tendermint/tendermint/libs/db"
 
+	sdkproofs "github.com/cosmos/cosmos-sdk/store/proofs"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 

--- a/store/rootmultistore.go
+++ b/store/rootmultistore.go
@@ -411,11 +411,17 @@ type CommitInfo struct {
 
 // Hash returns the simple merkle root hash of the stores sorted by name.
 func (ci CommitInfo) Hash() []byte {
-	// TODO cache to ci.hash []byte
 	m := make(map[string][]byte, len(ci.StoreInfos))
-	for _, storeInfo := range ci.StoreInfos {
-		m[storeInfo.Name] = storeInfo.Hash()
+	if sdk.IsUpgrade(sdk.BEP154) {
+		for _, storeInfo := range ci.StoreInfos {
+			m[storeInfo.Name] = storeInfo.Core.CommitID.Hash
+		}
+	} else {
+		for _, storeInfo := range ci.StoreInfos {
+			m[storeInfo.Name] = storeInfo.Hash()
+		}
 	}
+
 	return merkle.SimpleHashFromMap(m)
 }
 
@@ -428,8 +434,14 @@ func (ci CommitInfo) CommitID() CommitID {
 
 func (ci CommitInfo) toMap() map[string][]byte {
 	m := make(map[string][]byte, len(ci.StoreInfos))
-	for _, storeInfo := range ci.StoreInfos {
-		m[storeInfo.Name] = storeInfo.Hash()
+	if sdk.IsUpgrade(sdk.BEP154) {
+		for _, storeInfo := range ci.StoreInfos {
+			m[storeInfo.Name] = storeInfo.Core.CommitID.Hash
+		}
+	} else {
+		for _, storeInfo := range ci.StoreInfos {
+			m[storeInfo.Name] = storeInfo.Hash()
+		}
 	}
 
 	return m

--- a/store/rootmultistore_test.go
+++ b/store/rootmultistore_test.go
@@ -172,7 +172,7 @@ func TestMultiStoreQueryICS23Proof(t *testing.T) {
 func TestMultiStoreICS23Query(t *testing.T) {
 	// set upgrade env
 	sdk.UpgradeMgr.SetHeight(100)
-	sdk.UpgradeMgr.AddUpgradeHeight(sdk.BEP154, 1)
+	sdk.UpgradeMgr.AddUpgradeHeight(sdk.BEP171, 1)
 
 	db := dbm.NewMemDB()
 	multi := newMultiStoreWithMounts(db)

--- a/store/rootmultistore_test.go
+++ b/store/rootmultistore_test.go
@@ -3,11 +3,13 @@ package store
 import (
 	"testing"
 
+	"github.com/bnb-chain/ics23"
 	"github.com/stretchr/testify/require"
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/crypto/merkle"
 	dbm "github.com/tendermint/tendermint/libs/db"
 
+	sdkproofs "github.com/cosmos/cosmos-sdk/store/proofs"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -115,6 +117,114 @@ func TestParsePath(t *testing.T) {
 	require.Equal(t, substore, "bang")
 	require.Equal(t, subsubpath, "/baz")
 
+}
+
+func TestMultiStoreQueryICS23Proof(t *testing.T) {
+	db := dbm.NewMemDB()
+	multi := newMultiStoreWithMounts(db)
+	err := multi.LoadLatestVersion()
+	require.Nil(t, err)
+
+	k, v := []byte("wind"), []byte("blows")
+	k2, v2 := []byte("water"), []byte("flows")
+	// v3 := []byte("is cold")
+
+	cid := multi.Commit()
+
+	// Make sure we can get by name.
+	garbage := multi.getStoreByName("bad-name")
+	require.Nil(t, garbage)
+
+	// Set and commit data in one store.
+	store1 := multi.getStoreByName("store1").(KVStore)
+	store1.Set(k, v)
+
+	// ... and another.
+	store2 := multi.getStoreByName("store2").(KVStore)
+	store2.Set(k2, v2)
+
+	// Commit the multistore.
+	cid = multi.Commit()
+
+	commitInfo, _ := getCommitInfo(db, cid.Version)
+
+	cmap := commitInfo.toMap()
+	_, proofs, _ := merkle.SimpleProofsFromMap(cmap)
+
+	proof := proofs["store1"]
+	require.NotNil(t, proof)
+
+	// convert merkle.SimpleProof to CommitmentProof
+	existProof, err := sdkproofs.ConvertExistenceProof(proof, []byte("store1"), cmap["store1"])
+	require.Nil(t, err)
+
+	commitmentProof := &ics23.CommitmentProof{
+		Proof: &ics23.CommitmentProof_Exist{
+			Exist: existProof,
+		},
+	}
+
+	proofOp := NewSimpleMerkleCommitmentOp([]byte("store1"), commitmentProof)
+	result := ics23.VerifyMembership(proofOp.Spec, cid.Hash, proofOp.Proof, []byte("store1"), cmap["store1"])
+	require.True(t, result)
+}
+
+func TestMultiStoreICS23Query(t *testing.T) {
+	db := dbm.NewMemDB()
+	multi := newMultiStoreWithMounts(db)
+	err := multi.LoadLatestVersion()
+	require.Nil(t, err)
+
+	k, v := []byte("wind"), []byte("blows")
+	k2, v2 := []byte("water"), []byte("flows")
+	// v3 := []byte("is cold")
+
+	cid := multi.Commit()
+
+	// Make sure we can get by name.
+	garbage := multi.getStoreByName("bad-name")
+	require.Nil(t, garbage)
+
+	// Set and commit data in one store.
+	store1 := multi.getStoreByName("store1").(KVStore)
+	store1.Set(k, v)
+
+	// ... and another.
+	store2 := multi.getStoreByName("store2").(KVStore)
+	store2.Set(k2, v2)
+
+	// Commit the multistore.
+	cid = multi.Commit()
+	ver := cid.Version
+
+	// Reload multistore from database
+	multi = newMultiStoreWithMounts(db)
+	err = multi.LoadLatestVersion()
+	require.Nil(t, err)
+
+	// Test bad path.
+	query := abci.RequestQuery{Path: "/ics23-key", Data: k, Height: ver}
+	qres := multi.Query(query)
+	require.Equal(t, sdk.ToABCICode(sdk.CodespaceRoot, sdk.CodeUnknownRequest), sdk.ABCICodeType(qres.Code))
+
+	query.Path = "h897fy32890rf63296r92"
+	qres = multi.Query(query)
+	require.Equal(t, sdk.ToABCICode(sdk.CodespaceRoot, sdk.CodeUnknownRequest), sdk.ABCICodeType(qres.Code))
+
+	// Test invalid store name.
+	query.Path = "/garbage/key"
+	qres = multi.Query(query)
+	require.Equal(t, sdk.ToABCICode(sdk.CodespaceRoot, sdk.CodeUnknownRequest), sdk.ABCICodeType(qres.Code))
+
+	// Test valid query with data.
+	query.Path = "/store1/ics23-key"
+	query.Prove = true
+	qres = multi.Query(query)
+	require.Equal(t, sdk.ToABCICode(sdk.CodespaceRoot, sdk.CodeOK), sdk.ABCICodeType(qres.Code))
+	require.Equal(t, v, qres.Value)
+
+	err = VerifyValue(DefaultProofRuntime(), cid.Hash, ver, qres.Proof, "/store1/"+string(query.Data), qres.Value)
+	require.Nil(t, err)
 }
 
 func TestMultiStoreQuery(t *testing.T) {

--- a/store/rootmultistore_test.go
+++ b/store/rootmultistore_test.go
@@ -170,6 +170,10 @@ func TestMultiStoreQueryICS23Proof(t *testing.T) {
 }
 
 func TestMultiStoreICS23Query(t *testing.T) {
+	// set upgrade env
+	sdk.UpgradeMgr.SetHeight(100)
+	sdk.UpgradeMgr.AddUpgradeHeight(sdk.BEP154, 1)
+
 	db := dbm.NewMemDB()
 	multi := newMultiStoreWithMounts(db)
 	err := multi.LoadLatestVersion()
@@ -223,8 +227,13 @@ func TestMultiStoreICS23Query(t *testing.T) {
 	require.Equal(t, sdk.ToABCICode(sdk.CodespaceRoot, sdk.CodeOK), sdk.ABCICodeType(qres.Code))
 	require.Equal(t, v, qres.Value)
 
-	err = VerifyValue(DefaultProofRuntime(), cid.Hash, ver, qres.Proof, "/store1/"+string(query.Data), qres.Value)
-	require.Nil(t, err)
+	prt := DefaultProofRuntime()
+
+	err = prt.VerifyValue(qres.Proof, cid.Hash, "/store1/"+string(query.Data), qres.Value)
+	if err != nil {
+		println(err.Error())
+		return
+	}
 }
 
 func TestMultiStoreQuery(t *testing.T) {

--- a/types/upgrade.go
+++ b/types/upgrade.go
@@ -20,6 +20,7 @@ const (
 	BEP159                      = "BEP159"       // https://github.com/bnb-chain/BEPs/pull/159
 	BEP159Phase2                = "BEP159Phase2" // phase 2 activation height of BEP159, enable create validator and active oracle relayer whitelist
 	LimitConsAddrUpdateInterval = "LimitConsAddrUpdateInterval"
+	BEP171                      = "BEP171" //https://github.com/bnb-chain/BEPs/pull/171
 	BEP173                      = "BEP173" // https://github.com/bnb-chain/BEPs/pull/173
 	FixDoubleSignChainId        = "FixDoubleSignChainId"
 )


### PR DESCRIPTION
This pr will add ics23 proof to the multistore query. 

The new query path `ics23-key` will return ics23 proof if proof is requested.

Example ics23 proof query:

```go 
	query := abci.RequestQuery{
		Path: "/ibc/ics23-key", 
		Data: []byte("key"), 
		Height: ver,
		Prove: true,
	}
```

Also, we change the hash calculation of the root multistore (aka app hash), the reason is we can apply the ics23 proof directly by doing this.

## Reference

https://github.com/cosmos/cosmos-sdk/blob/c303d7f3417f67818bc1d2dce6b53732b0db81e4/store/types/commit_info.go#L23
