### PR TITLE
docs: add change logs for release v0.25.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Changelog
 
 ##v0.25.7
+
 * [sdk] [\#320](https://github.com/bnb-chain/bnc-cosmos-sdk/pull/320) fix: the breaking change of genesis state for testnet
 * [sdk] [\#319](https://github.com/bnb-chain/bnc-cosmos-sdk/pull/319) dep: update deps that were reported in OSV issues
+* [sdk] [\#318](https://github.com/bnb-chain/bnc-cosmos-sdk/pull/318) feat: limit sidechain consensus addr update interval
 * [sdk] [\#317](https://github.com/bnb-chain/bnc-cosmos-sdk/pull/317) fix: bnbcli params side-params error
 * [sdk] [\#316](https://github.com/bnb-chain/bnc-cosmos-sdk/pull/316) feat: support unjail cli
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 # Changelog
+
+##v0.25.7
+* [sdk] [\#320](https://github.com/bnb-chain/bnc-cosmos-sdk/pull/320) fix: the breaking change of genesis state for testnet
+* [sdk] [\#319](https://github.com/bnb-chain/bnc-cosmos-sdk/pull/319) dep: update deps that were reported in OSV issues
+* [sdk] [\#317](https://github.com/bnb-chain/bnc-cosmos-sdk/pull/317) fix: bnbcli params side-params error
+* [sdk] [\#316](https://github.com/bnb-chain/bnc-cosmos-sdk/pull/316) feat: support unjail cli
+
+
 ##v0.25.6
 * [sdk] [\#312](https://github.com/bnb-chain/bnc-cosmos-sdk/pull/312) hardfork: add bsc chainID to encodeSigHeader when submitting evidence for slashing
 * [sdk] [\#294](https://github.com/bnb-chain/bnc-cosmos-sdk/pull/294) BEP153: Native Staking Implementation


### PR DESCRIPTION
### Description
This PR prepares for the release v0.25.7. 
This should be a hard fork release.

### Rationale
Changelogs:
* [sdk] [\#320](https://github.com/bnb-chain/bnc-cosmos-sdk/pull/320) fix: the breaking change of genesis state for testnet
* [sdk] [\#319](https://github.com/bnb-chain/bnc-cosmos-sdk/pull/319) dep: update deps that were reported in OSV issues
* [sdk] [\#318](https://github.com/bnb-chain/bnc-cosmos-sdk/pull/318) feat: limit sidechain consensus addr update interval
* [sdk] [\#317](https://github.com/bnb-chain/bnc-cosmos-sdk/pull/317) fix: bnbcli params side-params error
* [sdk] [\#316](https://github.com/bnb-chain/bnc-cosmos-sdk/pull/316) feat: support unjail cli



### Example


### Changes
It is a hordfork release(LimitConsAddrUpdateInterval), it includes several bug fixes, and security updates.
