### PR TITLE
new slash mechanism

### DIFF
--- a/types/stake.go
+++ b/types/stake.go
@@ -15,7 +15,7 @@ const (
 	Bonded    BondStatus = 0x02
 )
 
-//BondStatusToString for pretty prints of Bond Status
+// BondStatusToString for pretty prints of Bond Status
 func BondStatusToString(b BondStatus) string {
 	switch b {
 	case 0x00:
@@ -73,6 +73,7 @@ type ValidatorSet interface {
 
 	Validator(Context, ValAddress) Validator            // get a particular validator by operator address
 	ValidatorByConsAddr(Context, ConsAddress) Validator // get a particular validator by consensus address
+	ValidatorByVoteAddr(Context, []byte) Validator      // get a particular validator by vote address
 	TotalPower(Context) Dec                             // total power of the validator set
 
 	// slash the validator and delegators of the validator, specifying offence height, offence power, and slash fraction

--- a/types/stake.go
+++ b/types/stake.go
@@ -50,6 +50,7 @@ type Validator interface {
 	GetDelegatorShares() Dec         // Total out standing delegator shares
 	GetBondHeight() int64            // height in which the validator became active
 	GetSideChainConsAddr() []byte    // validation consensus address on side chain
+	GetSideChainVoteAddr() []byte    // validation vote address on side chain
 	IsSideChainValidator() bool      // if it belongs to side chain
 }
 

--- a/x/slashing/errors.go
+++ b/x/slashing/errors.go
@@ -1,8 +1,9 @@
-//nolint
+// nolint
 package slashing
 
 import (
 	"fmt"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -21,16 +22,21 @@ const (
 	CodeSelfDelegationTooLowToUnjail CodeType = 105
 	CodeInvalidClaim                 CodeType = 106
 
-	CodeExpiredEvidence        CodeType = 201
-	CodeFailSlash              CodeType = 202
-	CodeHandledEvidence        CodeType = 203
-	CodeInvalidEvidence        CodeType = 204
-	CodeInvalidSideChain       CodeType = 205
-	CodeDuplicateDowntimeClaim CodeType = 206
+	CodeExpiredEvidence            CodeType = 201
+	CodeFailSlash                  CodeType = 202
+	CodeHandledEvidence            CodeType = 203
+	CodeInvalidEvidence            CodeType = 204
+	CodeInvalidSideChain           CodeType = 205
+	CodeDuplicateDowntimeClaim     CodeType = 206
+	CodeDuplicateMalicousVoteClaim CodeType = 207
 )
 
 func ErrNoValidatorForAddress(codespace sdk.CodespaceType) sdk.Error {
 	return sdk.NewError(codespace, CodeInvalidValidator, "that address is not associated with any known validator")
+}
+
+func ErrNoValidatorWithVoteAddr(codespace sdk.CodespaceType) sdk.Error {
+	return sdk.NewError(codespace, CodeInvalidValidator, "that vote address is not associated with any known validator")
 }
 
 func ErrBadValidatorAddr(codespace sdk.CodespaceType) sdk.Error {
@@ -79,6 +85,10 @@ func ErrInvalidSideChainId(codespace sdk.CodespaceType) sdk.Error {
 
 func ErrDuplicateDowntimeClaim(codespace sdk.CodespaceType) sdk.Error {
 	return sdk.NewError(codespace, CodeDuplicateDowntimeClaim, "duplicate downtime claim")
+}
+
+func ErrDuplicateMalicousVoteClaim(codespace sdk.CodespaceType) sdk.Error {
+	return sdk.NewError(codespace, CodeDuplicateMalicousVoteClaim, "duplicate malicious vote claim")
 }
 
 func ErrInvalidInput(codespace sdk.CodespaceType, msg string) sdk.Error {

--- a/x/slashing/errors.go
+++ b/x/slashing/errors.go
@@ -22,13 +22,13 @@ const (
 	CodeSelfDelegationTooLowToUnjail CodeType = 105
 	CodeInvalidClaim                 CodeType = 106
 
-	CodeExpiredEvidence            CodeType = 201
-	CodeFailSlash                  CodeType = 202
-	CodeHandledEvidence            CodeType = 203
-	CodeInvalidEvidence            CodeType = 204
-	CodeInvalidSideChain           CodeType = 205
-	CodeDuplicateDowntimeClaim     CodeType = 206
-	CodeDuplicateMalicousVoteClaim CodeType = 207
+	CodeExpiredEvidence             CodeType = 201
+	CodeFailSlash                   CodeType = 202
+	CodeHandledEvidence             CodeType = 203
+	CodeInvalidEvidence             CodeType = 204
+	CodeInvalidSideChain            CodeType = 205
+	CodeDuplicateDowntimeClaim      CodeType = 206
+	CodeDuplicateMaliciousVoteClaim CodeType = 207
 )
 
 func ErrNoValidatorForAddress(codespace sdk.CodespaceType) sdk.Error {
@@ -87,8 +87,8 @@ func ErrDuplicateDowntimeClaim(codespace sdk.CodespaceType) sdk.Error {
 	return sdk.NewError(codespace, CodeDuplicateDowntimeClaim, "duplicate downtime claim")
 }
 
-func ErrDuplicateMalicousVoteClaim(codespace sdk.CodespaceType) sdk.Error {
-	return sdk.NewError(codespace, CodeDuplicateMalicousVoteClaim, "duplicate malicious vote claim")
+func ErrDuplicateMaliciousVoteClaim(codespace sdk.CodespaceType) sdk.Error {
+	return sdk.NewError(codespace, CodeDuplicateMaliciousVoteClaim, "duplicate malicious vote claim")
 }
 
 func ErrInvalidInput(codespace sdk.CodespaceType, msg string) sdk.Error {

--- a/x/slashing/execute_test.go
+++ b/x/slashing/execute_test.go
@@ -1,9 +1,10 @@
 package slashing
 
 import (
-	"github.com/cosmos/cosmos-sdk/bsc/rlp"
 	"testing"
 	"time"
+
+	"github.com/cosmos/cosmos-sdk/bsc/rlp"
 
 	"github.com/stretchr/testify/require"
 
@@ -33,8 +34,8 @@ func TestSideChainSlashDowntime(t *testing.T) {
 	sideHeight := uint64(100)
 	sideChainId := "bsc"
 	sideTimestamp := ctx.BlockHeader().Time.Add(-6 * 60 * 60 * time.Second)
-	claim := SideDowntimeSlashPackage{
-		SideConsAddr:  sideConsAddr,
+	claim := SideSlashPackage{
+		SideAddr:      sideConsAddr,
 		SideHeight:    sideHeight,
 		SideChainId:   sdk.ChainID(1),
 		SideTimestamp: uint64(sideTimestamp.Unix()),
@@ -74,22 +75,22 @@ func TestSideChainSlashDowntime(t *testing.T) {
 
 	claim.SideHeight = 0
 	bz, _ := rlp.EncodeToBytes(&claim)
-	_, result = keeper.checkSideDowntimeSlashPackage(bz)
+	_, result = keeper.checkSideSlashPackage(bz)
 	require.NotNil(t, result)
 
 	claim.SideHeight = sideHeight
-	claim.SideConsAddr = createSideAddr(21)
+	claim.SideAddr = createSideAddr(21)
 
 	result = keeper.slashingSideDowntime(ctx, &claim)
 	require.NotNil(t, result)
 
-	claim.SideConsAddr = sideConsAddr
+	claim.SideAddr = sideConsAddr
 	claim.SideTimestamp = uint64(ctx.BlockHeader().Time.Add(-24 * 60 * 60 * time.Second).Unix())
 	result = keeper.slashingSideDowntime(ctx, &claim)
 	require.EqualValues(t, CodeExpiredEvidence, result.Code(), "Expected got 201 err code, but got err: %v", result)
 
 	claim.SideTimestamp = uint64(ctx.BlockHeader().Time.Add(-6 * 60 * 60 * time.Second).Unix())
-	claim.SideConsAddr = sideConsAddr
+	claim.SideAddr = sideConsAddr
 	claim.SideChainId = sdk.ChainID(2)
 
 	result = keeper.slashingSideDowntime(ctx, &claim)
@@ -97,7 +98,7 @@ func TestSideChainSlashDowntime(t *testing.T) {
 	require.EqualValues(t, CodeInvalidSideChain, result.Code(), "Expected got 205 error code, but got err: %v", result)
 
 	claim.SideHeight = sideHeight
-	claim.SideConsAddr = createSideAddr(20)
+	claim.SideAddr = createSideAddr(20)
 	claim.SideChainId = sdk.ChainID(1)
 
 	result = keeper.slashingSideDowntime(ctx, &claim)
@@ -138,8 +139,8 @@ func TestSlashDowntimeBalanceVerify(t *testing.T) {
 
 	sideHeight := uint64(50)
 	sideTimestamp := ctx.BlockHeader().Time.Add(-6 * 60 * 60 * time.Second)
-	claim := SideDowntimeSlashPackage{
-		SideConsAddr:  sideConsAddr2,
+	claim := SideSlashPackage{
+		SideAddr:      sideConsAddr2,
 		SideHeight:    sideHeight,
 		SideChainId:   sdk.ChainID(1),
 		SideTimestamp: uint64(sideTimestamp.Unix()),
@@ -166,8 +167,8 @@ func TestSlashDowntimeBalanceVerify(t *testing.T) {
 
 	sideHeight = uint64(80)
 	sideTimestamp = ctx.BlockHeader().Time.Add(-3 * 60 * 60 * time.Second)
-	claim = SideDowntimeSlashPackage{
-		SideConsAddr:  sideConsAddr2,
+	claim = SideSlashPackage{
+		SideAddr:      sideConsAddr2,
 		SideHeight:    sideHeight,
 		SideChainId:   sdk.ChainID(1),
 		SideTimestamp: uint64(sideTimestamp.Unix()),

--- a/x/slashing/keeper.go
+++ b/x/slashing/keeper.go
@@ -435,7 +435,7 @@ func (k *Keeper) slashingSideMaliciousVote(ctx sdk.Context, pack *SideSlashPacka
 
 	// Malicious vote confirmed
 	logger.Info(fmt.Sprintf("Confirmed malicious vote from %s at height %d, age %d is less than max age %d, summit at %d, jailed until %d before slashing",
-		sideConsAddr, pack.SideHeight, age, maxEvidenceAge, pack.SideTimestamp, uint64(signInfo.JailedUntil.Unix())))
+		sdk.HexAddress(sideConsAddr), pack.SideHeight, age, maxEvidenceAge, pack.SideTimestamp, uint64(signInfo.JailedUntil.Unix())))
 
 	slashAmt := k.DoubleSignSlashAmount(sideCtx)
 	validator, slashedAmt, err := k.validatorSet.SlashSideChain(ctx, sideChainName, sideConsAddr, sdk.NewDec(slashAmt))

--- a/x/slashing/keeper.go
+++ b/x/slashing/keeper.go
@@ -242,7 +242,7 @@ func (k *Keeper) ExecuteSynPackage(ctx sdk.Context, payload []byte, _ int64) sdk
 		if sideSlashPack.addrType == SideConsAddrType {
 			err = k.slashingSideDowntime(ctx, sideSlashPack)
 		} else if sideSlashPack.addrType == SideVoteAddrType {
-			err = k.slashingSideMalicousVote(ctx, sideSlashPack)
+			err = k.slashingSideMaliciousVote(ctx, sideSlashPack)
 		}
 	}
 	if err != nil {
@@ -388,7 +388,7 @@ func (k *Keeper) slashingSideDowntime(ctx sdk.Context, pack *SideSlashPackage) s
 	return nil
 }
 
-func (k *Keeper) slashingSideMalicousVote(ctx sdk.Context, pack *SideSlashPackage) sdk.Error {
+func (k *Keeper) slashingSideMaliciousVote(ctx sdk.Context, pack *SideSlashPackage) sdk.Error {
 	sideVoteAddr := pack.SideAddr
 	sideChainName, err := k.ScKeeper.GetDestChainName(pack.SideChainId)
 	if err != nil {
@@ -425,8 +425,8 @@ func (k *Keeper) slashingSideMalicousVote(ctx sdk.Context, pack *SideSlashPackag
 	// in duration of malicious vote slash, validator can only be slashed once, to protect validator from funds drained
 	if k.isMaliciousVoteSlashed(sideCtx, sideConsAddr) && pack.SideTimestamp < uint64(signInfo.JailedUntil.Second()) {
 		return ErrFailedToSlash(k.Codespace, "still in duration of lastest malicious vote slash")
-	} else if k.hasSlashRecord(sideCtx, sideConsAddr, MalicousVote, pack.SideHeight) {
-		return ErrDuplicateMalicousVoteClaim(k.Codespace)
+	} else if k.hasSlashRecord(sideCtx, sideConsAddr, MaliciousVote, pack.SideHeight) {
+		return ErrDuplicateMaliciousVoteClaim(k.Codespace)
 	}
 
 	slashAmt := k.DoubleSignSlashAmount(sideCtx)
@@ -454,7 +454,7 @@ func (k *Keeper) slashingSideMalicousVote(ctx sdk.Context, pack *SideSlashPackag
 	jailUntil := header.Time.Add(k.DoubleSignUnbondDuration(sideCtx))
 	sr := SlashRecord{
 		ConsAddr:         sideConsAddr,
-		InfractionType:   MalicousVote,
+		InfractionType:   MaliciousVote,
 		InfractionHeight: pack.SideHeight,
 		SlashHeight:      header.Height,
 		JailUntil:        jailUntil,
@@ -471,7 +471,7 @@ func (k *Keeper) slashingSideMalicousVote(ctx sdk.Context, pack *SideSlashPackag
 	if k.PbsbServer != nil {
 		event := SideSlashEvent{
 			Validator:              validator.GetOperator(),
-			InfractionType:         MalicousVote,
+			InfractionType:         MaliciousVote,
 			InfractionHeight:       int64(pack.SideHeight),
 			SlashHeight:            header.Height,
 			JailUtil:               jailUntil,

--- a/x/slashing/keeper.go
+++ b/x/slashing/keeper.go
@@ -420,7 +420,7 @@ func (k *Keeper) slashingSideMalicousVote(ctx sdk.Context, pack *SideSlashPackag
 		return sdk.ErrInternal(fmt.Sprintf("Expected signing info for validator %s but not found", sdk.HexEncode(sideConsAddr)))
 	}
 	// in duration of malicious vote slash, validator can only be slashed once, to protect validator from funds drained
-	if k.isMaliciousSlashed(sideCtx, sideConsAddr) && pack.SideTimestamp < uint64(signInfo.JailedUntil.Second()) {
+	if k.isMaliciousVoteSlashed(sideCtx, sideConsAddr) && pack.SideTimestamp < uint64(signInfo.JailedUntil.Second()) {
 		return ErrFailedToSlash(k.Codespace, "still in duration of lastest malicious vote slash")
 	} else if k.hasSlashRecord(sideCtx, sideConsAddr, MalicousVote, pack.SideHeight) {
 		return ErrDuplicateMalicousVoteClaim(k.Codespace)

--- a/x/slashing/keeper.go
+++ b/x/slashing/keeper.go
@@ -425,7 +425,7 @@ func (k *Keeper) slashingSideMaliciousVote(ctx sdk.Context, pack *SideSlashPacka
 		return sdk.ErrInternal(fmt.Sprintf("Expected signing info for validator %s but not found", sdk.HexEncode(sideConsAddr)))
 	}
 	// in duration of malicious vote slash, validator can only be slashed once, to protect validator from funds drained
-	if k.isMaliciousVoteSlashed(sideCtx, sideConsAddr) && pack.SideTimestamp < uint64(signInfo.JailedUntil.Second()) {
+	if k.isMaliciousVoteSlashed(sideCtx, sideConsAddr) && pack.SideTimestamp < uint64(signInfo.JailedUntil.Unix()) {
 		logger.Info(fmt.Sprintf("slashing is blocked because %s is still in duration of lastest malicious vote slash", sideConsAddr))
 		return ErrFailedToSlash(k.Codespace, "still in duration of lastest malicious vote slash")
 	} else if k.hasSlashRecord(sideCtx, sideConsAddr, MaliciousVote, pack.SideHeight) {
@@ -435,7 +435,7 @@ func (k *Keeper) slashingSideMaliciousVote(ctx sdk.Context, pack *SideSlashPacka
 
 	// Malicious vote confirmed
 	logger.Info(fmt.Sprintf("Confirmed malicious vote from %s at height %d, age %d is less than max age %d, summit at %d, jailed until %d before slashing",
-		sideConsAddr, pack.SideHeight, age, maxEvidenceAge, pack.SideTimestamp, uint64(signInfo.JailedUntil.Second())))
+		sideConsAddr, pack.SideHeight, age, maxEvidenceAge, pack.SideTimestamp, uint64(signInfo.JailedUntil.Unix())))
 
 	slashAmt := k.DoubleSignSlashAmount(sideCtx)
 	validator, slashedAmt, err := k.validatorSet.SlashSideChain(ctx, sideChainName, sideConsAddr, sdk.NewDec(slashAmt))

--- a/x/slashing/keeper.go
+++ b/x/slashing/keeper.go
@@ -414,6 +414,9 @@ func (k *Keeper) slashingSideMalicousVote(ctx sdk.Context, pack *SideSlashPackag
 	// because validator may edit vote addr, but previous vote addr would still point to this validator
 	// so validator can't escape from slashing by editing vote addr
 	// But once the voting private key is leaked, validator can't save itself by editing vote addr at the same time
+	//
+	// TODO: use snapshot to get mapping from vote addr to cons addr, then slash according to it;
+	//		 this will allow validator to edit it's vote addr when vote private key is leaked
 	sideConsAddr := []byte(validator.GetSideChainConsAddr())
 	signInfo, found := k.getValidatorSigningInfo(sideCtx, sideConsAddr)
 	if !found {

--- a/x/slashing/slash_record.go
+++ b/x/slashing/slash_record.go
@@ -13,7 +13,7 @@ import (
 const (
 	DoubleSign byte = iota
 	Downtime
-	MalicousVote
+	MaliciousVote
 )
 
 type SlashRecord struct {
@@ -159,7 +159,7 @@ func (k Keeper) isMaliciousVoteSlashed(ctx sdk.Context, consAddr []byte) bool {
 
 	for ; iterator.Valid(); iterator.Next() {
 		slashRecord := MustUnmarshalSlashRecord(k.cdc, iterator.Key(), iterator.Value())
-		if slashRecord.InfractionType == MalicousVote {
+		if slashRecord.InfractionType == MaliciousVote {
 			return true
 		}
 	}

--- a/x/slashing/slash_record.go
+++ b/x/slashing/slash_record.go
@@ -13,6 +13,7 @@ import (
 const (
 	DoubleSign byte = iota
 	Downtime
+	MalicousVote
 )
 
 type SlashRecord struct {

--- a/x/slashing/slash_record.go
+++ b/x/slashing/slash_record.go
@@ -151,6 +151,21 @@ func (k Keeper) getSlashRecordsByConsAddr(ctx sdk.Context, consAddr []byte) (sla
 	return
 }
 
+func (k Keeper) isMaliciousSlashed(ctx sdk.Context, consAddr []byte) bool {
+	store := ctx.KVStore(k.storeKey)
+	consAddrPrefixKey := GetSlashRecordsByAddrIndexKey(consAddr)
+	iterator := sdk.KVStorePrefixIterator(store, consAddrPrefixKey)
+	defer iterator.Close()
+
+	for ; iterator.Valid(); iterator.Next() {
+		slashRecord := MustUnmarshalSlashRecord(k.cdc, iterator.Key(), iterator.Value())
+		if slashRecord.InfractionType == MalicousVote {
+			return true
+		}
+	}
+	return false
+}
+
 func (k Keeper) getSlashRecordsByConsAddrAndType(ctx sdk.Context, consAddr []byte, infractionType byte) (slashRecords []SlashRecord) {
 	store := ctx.KVStore(k.storeKey)
 	consAddrPrefixKey := GetSlashRecordsByAddrAndTypeIndexKey(consAddr, infractionType)

--- a/x/slashing/slash_record.go
+++ b/x/slashing/slash_record.go
@@ -151,7 +151,7 @@ func (k Keeper) getSlashRecordsByConsAddr(ctx sdk.Context, consAddr []byte) (sla
 	return
 }
 
-func (k Keeper) isMaliciousSlashed(ctx sdk.Context, consAddr []byte) bool {
+func (k Keeper) isMaliciousVoteSlashed(ctx sdk.Context, consAddr []byte) bool {
 	store := ctx.KVStore(k.storeKey)
 	consAddrPrefixKey := GetSlashRecordsByAddrIndexKey(consAddr)
 	iterator := sdk.KVStorePrefixIterator(store, consAddrPrefixKey)

--- a/x/slashing/types.go
+++ b/x/slashing/types.go
@@ -2,9 +2,17 @@ package slashing
 
 import "github.com/cosmos/cosmos-sdk/types"
 
-type SideDowntimeSlashPackage struct {
-	SideConsAddr  []byte        `json:"side_cons_addr"`
+type AddressType int
+
+const (
+	SideConsAddrType AddressType = iota + 1
+	SideVoteAddrType
+)
+
+type SideSlashPackage struct {
+	SideAddr      []byte        `json:"side_addr"`
 	SideHeight    uint64        `json:"side_height"`
 	SideChainId   types.ChainID `json:"side_chain_id"`
 	SideTimestamp uint64        `json:"side_timestamp"`
+	addrType      AddressType   `rlp:"-"`
 }

--- a/x/stake/keeper/sdk_types.go
+++ b/x/stake/keeper/sdk_types.go
@@ -65,6 +65,15 @@ func (k Keeper) ValidatorByConsAddr(ctx sdk.Context, addr sdk.ConsAddress) sdk.V
 	return val
 }
 
+// get the sdk.validator for a particular vote address
+func (k Keeper) ValidatorByVoteAddr(ctx sdk.Context, VoteAddress []byte) sdk.Validator {
+	val, found := k.GetValidatorBySideVoteAddr(ctx, VoteAddress)
+	if !found {
+		return nil
+	}
+	return val
+}
+
 // get the sdk.validator for a particular consensus address
 func (k Keeper) ValidatorBySideChainConsAddr(ctx sdk.Context, sideChainConsAddr []byte) sdk.Validator {
 	val, found := k.GetValidatorBySideConsAddr(ctx, sideChainConsAddr)

--- a/x/stake/types/validator.go
+++ b/x/stake/types/validator.go
@@ -624,6 +624,7 @@ func (v Validator) GetCommission() sdk.Dec       { return v.Commission.Rate }
 func (v Validator) GetDelegatorShares() sdk.Dec  { return v.DelegatorShares }
 func (v Validator) GetBondHeight() int64         { return v.BondHeight }
 func (v Validator) GetSideChainConsAddr() []byte { return v.SideConsAddr }
+func (v Validator) GetSideChainVoteAddr() []byte { return v.SideVoteAddr }
 func (v Validator) IsSideChainValidator() bool   { return len(v.SideChainId) != 0 }
 
 func (v Validator) IsSelfDelegator(address sdk.AccAddress) bool { return v.FeeAddr.Equals(address) }


### PR DESCRIPTION
Description
    introduce a new type of slashing for malicious vote.
    it's trigged by crossschain package from systemscontracts in bsc and reuse params of double sign slashing, with following features:
            a. one validator can't be slashed when it has been slashed for malicious vote previous and still in jail
            b. validator can't escape from slashing by editing vote address after malicious vote

Rationale
    

Example
tested in new qa

Changes
NA