### PR TITLE
feat: add tag and query API for cross stake reward

### DIFF
--- a/cmd/gaia/cmd/gaiacli/main.go
+++ b/cmd/gaia/cmd/gaiacli/main.go
@@ -82,6 +82,7 @@ func main() {
 		stakecmd.GetCmdQueryValidators(storeStake, cdc),
 		govcmd.GetCmdQueryVote(storeGov, cdc),
 		govcmd.GetCmdQueryVotes(storeGov, cdc),
+		stakecmd.GetCmdQueryCrossStakeRewardByBscAddress(storeStake, cdc),
 	)...)
 
 	//Add query commands

--- a/x/stake/client/cli/cmd.go
+++ b/x/stake/client/cli/cmd.go
@@ -56,6 +56,7 @@ func AddCommands(root *cobra.Command, cdc *codec.Codec) {
 			GetCmdQuerySideChainReDelegationsByValidator(cdc),
 			GetCmdQuerySideChainTopValidators(cdc),
 			GetCmdQuerySideAllValidatorsCount(cdc),
+			GetCmdQueryCrossStakeRewardByBscAddress(cdc),
 		)...,
 	)
 

--- a/x/stake/client/cli/query.go
+++ b/x/stake/client/cli/query.go
@@ -462,7 +462,7 @@ func GetCmdQueryPool(storeName string, cdc *codec.Codec) *cobra.Command {
 	return cmd
 }
 
-// GetCmdQueryPool implements the params query command.
+// GetCmdQueryParams implements the params query command.
 func GetCmdQueryParams(storeName string, cdc *codec.Codec) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "parameters",

--- a/x/stake/client/cli/query_sidechain.go
+++ b/x/stake/client/cli/query_sidechain.go
@@ -772,13 +772,7 @@ func GetCmdQueryCrossStakeRewardByBscAddress(cdc *codec.Codec) *cobra.Command {
 				return err
 			}
 
-			switch viper.Get(cli.OutputFlag) {
-			case "text":
-				fmt.Println("The reward balance is:", string(response))
-			case "json":
-				//TODO
-				fmt.Println("The reward balance is:", string(response))
-			}
+			fmt.Println("The reward balance of specified side chain address on BC is:", string(response))
 
 			return nil
 		},

--- a/x/stake/keeper/distribute_sidechain.go
+++ b/x/stake/keeper/distribute_sidechain.go
@@ -196,7 +196,7 @@ func (k Keeper) DistributeInBreathBlock(ctx sdk.Context, sideChainId string) sdk
 			if k.AddrPool != nil {
 				k.AddrPool.AddAddrs(changedAddrs[:])
 			}
-			rewardSum += totalReward
+			rewardSum += remainReward.RawInt()
 		}
 
 		if ctx.IsDeliverTx() && k.PbsbServer != nil {

--- a/x/stake/querier/queryable.go
+++ b/x/stake/querier/queryable.go
@@ -30,6 +30,7 @@ const (
 	QueryTopValidators                 = "topValidators"
 	QueryAllValidatorsCount            = "allValidatorsCount"
 	QueryAllUnJailValidatorsCount      = "allUnJailValidatorsCount"
+	QueryCrossStakeRewardByBscAddress  = "crossStakeRewardByBscAddress"
 )
 
 // creates a querier for staking REST endpoints
@@ -148,6 +149,13 @@ func NewQuerier(k keep.Keeper, cdc *codec.Codec) sdk.Querier {
 				return res, err
 			}
 			return queryAllUnJailValidatorsCount(ctx, cdc, k)
+		case QueryCrossStakeRewardByBscAddress:
+			p := new(QueryCrossStakeRewardParams)
+			ctx, err = RequestPrepare(ctx, k, req, p)
+			if err != nil {
+				return res, err
+			}
+			return queryCrossStakeRewardByBscAddress(ctx, cdc, p, k)
 		default:
 			return nil, sdk.ErrUnknownRequest("unknown stake query endpoint")
 		}
