### PR TITLE
feat: support unjail cli

### DIFF
--- a/x/slashing/client/cli/cmd.go
+++ b/x/slashing/client/cli/cmd.go
@@ -17,6 +17,7 @@ func AddCommands(root *cobra.Command, cdc *codec.Codec) {
 
 	slashingCmd.AddCommand(
 		client.PostCommands(
+			GetCmdUnjail(cdc),
 			GetCmdBscSubmitEvidence(cdc),
 			GetCmdSideChainUnjail(cdc),
 		)...)


### PR DESCRIPTION
Add `Unjail` cli support.

Example:

```
$ ./build/tbnbcli slashing unjail -h
unjail validator previously jailed for downtime

Usage:
  bnbcli slashing unjail [flags]

Flags:
      --account-number int   AccountNumber number to sign the tx
      --async                broadcast transactions asynchronously
      --chain-id string      Chain ID of tendermint node
      --dry                  Generate and return the tx bytes (do not broadcast)
      --dry-run              ignore the perform a simulation of a transaction, but don't broadcast it
      --from string          Name or address of private key with which to sign
      --generate-only        build an unsigned transaction and write it to STDOUT
  -h, --help                 help for unjail
      --indent               Add indent to JSON response
      --json                 return output in json format
      --ledger               Use a connected Ledger device
      --memo string          Memo to send along with transaction
      --node string          <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
      --offline              Offline mode. Do not query blockchain data
      --print-response       return tx response (only works with async = false) (default true)
      --sequence int         Sequence number to sign the tx
      --source int           Source of tx
      --trust-node           Trust connected full node (don't verify proofs for responses) (default true)
      --tss                  Use a tss vault

$ ./build/tbnbcli slashing unjail --from alice --node https://data-seed-pre-0-s1.binance.org:443 --trust-node --chain-id $chain_id
```