### PR TITLE
bep154: enable text proposal on BNB Smart Chain

### DIFF
--- a/types/upgrade.go
+++ b/types/upgrade.go
@@ -15,6 +15,7 @@ const (
 	FixFailAckPackage    = "FixFailAckPackage"
 	BEP128               = "BEP128" //https://github.com/bnb-chain/BEPs/pull/128
 	BEP153               = "BEP153" //https://github.com/bnb-chain/BEPs/pull/153
+	BEP154               = "BEP154" //https://github.com/bnb-chain/BEPs/pull/303
 )
 
 var MainNetConfig = UpgradeConfig{

--- a/x/gov/proposals_sidechain.go
+++ b/x/gov/proposals_sidechain.go
@@ -1,6 +1,6 @@
 package gov
 
-//nolint
+// nolint
 const (
 	// side chain params change
 	ProposalTypeSCParamsChange ProposalKind = 0x81
@@ -9,7 +9,8 @@ const (
 )
 
 func validSideProposalType(pt ProposalKind) bool {
-	if pt == ProposalTypeSCParamsChange ||
+	if pt == ProposalTypeText ||
+		pt == ProposalTypeSCParamsChange ||
 		pt == ProposalTypeCSCParamsChange {
 		return true
 	}


### PR DESCRIPTION
"Text" accepted as a valid BNB Smart Chain proposalType in proposals_sidechain.go
Updated upgrade.go to include BEP154  