### PR TITLE
fix: place the upgrade check in right place

### DIFF
--- a/x/stake/handler_sidechain.go
+++ b/x/stake/handler_sidechain.go
@@ -73,6 +73,11 @@ func handleMsgCreateSideChainValidator(ctx sdk.Context, msg MsgCreateSideChainVa
 }
 
 func handleMsgEditSideChainValidator(ctx sdk.Context, msg MsgEditSideChainValidator, k keeper.Keeper) sdk.Result {
+	if len(msg.SideConsAddr) != 0 {
+		if !sdk.IsUpgrade(sdk.BEP159) {
+			return ErrEditConsensusKeyBeforeBEP159(k.Codespace()).Result()
+		}
+	}
 	if scCtx, err := k.ScKeeper.PrepareCtxForSideChain(ctx, msg.SideChainId); err != nil {
 		return ErrInvalidSideChainId(k.Codespace()).Result()
 	} else {

--- a/x/stake/stake.go
+++ b/x/stake/stake.go
@@ -168,18 +168,19 @@ const (
 )
 
 var (
-	ErrNilValidatorAddr           = types.ErrNilValidatorAddr
-	ErrNoValidatorFound           = types.ErrNoValidatorFound
-	ErrValidatorOwnerExists       = types.ErrValidatorOwnerExists
-	ErrValidatorPubKeyExists      = types.ErrValidatorPubKeyExists
-	ErrValidatorSideConsAddrExist = types.ErrValidatorSideConsAddrExists
-	ErrInvalidDelegator           = types.ErrInvalidDelegator
-	ErrValidatorJailed            = types.ErrValidatorJailed
-	ErrInvalidProposal            = types.ErrInvalidProposal
-	ErrBadRemoveValidator         = types.ErrBadRemoveValidator
-	ErrDescriptionLength          = types.ErrDescriptionLength
-	ErrCommissionNegative         = types.ErrCommissionNegative
-	ErrCommissionHuge             = types.ErrCommissionHuge
+	ErrNilValidatorAddr             = types.ErrNilValidatorAddr
+	ErrNoValidatorFound             = types.ErrNoValidatorFound
+	ErrEditConsensusKeyBeforeBEP159 = types.ErrEditConsensusKeyBeforeBEP159
+	ErrValidatorOwnerExists         = types.ErrValidatorOwnerExists
+	ErrValidatorPubKeyExists        = types.ErrValidatorPubKeyExists
+	ErrValidatorSideConsAddrExist   = types.ErrValidatorSideConsAddrExists
+	ErrInvalidDelegator             = types.ErrInvalidDelegator
+	ErrValidatorJailed              = types.ErrValidatorJailed
+	ErrInvalidProposal              = types.ErrInvalidProposal
+	ErrBadRemoveValidator           = types.ErrBadRemoveValidator
+	ErrDescriptionLength            = types.ErrDescriptionLength
+	ErrCommissionNegative           = types.ErrCommissionNegative
+	ErrCommissionHuge               = types.ErrCommissionHuge
 
 	ErrNilDelegatorAddr          = types.ErrNilDelegatorAddr
 	ErrBadDenom                  = types.ErrBadDenom

--- a/x/stake/types/errors.go
+++ b/x/stake/types/errors.go
@@ -52,6 +52,10 @@ func ErrNoValidatorFound(codespace sdk.CodespaceType) sdk.Error {
 	return sdk.NewError(codespace, CodeInvalidValidator, "validator does not exist for that address")
 }
 
+func ErrEditConsensusKeyBeforeBEP159(codespace sdk.CodespaceType) sdk.Error {
+	return sdk.NewError(codespace, CodeUnauthorized, "side consensus address cannot be updated before BEP159")
+}
+
 func ErrValidatorOwnerExists(codespace sdk.CodespaceType) sdk.Error {
 	return sdk.NewError(codespace, CodeInvalidValidator, "validator already exist for this operator address, must use new validator operator address")
 }

--- a/x/stake/types/msg_sidechain.go
+++ b/x/stake/types/msg_sidechain.go
@@ -185,16 +185,11 @@ func (msg MsgEditSideChainValidator) ValidateBasic() sdk.Error {
 			return err
 		}
 	}
-
 	if len(msg.SideConsAddr) != 0 {
-		if !sdk.IsUpgrade(sdk.BEP159) {
-			return sdk.NewError(DefaultCodespace, CodeInvalidInput, "side consensus address cannot be updated before BEP159")
-		}
 		if err := checkSideChainAddr("SideConsAddr", msg.SideConsAddr); err != nil {
 			return err
 		}
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
### Description
Currently the BEP159 upgrade check is placed in the `validateBasic` function which is stateless and dont have the context about block height,  it will cause the wrong check on cmd and SDK.

### Rationale
We move the check to the handler instead of `validateBasic`.

It wont impact the on-chain logic and will not cause hardfork.

### Example
No

