### PR TITLE
query: enrich cross stake info query

### DIFF
--- a/x/stake/client/cli/cmd.go
+++ b/x/stake/client/cli/cmd.go
@@ -56,7 +56,7 @@ func AddCommands(root *cobra.Command, cdc *codec.Codec) {
 			GetCmdQuerySideChainReDelegationsByValidator(cdc),
 			GetCmdQuerySideChainTopValidators(cdc),
 			GetCmdQuerySideAllValidatorsCount(cdc),
-			GetCmdQueryCrossStakeRewardByBscAddress(cdc),
+			GetCmdQueryCrossStakeInfoByBscAddress(cdc),
 		)...,
 	)
 

--- a/x/stake/client/cli/query_sidechain.go
+++ b/x/stake/client/cli/query_sidechain.go
@@ -739,11 +739,11 @@ func GetCmdQuerySideAllValidatorsCount(cdc *codec.Codec) *cobra.Command {
 	return cmd
 }
 
-// GetCmdQueryCrossStakeRewardByBscAddress implements the cross stake reward query command.
-func GetCmdQueryCrossStakeRewardByBscAddress(cdc *codec.Codec) *cobra.Command {
+// GetCmdQueryCrossStakeInfoByBscAddress implements the cross stake reward query command.
+func GetCmdQueryCrossStakeInfoByBscAddress(cdc *codec.Codec) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "cross-stake-reward",
-		Short: "Query the cross stake reward balance by BSC address",
+		Use:   "cross-stake-info",
+		Short: "Query the cross stake info by BSC address",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			bscAddress, err := sdk.NewSmartChainAddress(args[0])
@@ -767,12 +767,25 @@ func GetCmdQueryCrossStakeRewardByBscAddress(cdc *codec.Codec) *cobra.Command {
 				return err
 			}
 
-			response, err := cliCtx.QueryWithData("custom/stake/"+stake.QueryCrossStakeReward, bz)
+			response, err := cliCtx.QueryWithData("custom/stake/"+stake.QueryCrossStakeInfo, bz)
 			if err != nil {
 				return err
 			}
 
-			fmt.Println("The reward balance of specified side chain address on BC is:", string(response))
+			switch viper.Get(cli.OutputFlag) {
+			case "text":
+				var csResp types.CrossStakeInfoResponse
+				if err = cdc.UnmarshalJSON(response, &csResp); err != nil {
+					return err
+				}
+				resp, err := csResp.HumanReadableString()
+				if err != nil {
+					return err
+				}
+				fmt.Println(resp)
+			case "json":
+				fmt.Println(string(response))
+			}
 
 			return nil
 		},

--- a/x/stake/stake.go
+++ b/x/stake/stake.go
@@ -28,7 +28,7 @@ type (
 	QueryDelegatorParams        = querier.QueryDelegatorParams
 	QueryValidatorParams        = querier.QueryValidatorParams
 	QueryBondsParams            = querier.QueryBondsParams
-	QueryCrossStakeRewardParams = querier.QueryCrossStakeRewardParams
+	QueryCrossStakeRewardParams = querier.QueryCrossStakeInfoParams
 	CreateValidatorJsonMsg      = types.CreateValidatorJsonMsg
 	QueryTopValidatorsParams    = querier.QueryTopValidatorsParams
 	BaseParams                  = querier.BaseParams
@@ -147,7 +147,7 @@ const (
 	QueryDelegatorValidator            = querier.QueryDelegatorValidator
 	QueryPool                          = querier.QueryPool
 	QueryParameters                    = querier.QueryParameters
-	QueryCrossStakeReward              = querier.QueryCrossStakeRewardByBscAddress
+	QueryCrossStakeInfo                = querier.QueryCrossStakeInfoByBscAddress
 
 	Topic = types.Topic
 )

--- a/x/stake/types/cross_stake.go
+++ b/x/stake/types/cross_stake.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"fmt"
 	"math/big"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -95,4 +96,33 @@ type CrossStakeRefundPackage struct {
 func GetStakeCAoB(sourceAddr []byte, salt string) sdk.AccAddress {
 	saltBytes := []byte("Staking" + salt + "Address Anchor")
 	return sdk.XOR(tmhash.SumTruncated(saltBytes), sourceAddr)
+}
+
+// ----------------------------------------------------------------------------
+// Client Types
+
+type CrossStakeInfoResponse struct {
+	Reward            int64          `json:"reward"`
+	DelegationAddress sdk.AccAddress `json:"delegation_address"`
+	RewardAddress     sdk.AccAddress `json:"reward_address"`
+}
+
+// NewCrossStakeInfoResponse creates a new CrossStakeInfoResponse instance
+func NewCrossStakeInfoResponse(
+	delAddr sdk.AccAddress, rewardAddr sdk.AccAddress, reward int64,
+) CrossStakeInfoResponse {
+	return CrossStakeInfoResponse{
+		reward,
+		delAddr,
+		rewardAddr,
+	}
+}
+
+func (dr CrossStakeInfoResponse) HumanReadableString() (string, error) {
+	resp := "Delegation \n"
+	resp += fmt.Sprintf("Reward: %d\n", dr.Reward)
+	resp += fmt.Sprintf("Delegation address: %s\n", dr.DelegationAddress.String())
+	resp += fmt.Sprintf("Reward address: %s", dr.RewardAddress.String())
+
+	return resp, nil
 }


### PR DESCRIPTION
### Description

Rename the query method of cross stake reward to `QueryCrossStakeInfoByBscAddress` and add delegation address and reward address to the response.

### Rationale

N/A

### Example

N/A

### Changes

- Rename `QueryCrossStakeRewardByBscAddress` method to `QueryCrossStakeInfoByBscAddress`
- Add delegation address and reward address to the response
