### PR TITLE
fix: use height in store for checking upgrade status

### DIFF
--- a/store/rootmultistore.go
+++ b/store/rootmultistore.go
@@ -421,7 +421,7 @@ func (si StoreInfo) GetHash() []byte {
 // Hash returns the simple merkle root hash of the stores sorted by name.
 func (ci CommitInfo) Hash() []byte {
 	m := make(map[string][]byte, len(ci.StoreInfos))
-	if sdk.IsUpgrade(sdk.BEP171) {
+	if sdk.IsUpgradeWithHeight(sdk.BEP171, ci.Version) {
 		for _, storeInfo := range ci.StoreInfos {
 			m[storeInfo.Name] = storeInfo.GetHash()
 		}
@@ -443,7 +443,7 @@ func (ci CommitInfo) CommitID() CommitID {
 
 func (ci CommitInfo) toMap() map[string][]byte {
 	m := make(map[string][]byte, len(ci.StoreInfos))
-	if sdk.IsUpgrade(sdk.BEP171) {
+	if sdk.IsUpgradeWithHeight(sdk.BEP171, ci.Version) {
 		for _, storeInfo := range ci.StoreInfos {
 			m[storeInfo.Name] = storeInfo.Core.CommitID.Hash
 		}

--- a/types/upgrade.go
+++ b/types/upgrade.go
@@ -173,6 +173,15 @@ func IsUpgrade(name string) bool {
 	return UpgradeMgr.GetHeight() >= upgradeHeight
 }
 
+func IsUpgradeWithHeight(name string, height int64) bool {
+	upgradeHeight := UpgradeMgr.GetUpgradeHeight(name)
+	if upgradeHeight == 0 {
+		return false
+	}
+
+	return height >= upgradeHeight
+}
+
 func ShouldCommitStore(storeKeyName string) bool {
 	storeKeyHeight := UpgradeMgr.GetStoreKeyHeight(storeKeyName)
 	if storeKeyHeight == 0 {


### PR DESCRIPTION
### Description

This pr will fix the issue that we can not get the right commit id when there is a fork to calculate the hash of the merkle tree.

It will use the height of the commit itself to check the upgrade status instead of the height set in begin block when calculating the hash of the merkle trees.

### Rationale

Fix issue calculate store hash.

### Example

N/A

### Changes

Notable changes:
* use height in store for checking upgrade status
