### PR TITLE
docs: add change logs for release v0.25.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+##v0.25.6
+* [sdk] [\#312](https://github.com/bnb-chain/bnc-cosmos-sdk/pull/312) hardfork: add bsc chainID to encodeSigHeader when submitting evidence for slashing
+* [sdk] [\#294](https://github.com/bnb-chain/bnc-cosmos-sdk/pull/294) BEP153: Native Staking Implementation
+
+##v0.25.5
+* [sdk] [\#311](https://github.com/bnb-chain/bnc-cosmos-sdk/pull/311) query: enrich cross stake info query
 
 ##v0.25.4
 * [sdk] [\#305](https://github.com/bnb-chain/bnc-cosmos-sdk/pull/305) BEP173: enable text proposal on BNB Smart Chain

--- a/x/stake/client/cli/cmd.go
+++ b/x/stake/client/cli/cmd.go
@@ -69,7 +69,7 @@ func AddCommands(root *cobra.Command, cdc *codec.Codec) {
 			GetCmdQuerySideChainReDelegationsByValidator(cdc),
 			GetCmdQuerySideChainTopValidators(cdc),
 			GetCmdQuerySideAllValidatorsCount(cdc),
-			GetCmdQueryCrossStakeRewardByBscAddress(cdc),
+			GetCmdQueryCrossStakeInfoByBscAddress(cdc),
 		)...,
 	)
 

--- a/x/stake/querier/queryable.go
+++ b/x/stake/querier/queryable.go
@@ -30,7 +30,7 @@ const (
 	QueryTopValidators                 = "topValidators"
 	QueryAllValidatorsCount            = "allValidatorsCount"
 	QueryAllUnJailValidatorsCount      = "allUnJailValidatorsCount"
-	QueryCrossStakeRewardByBscAddress  = "crossStakeRewardByBscAddress"
+	QueryCrossStakeInfoByBscAddress    = "crossStakeInfoByBscAddress"
 )
 
 // creates a querier for staking REST endpoints
@@ -156,13 +156,13 @@ func NewQuerier(k keep.Keeper, cdc *codec.Codec) sdk.Querier {
 				return res, err
 			}
 			return queryAllUnJailValidatorsCount(ctx, cdc, k)
-		case QueryCrossStakeRewardByBscAddress:
-			p := new(QueryCrossStakeRewardParams)
+		case QueryCrossStakeInfoByBscAddress:
+			p := new(QueryCrossStakeInfoParams)
 			ctx, err = RequestPrepare(ctx, k, req, p)
 			if err != nil {
 				return res, err
 			}
-			return queryCrossStakeRewardByBscAddress(ctx, cdc, p, k)
+			return queryCrossStakeInfoByBscAddress(ctx, cdc, p, k)
 		default:
 			return nil, sdk.ErrUnknownRequest("unknown stake query endpoint")
 		}
@@ -245,8 +245,8 @@ type QueryRedelegationParams struct {
 	ValDstAddr    sdk.ValAddress
 }
 
-// defines the params for 'custom/stake/crossStakeReward'
-type QueryCrossStakeRewardParams struct {
+// defines the params for 'custom/stake/crossStakeInfo'
+type QueryCrossStakeInfoParams struct {
 	BaseParams
 	BscAddress sdk.SmartChainAddress
 }
@@ -462,14 +462,15 @@ func queryAllUnJailValidatorsCount(ctx sdk.Context, cdc *codec.Codec, k keep.Kee
 	return res, nil
 }
 
-func queryCrossStakeRewardByBscAddress(ctx sdk.Context, cdc *codec.Codec, params *QueryCrossStakeRewardParams, k keep.Keeper) ([]byte, sdk.Error) {
+func queryCrossStakeInfoByBscAddress(ctx sdk.Context, cdc *codec.Codec, params *QueryCrossStakeInfoParams, k keep.Keeper) ([]byte, sdk.Error) {
 	if params.BscAddress.IsEmpty() {
 		return []byte{}, sdk.ErrInternal("invalid side chain address")
 	}
-	delegateCAoB := types.GetStakeCAoB(params.BscAddress[:], types.DelegateCAoBSalt)
-	rewardCAoB := types.GetStakeCAoB(delegateCAoB.Bytes(), types.RewardCAoBSalt)
+	delCAoB := types.GetStakeCAoB(params.BscAddress[:], types.DelegateCAoBSalt)
+	rewardCAoB := types.GetStakeCAoB(delCAoB.Bytes(), types.RewardCAoBSalt)
 	reward := k.BankKeeper.GetCoins(ctx, rewardCAoB).AmountOf(k.BondDenom(ctx))
-	res, errRes := codec.MarshalJSONIndent(cdc, reward)
+	csResponse := types.NewCrossStakeInfoResponse(delCAoB, rewardCAoB, reward)
+	res, errRes := codec.MarshalJSONIndent(cdc, csResponse)
 	if errRes != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", errRes.Error()))
 	}

--- a/x/stake/stake.go
+++ b/x/stake/stake.go
@@ -8,32 +8,32 @@ import (
 )
 
 type (
-	Keeper                      = keeper.Keeper
-	Validator                   = types.Validator
-	Description                 = types.Description
-	Commission                  = types.Commission
-	Delegation                  = types.Delegation
-	UnbondingDelegation         = types.UnbondingDelegation
-	Redelegation                = types.Redelegation
-	Params                      = types.Params
-	Pool                        = types.Pool
-	MsgCreateValidator          = types.MsgCreateValidator
-	MsgCreateValidatorOpen      = types.MsgCreateValidatorOpen
-	MsgRemoveValidator          = types.MsgRemoveValidator
-	MsgCreateValidatorProposal  = types.MsgCreateValidatorProposal
-	MsgEditValidator            = types.MsgEditValidator
-	MsgDelegate                 = types.MsgDelegate
-	MsgBeginUnbonding           = types.MsgBeginUnbonding
-	MsgRedelegate               = types.MsgRedelegate
-	MsgUndelegate               = types.MsgUndelegate
-	GenesisState                = types.GenesisState
-	QueryDelegatorParams        = querier.QueryDelegatorParams
-	QueryValidatorParams        = querier.QueryValidatorParams
-	QueryBondsParams            = querier.QueryBondsParams
-	CreateValidatorJsonMsg      = types.CreateValidatorJsonMsg
-	QueryTopValidatorsParams    = querier.QueryTopValidatorsParams
-	BaseParams                  = querier.BaseParams
-	QueryCrossStakeRewardParams = querier.QueryCrossStakeRewardParams
+	Keeper                     = keeper.Keeper
+	Validator                  = types.Validator
+	Description                = types.Description
+	Commission                 = types.Commission
+	Delegation                 = types.Delegation
+	UnbondingDelegation        = types.UnbondingDelegation
+	Redelegation               = types.Redelegation
+	Params                     = types.Params
+	Pool                       = types.Pool
+	MsgCreateValidator         = types.MsgCreateValidator
+	MsgCreateValidatorOpen     = types.MsgCreateValidatorOpen
+	MsgRemoveValidator         = types.MsgRemoveValidator
+	MsgCreateValidatorProposal = types.MsgCreateValidatorProposal
+	MsgEditValidator           = types.MsgEditValidator
+	MsgDelegate                = types.MsgDelegate
+	MsgBeginUnbonding          = types.MsgBeginUnbonding
+	MsgRedelegate              = types.MsgRedelegate
+	MsgUndelegate              = types.MsgUndelegate
+	GenesisState               = types.GenesisState
+	QueryDelegatorParams       = querier.QueryDelegatorParams
+	QueryValidatorParams       = querier.QueryValidatorParams
+	QueryBondsParams           = querier.QueryBondsParams
+	QueryCrossStakeInfoParams  = querier.QueryCrossStakeInfoParams
+	CreateValidatorJsonMsg     = types.CreateValidatorJsonMsg
+	QueryTopValidatorsParams   = querier.QueryTopValidatorsParams
+	BaseParams                 = querier.BaseParams
 
 	MsgCreateSideChainValidator = types.MsgCreateSideChainValidator
 	MsgEditSideChainValidator   = types.MsgEditSideChainValidator
@@ -150,7 +150,7 @@ const (
 	QueryDelegatorValidator            = querier.QueryDelegatorValidator
 	QueryPool                          = querier.QueryPool
 	QueryParameters                    = querier.QueryParameters
-	QueryCrossStakeReward              = querier.QueryCrossStakeRewardByBscAddress
+	QueryCrossStakeInfo                = querier.QueryCrossStakeInfoByBscAddress
 
 	Topic = types.Topic
 )

--- a/x/stake/types/cross_stake.go
+++ b/x/stake/types/cross_stake.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"fmt"
 	"math/big"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -95,4 +96,33 @@ type CrossStakeRefundPackage struct {
 func GetStakeCAoB(sourceAddr []byte, salt string) sdk.AccAddress {
 	saltBytes := []byte("Staking" + salt + "Address Anchor")
 	return sdk.XOR(tmhash.SumTruncated(saltBytes), sourceAddr)
+}
+
+// ----------------------------------------------------------------------------
+// Client Types
+
+type CrossStakeInfoResponse struct {
+	Reward            int64          `json:"reward"`
+	DelegationAddress sdk.AccAddress `json:"delegation_address"`
+	RewardAddress     sdk.AccAddress `json:"reward_address"`
+}
+
+// NewCrossStakeInfoResponse creates a new CrossStakeInfoResponse instance
+func NewCrossStakeInfoResponse(
+	delAddr sdk.AccAddress, rewardAddr sdk.AccAddress, reward int64,
+) CrossStakeInfoResponse {
+	return CrossStakeInfoResponse{
+		reward,
+		delAddr,
+		rewardAddr,
+	}
+}
+
+func (dr CrossStakeInfoResponse) HumanReadableString() (string, error) {
+	resp := "Delegation \n"
+	resp += fmt.Sprintf("Reward: %d\n", dr.Reward)
+	resp += fmt.Sprintf("Delegation address: %s\n", dr.DelegationAddress.String())
+	resp += fmt.Sprintf("Reward address: %s", dr.RewardAddress.String())
+
+	return resp, nil
 }


### PR DESCRIPTION
### Description
This PR prepares for the release v0.25.6. 

This should be a hard fork release.
### Rationale
Changelogs:
* [sdk] [\#312](https://github.com/bnb-chain/bnc-cosmos-sdk/pull/312) hardfork: add bsc chainID to encodeSigHeader when submitting evidence for slashing
* [sdk] [\#294](https://github.com/bnb-chain/bnc-cosmos-sdk/pull/294) BEP153: Native Staking Implementation



### Example


### Changes
It is a hardfork release, everyone is encouraged to upgrade to latest version.
