### PR TITLE
bep173: enable text proposal on BNB Smart Chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+##v0.25.4
+* [sdk] [\#305](https://github.com/bnb-chain/bnc-cosmos-sdk/pull/305) BEP173: enable text proposal on BNB Smart Chain
+
+##v0.25.3
+* [sdk] [\#299](https://github.com/bnb-chain/bnc-cosmos-sdk/pull/299) Fix some audit and recon related issues
+
+##v0.25.2
+* [sdk] [\#295](https://github.com/bnb-chain/bnc-cosmos-sdk/pull/295) Update cross chain logic of native staking
+
 ##v0.25.1
 * [sdk] [\#290](https://github.com/bnb-chain/bnc-cosmos-sdk/pull/290) BEP153: Native Staking Implementation
 

--- a/cmd/gaia/cmd/gaiacli/main.go
+++ b/cmd/gaia/cmd/gaiacli/main.go
@@ -82,7 +82,6 @@ func main() {
 		stakecmd.GetCmdQueryValidators(storeStake, cdc),
 		govcmd.GetCmdQueryVote(storeGov, cdc),
 		govcmd.GetCmdQueryVotes(storeGov, cdc),
-		stakecmd.GetCmdQueryCrossStakeRewardByBscAddress(storeStake, cdc),
 	)...)
 
 	//Add query commands

--- a/types/upgrade.go
+++ b/types/upgrade.go
@@ -15,6 +15,7 @@ const (
 	FixFailAckPackage    = "FixFailAckPackage"
 	BEP128               = "BEP128" //https://github.com/bnb-chain/BEPs/pull/128
 	BEP153               = "BEP153" //https://github.com/bnb-chain/BEPs/pull/153
+	BEP173               = "BEP173" //https://github.com/bnb-chain/BEPs/pull/173
 )
 
 var MainNetConfig = UpgradeConfig{

--- a/x/gov/handler_sidechain.go
+++ b/x/gov/handler_sidechain.go
@@ -6,6 +6,10 @@ import (
 )
 
 func handleMsgSideChainSubmitProposal(ctx sdk.Context, keeper Keeper, msg MsgSideChainSubmitProposal) sdk.Result {
+	if msg.ProposalType == ProposalTypeText && !sdk.IsUpgrade(sdk.BEP173) {
+		return ErrInvalidProposalType(keeper.codespace, msg.ProposalType).Result()
+	}
+
 	ctx, err := keeper.ScKeeper.PrepareCtxForSideChain(ctx, msg.SideChainId)
 	if err != nil {
 		return ErrInvalidSideChainId(keeper.codespace, msg.SideChainId).Result()

--- a/x/gov/proposals_sidechain.go
+++ b/x/gov/proposals_sidechain.go
@@ -1,6 +1,6 @@
 package gov
 
-//nolint
+// nolint
 const (
 	// side chain params change
 	ProposalTypeSCParamsChange ProposalKind = 0x81
@@ -9,7 +9,8 @@ const (
 )
 
 func validSideProposalType(pt ProposalKind) bool {
-	if pt == ProposalTypeSCParamsChange ||
+	if pt == ProposalTypeText ||
+		pt == ProposalTypeSCParamsChange ||
 		pt == ProposalTypeCSCParamsChange {
 		return true
 	}


### PR DESCRIPTION
"Text" accepted as a valid BNB Smart Chain proposalType in proposals_sidechain.go

BEP154 upgrade validation to be handled in handler_sidechain.go

Tested the implementation before and after the BEP173 upgrade. Proposal type "Text" is accepted after the BEP173 upgrade.  

Commands:

Submit Text Proposal

./tbnbcli gov submit-proposal --type text …[flags]

Query Proposal

./tbnbcli gov query-proposal --proposal-id {id} ...[flags]

Voting 

./tbnbcli gov vote --option yes --proposal-id {id} ...[flags]