### PR TITLE
release: prepares for the release of v0.26.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+##v0.26.2
+* [cli] [\#336] (https://github.com/bnb-chain/bnc-cosmos-sdk/pull/336) fix: fix merkle proof invalid issue of cli query
+
 ##v0.26.1
 * [sdk] [\#331] (https://github.com/bnb-chain/bnc-cosmos-sdk/pull/331) fix: fix the bug introduced by fixing the testnet syncing issue
 

--- a/client/context/query.go
+++ b/client/context/query.go
@@ -43,7 +43,7 @@ func (ctx CLIContext) QueryWithData(path string, data []byte) (res []byte, err e
 // QueryStore performs a query from a Tendermint node with the provided key and
 // store name.
 func (ctx CLIContext) QueryStore(key cmn.HexBytes, storeName string) (res []byte, err error) {
-	return ctx.queryStore(key, storeName, "key")
+	return ctx.queryStore(key, storeName, "ics23-key")
 }
 
 // QuerySubspace performs a query from a Tendermint node with the provided
@@ -279,11 +279,11 @@ func parseQueryStorePath(path string) (storeName string, err error) {
 	paths := strings.SplitN(path[1:], "/", 3)
 	switch {
 	case len(paths) != 3:
-		return "", errors.New("expected format like /store/<storeName>/key")
+		return "", errors.New("expected format like /store/<storeName>/key|ics23-key")
 	case paths[0] != "store":
-		return "", errors.New("expected format like /store/<storeName>/key")
-	case paths[2] != "key":
-		return "", errors.New("expected format like /store/<storeName>/key")
+		return "", errors.New("expected format like /store/<storeName>/key|ics23-key")
+	case paths[2] != "key" && paths[2] != "ics23-key":
+		return "", errors.New("expected format like /store/<storeName>/key|ics23-key")
 	}
 
 	return paths[1], nil


### PR DESCRIPTION
# Description

This pr prepares for the release of v0.26.2, which is a bug-fix release.

# Changes

(https://github.com/bnb-chain/bnc-cosmos-sdk/pull/336) fix: fix merkle proof invalid issue of cli query

# Example
```
❯ ./tbnbcli token info --symbol BUSD-BAF --chain-id=Binance-Chain-Ganges --node=data-seed-pre-0-s3.binance.org:80
{
  "type": "bnbchain/Token",
  "value": {
    "name": "BUSD token",
    "symbol": "BUSD-BAF",
    "original_symbol": "BUSD",
    "total_supply": "16000000.00000000",
    "owner": "tbnb15yqj8s26vvf4l62954pr9wh8ltypwuzkmqwre4",
    "mintable": false,
    "contract_address": "0xeD24FC36d5Ee211Ea25A80239Fb8C4Cfd80f12Ee",
    "contract_decimals": 18
  }
}
```
