### PR TITLE
fix: fix the breaking change of genesis state for testnet

### DIFF
--- a/types/context.go
+++ b/types/context.go
@@ -8,6 +8,10 @@ import (
 	"github.com/tendermint/tendermint/libs/log"
 )
 
+const (
+	ChainIdGanges = "Binance-Chain-Ganges"
+)
+
 type Context struct {
 	ctx                context.Context
 	ms                 MultiStore

--- a/x/paramHub/hub.go
+++ b/x/paramHub/hub.go
@@ -34,41 +34,80 @@ func RegisterUpgradeBeginBlocker(paramHub *ParamHub) {
 		paramHub.UpdateFeeParams(ctx, swapFeeParams)
 	})
 	sdk.UpgradeMgr.RegisterBeginBlocker(sdk.LaunchBscUpgrade, func(ctx sdk.Context) {
-		updateFeeParams := []param.FeeParam{
-			&param.FixedFeeParams{MsgType: "side_create_validator", Fee: CreateSideChainValidatorFee, FeeFor: sdk.FeeForProposer},
-			&param.FixedFeeParams{MsgType: "side_edit_validator", Fee: EditSideChainValidatorFee, FeeFor: sdk.FeeForProposer},
-			&param.FixedFeeParams{MsgType: "side_delegate", Fee: SideChainDelegateFee, FeeFor: sdk.FeeForProposer},
-			&param.FixedFeeParams{MsgType: "side_redelegate", Fee: SideChainRedelegateFee, FeeFor: sdk.FeeForProposer},
-			&param.FixedFeeParams{MsgType: "side_undelegate", Fee: SideChainUndelegateFee, FeeFor: sdk.FeeForProposer},
+		if ctx.ChainID() == sdk.ChainIdGanges {
+			updateFeeParams := []param.FeeParam{
+				&param.FixedFeeParams{MsgType: "side_create_validator", Fee: CreateSideChainValidatorFee, FeeFor: sdk.FeeForProposer},
+				&param.FixedFeeParams{MsgType: "side_edit_validator", Fee: EditSideChainValidatorFee, FeeFor: sdk.FeeForProposer},
+				&param.FixedFeeParams{MsgType: "side_delegate", Fee: SideChainDelegateFee, FeeFor: sdk.FeeForProposer},
+				&param.FixedFeeParams{MsgType: "side_redelegate", Fee: SideChainRedelegateFee, FeeFor: sdk.FeeForProposer},
+				&param.FixedFeeParams{MsgType: "side_undelegate", Fee: SideChainUndelegateFee, FeeFor: sdk.FeeForProposer},
 
-			&param.FixedFeeParams{MsgType: "bsc_submit_evidence", Fee: BscSubmitEvidenceFee, FeeFor: sdk.FeeForProposer},
-			&param.FixedFeeParams{MsgType: "side_chain_unjail", Fee: SideChainUnjail, FeeFor: sdk.FeeForProposer},
+				&param.FixedFeeParams{MsgType: "bsc_submit_evidence", Fee: BscSubmitEvidenceFee, FeeFor: sdk.FeeForProposer},
+				&param.FixedFeeParams{MsgType: "side_chain_unjail", Fee: SideChainUnjail, FeeFor: sdk.FeeForProposer},
 
-			&param.FixedFeeParams{MsgType: "side_submit_proposal", Fee: SideProposeFee, FeeFor: sdk.FeeForProposer},
-			&param.FixedFeeParams{MsgType: "side_deposit", Fee: SideDepositFee, FeeFor: sdk.FeeForProposer},
-			&param.FixedFeeParams{MsgType: "side_vote", Fee: SideVoteFee, FeeFor: sdk.FeeForProposer},
+				&param.FixedFeeParams{MsgType: "side_submit_proposal", Fee: SideProposeFee, FeeFor: sdk.FeeForProposer},
+				&param.FixedFeeParams{MsgType: "side_deposit", Fee: SideDepositFee, FeeFor: sdk.FeeForProposer},
+				&param.FixedFeeParams{MsgType: "side_vote", Fee: SideVoteFee, FeeFor: sdk.FeeForProposer},
 
-			&param.FixedFeeParams{MsgType: "crossBind", Fee: CrossBindFee, FeeFor: sdk.FeeForProposer},
-			&param.FixedFeeParams{MsgType: "crossUnbind", Fee: CrossUnbindFee, FeeFor: sdk.FeeForProposer},
-			&param.FixedFeeParams{MsgType: "crossTransferOut", Fee: CrossTransferOutFee, FeeFor: sdk.FeeForProposer},
-			&param.FixedFeeParams{MsgType: "oracleClaim", Fee: sdk.ZeroFee, FeeFor: sdk.FeeFree},
+				&param.FixedFeeParams{MsgType: "crossBind", Fee: 1e6, FeeFor: sdk.FeeForProposer},
+				&param.FixedFeeParams{MsgType: "crossUnbind", Fee: 1e6, FeeFor: sdk.FeeForProposer},
+				&param.FixedFeeParams{MsgType: "crossTransferOut", Fee: 1e6, FeeFor: sdk.FeeForProposer},
+				&param.FixedFeeParams{MsgType: "oracleClaim", Fee: sdk.ZeroFee, FeeFor: sdk.FeeFree},
 
-			// Following fees are charged on BC, and received at BSC, they are still fees in a broad sense, so still
-			// decide to put it here, rather than in paramset.
-			&param.FixedFeeParams{MsgType: "crossBindRelayFee", Fee: CrossBindRelayFee, FeeFor: sdk.FeeForProposer},
-			&param.FixedFeeParams{MsgType: "crossUnbindRelayFee", Fee: CrossUnbindRelayFee, FeeFor: sdk.FeeForProposer},
-			&param.FixedFeeParams{MsgType: "crossTransferOutRelayFee", Fee: CrossTransferOutRelayFee, FeeFor: sdk.FeeForProposer},
+				// Following fees are charged on BC, and received at BSC, they are still fees in a broad sense, so still
+				// decide to put it here, rather than in paramset.
+				&param.FixedFeeParams{MsgType: "crossBindRelayFee", Fee: CrossBindRelayFee, FeeFor: sdk.FeeForProposer},
+				&param.FixedFeeParams{MsgType: "crossUnbindRelayFee", Fee: CrossUnbindRelayFee, FeeFor: sdk.FeeForProposer},
+				&param.FixedFeeParams{MsgType: "crossTransferOutRelayFee", Fee: 2e6, FeeFor: sdk.FeeForProposer},
+			}
+			paramHub.UpdateFeeParams(ctx, updateFeeParams)
+		} else {
+			updateFeeParams := []param.FeeParam{
+				&param.FixedFeeParams{MsgType: "side_create_validator", Fee: CreateSideChainValidatorFee, FeeFor: sdk.FeeForProposer},
+				&param.FixedFeeParams{MsgType: "side_edit_validator", Fee: EditSideChainValidatorFee, FeeFor: sdk.FeeForProposer},
+				&param.FixedFeeParams{MsgType: "side_delegate", Fee: SideChainDelegateFee, FeeFor: sdk.FeeForProposer},
+				&param.FixedFeeParams{MsgType: "side_redelegate", Fee: SideChainRedelegateFee, FeeFor: sdk.FeeForProposer},
+				&param.FixedFeeParams{MsgType: "side_undelegate", Fee: SideChainUndelegateFee, FeeFor: sdk.FeeForProposer},
+
+				&param.FixedFeeParams{MsgType: "bsc_submit_evidence", Fee: BscSubmitEvidenceFee, FeeFor: sdk.FeeForProposer},
+				&param.FixedFeeParams{MsgType: "side_chain_unjail", Fee: SideChainUnjail, FeeFor: sdk.FeeForProposer},
+
+				&param.FixedFeeParams{MsgType: "side_submit_proposal", Fee: SideProposeFee, FeeFor: sdk.FeeForProposer},
+				&param.FixedFeeParams{MsgType: "side_deposit", Fee: SideDepositFee, FeeFor: sdk.FeeForProposer},
+				&param.FixedFeeParams{MsgType: "side_vote", Fee: SideVoteFee, FeeFor: sdk.FeeForProposer},
+
+				&param.FixedFeeParams{MsgType: "crossBind", Fee: CrossBindFee, FeeFor: sdk.FeeForProposer},
+				&param.FixedFeeParams{MsgType: "crossUnbind", Fee: CrossUnbindFee, FeeFor: sdk.FeeForProposer},
+				&param.FixedFeeParams{MsgType: "crossTransferOut", Fee: CrossTransferOutFee, FeeFor: sdk.FeeForProposer},
+				&param.FixedFeeParams{MsgType: "oracleClaim", Fee: sdk.ZeroFee, FeeFor: sdk.FeeFree},
+
+				// Following fees are charged on BC, and received at BSC, they are still fees in a broad sense, so still
+				// decide to put it here, rather than in paramset.
+				&param.FixedFeeParams{MsgType: "crossBindRelayFee", Fee: CrossBindRelayFee, FeeFor: sdk.FeeForProposer},
+				&param.FixedFeeParams{MsgType: "crossUnbindRelayFee", Fee: CrossUnbindRelayFee, FeeFor: sdk.FeeForProposer},
+				&param.FixedFeeParams{MsgType: "crossTransferOutRelayFee", Fee: CrossTransferOutRelayFee, FeeFor: sdk.FeeForProposer},
+			}
+			paramHub.UpdateFeeParams(ctx, updateFeeParams)
 		}
-		paramHub.UpdateFeeParams(ctx, updateFeeParams)
 	})
 	sdk.UpgradeMgr.RegisterBeginBlocker(sdk.BEP8, func(ctx sdk.Context) {
-		miniTokenFeeParams := []param.FeeParam{
-			&param.FixedFeeParams{MsgType: "tinyIssueMsg", Fee: TinyIssueFee, FeeFor: sdk.FeeForAll},
-			&param.FixedFeeParams{MsgType: "miniIssueMsg", Fee: MiniIssueFee, FeeFor: sdk.FeeForAll},
-			&param.FixedFeeParams{MsgType: "miniTokensSetURI", Fee: MiniSetUriFee, FeeFor: sdk.FeeForProposer},
-			&param.FixedFeeParams{MsgType: "dexListMini", Fee: MiniListingFee, FeeFor: sdk.FeeForAll},
+		if ctx.ChainID() == sdk.ChainIdGanges {
+			miniTokenFeeParams := []param.FeeParam{
+				&param.FixedFeeParams{MsgType: "tinyIssueMsg", Fee: TinyIssueFee, FeeFor: sdk.FeeForAll},
+				&param.FixedFeeParams{MsgType: "miniIssueMsg", Fee: 4e8, FeeFor: sdk.FeeForAll},
+				&param.FixedFeeParams{MsgType: "miniTokensSetURI", Fee: MiniSetUriFee, FeeFor: sdk.FeeForProposer},
+				&param.FixedFeeParams{MsgType: "dexListMini", Fee: 10e8, FeeFor: sdk.FeeForAll},
+			}
+			paramHub.UpdateFeeParams(ctx, miniTokenFeeParams)
+		} else {
+			miniTokenFeeParams := []param.FeeParam{
+				&param.FixedFeeParams{MsgType: "tinyIssueMsg", Fee: TinyIssueFee, FeeFor: sdk.FeeForAll},
+				&param.FixedFeeParams{MsgType: "miniIssueMsg", Fee: MiniIssueFee, FeeFor: sdk.FeeForAll},
+				&param.FixedFeeParams{MsgType: "miniTokensSetURI", Fee: MiniSetUriFee, FeeFor: sdk.FeeForProposer},
+				&param.FixedFeeParams{MsgType: "dexListMini", Fee: MiniListingFee, FeeFor: sdk.FeeForAll},
+			}
+			paramHub.UpdateFeeParams(ctx, miniTokenFeeParams)
 		}
-		paramHub.UpdateFeeParams(ctx, miniTokenFeeParams)
 	})
 	sdk.UpgradeMgr.RegisterBeginBlocker(sdk.BEP82, func(ctx sdk.Context) {
 		updateFeeParams := []param.FeeParam{

--- a/x/stake/genesis.go
+++ b/x/stake/genesis.go
@@ -3,12 +3,12 @@ package stake
 import (
 	"fmt"
 
+	"github.com/pkg/errors"
 	abci "github.com/tendermint/tendermint/abci/types"
 	tmtypes "github.com/tendermint/tendermint/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/stake/types"
-	"github.com/pkg/errors"
 )
 
 // InitGenesis sets the pool and parameters for the provided keeper and

--- a/x/stake/keeper/params.go
+++ b/x/stake/keeper/params.go
@@ -3,10 +3,11 @@ package keeper
 import (
 	"time"
 
+	"github.com/tendermint/tendermint/crypto"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/params"
 	"github.com/cosmos/cosmos-sdk/x/stake/types"
-	"github.com/tendermint/tendermint/crypto"
 )
 
 // Default parameter namespace
@@ -161,8 +162,14 @@ func (k Keeper) SetParams(ctx sdk.Context, params types.Params) {
 	k.paramstore.Set(ctx, types.KeyMaxValidators, params.MaxValidators)
 	k.paramstore.Set(ctx, types.KeyBondDenom, params.BondDenom)
 	if sdk.IsUpgrade(sdk.LaunchBscUpgrade) {
-		k.paramstore.Set(ctx, types.KeyMinSelfDelegation, params.MinSelfDelegation)
-		k.paramstore.Set(ctx, types.KeyMinDelegationChange, params.MinDelegationChange)
+		if ctx.ChainID() == sdk.ChainIdGanges {
+			k.paramstore.Set(ctx, types.KeyMaxValidators, uint16(11))
+			k.paramstore.Set(ctx, types.KeyMinSelfDelegation, int64(5000000000000))
+			k.paramstore.Set(ctx, types.KeyMinDelegationChange, params.MinDelegationChange)
+		} else {
+			k.paramstore.Set(ctx, types.KeyMinSelfDelegation, params.MinSelfDelegation)
+			k.paramstore.Set(ctx, types.KeyMinDelegationChange, params.MinDelegationChange)
+		}
 	}
 	if sdk.IsUpgrade(sdk.BEP128) {
 		k.paramstore.Set(ctx, types.KeyRewardDistributionBatchSize, params.RewardDistributionBatchSize)


### PR DESCRIPTION
This pr will fix the [syncing issue of testnet](https://github.com/bnb-chain/node/issues/916). 

The root cause is the genesis params are changed after the testnet setup and the genesis params are not read from the genesis file but from the code. 

This pr will fix the breaking change of the genesis params so users can syncing from genesis state for tesnet.