@@ -221,6 +229,12 @@ type QueryBondsParams struct {
 type QueryTopValidatorsParams struct {
 	BaseParams
 	Top int
+}
+
+// defines the params for 'custom/stake/crossStakeReward'
+type QueryCrossStakeRewardParams struct {
+	BaseParams
+	BscAddress sdk.SmartChainAddress
 }
 
 func queryValidators(ctx sdk.Context, cdc *codec.Codec, k keep.Keeper) (res []byte, err sdk.Error) {
@@ -415,6 +429,20 @@ func queryAllUnJailValidatorsCount(ctx sdk.Context, cdc *codec.Codec, k keep.Kee
 
 	count := k.GetAllUnJailValidatorsCount(ctx)
 	res, errRes := codec.MarshalJSONIndent(cdc, count)
+	if errRes != nil {
+		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", errRes.Error()))
+	}
+	return res, nil
+}
+
+func queryCrossStakeRewardByBscAddress(ctx sdk.Context, cdc *codec.Codec, params *QueryCrossStakeRewardParams, k keep.Keeper) ([]byte, sdk.Error) {
+	if params.BscAddress.IsEmpty() {
+		return []byte{}, sdk.ErrInternal("invalid side chain address")
+	}
+	delegateCAoB := types.GetStakeCAoB(params.BscAddress[:], types.DelegateCAoBSalt)
+	rewardCAoB := types.GetStakeCAoB(delegateCAoB.Bytes(), types.RewardCAoBSalt)
+	reward := k.BankKeeper.GetCoins(ctx, rewardCAoB).AmountOf(k.BondDenom(ctx))
+	res, errRes := codec.MarshalJSONIndent(cdc, reward)
 	if errRes != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", errRes.Error()))
 	}

--- a/x/stake/stake.go
+++ b/x/stake/stake.go
@@ -8,29 +8,30 @@ import (
 )
 
 type (
-	Keeper                     = keeper.Keeper
-	Validator                  = types.Validator
-	Description                = types.Description
-	Commission                 = types.Commission
-	Delegation                 = types.Delegation
-	UnbondingDelegation        = types.UnbondingDelegation
-	Redelegation               = types.Redelegation
-	Params                     = types.Params
-	Pool                       = types.Pool
-	MsgCreateValidator         = types.MsgCreateValidator
-	MsgRemoveValidator         = types.MsgRemoveValidator
-	MsgCreateValidatorProposal = types.MsgCreateValidatorProposal
-	MsgEditValidator           = types.MsgEditValidator
-	MsgDelegate                = types.MsgDelegate
-	MsgBeginUnbonding          = types.MsgBeginUnbonding
-	MsgBeginRedelegate         = types.MsgBeginRedelegate
-	GenesisState               = types.GenesisState
-	QueryDelegatorParams       = querier.QueryDelegatorParams
-	QueryValidatorParams       = querier.QueryValidatorParams
-	QueryBondsParams           = querier.QueryBondsParams
-	CreateValidatorJsonMsg     = types.CreateValidatorJsonMsg
-	QueryTopValidatorsParams   = querier.QueryTopValidatorsParams
-	BaseParams                 = querier.BaseParams
+	Keeper                      = keeper.Keeper
+	Validator                   = types.Validator
+	Description                 = types.Description
+	Commission                  = types.Commission
+	Delegation                  = types.Delegation
+	UnbondingDelegation         = types.UnbondingDelegation
+	Redelegation                = types.Redelegation
+	Params                      = types.Params
+	Pool                        = types.Pool
+	MsgCreateValidator          = types.MsgCreateValidator
+	MsgRemoveValidator          = types.MsgRemoveValidator
+	MsgCreateValidatorProposal  = types.MsgCreateValidatorProposal
+	MsgEditValidator            = types.MsgEditValidator
+	MsgDelegate                 = types.MsgDelegate
+	MsgBeginUnbonding           = types.MsgBeginUnbonding
+	MsgBeginRedelegate          = types.MsgBeginRedelegate
+	GenesisState                = types.GenesisState
+	QueryDelegatorParams        = querier.QueryDelegatorParams
+	QueryValidatorParams        = querier.QueryValidatorParams
+	QueryBondsParams            = querier.QueryBondsParams
+	QueryCrossStakeRewardParams = querier.QueryCrossStakeRewardParams
+	CreateValidatorJsonMsg      = types.CreateValidatorJsonMsg
+	QueryTopValidatorsParams    = querier.QueryTopValidatorsParams
+	BaseParams                  = querier.BaseParams
 
 	MsgCreateSideChainValidator = types.MsgCreateSideChainValidator
 	MsgEditSideChainValidator   = types.MsgEditSideChainValidator
@@ -146,6 +147,7 @@ const (
 	QueryDelegatorValidator            = querier.QueryDelegatorValidator
 	QueryPool                          = querier.QueryPool
 	QueryParameters                    = querier.QueryParameters
+	QueryCrossStakeReward              = querier.QueryCrossStakeRewardByBscAddress
 
 	Topic = types.Topic
 )


### PR DESCRIPTION
### Description

Add a tag for recon service and query api for user to get their cross stake reward by their bsc address

### Rationale

N/A

### Example

N/A

### Changes

- Add `QueryCrossStakeRewardByBscAddress` method
- Adjust total reward distrituion tag 
