### PR TITLE
release: draft release for v0.26.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+##v0.26.4
+* [fix] [\#345] (https://github.com/bnb-chain/bnc-cosmos-sdk/pull/345) fix: fix validator unmarshal failed issue
+
 ##v0.26.3
 * [sdk] [\#289] (https://github.com/bnb-chain/bnc-cosmos-sdk/pull/289) feat: implement bep126
 * [sdk] [\#335] (https://github.com/bnb-chain/bnc-cosmos-sdk/pull/335) feat: implement new slash mechanism

--- a/x/stake/types/validator.go
+++ b/x/stake/types/validator.go
@@ -47,10 +47,11 @@ type Validator struct {
 	SideChainId      string         `json:"side_chain_id,omitempty"`     // side chain id to distinguish different side chains
 	SideConsAddr     []byte         `json:"side_cons_addr,omitempty"`    // consensus address of the side chain validator, this replaces the `ConsPubKey`
 	SideFeeAddr      []byte         `json:"side_fee_addr,omitempty"`     // fee address on the side chain
-	SideVoteAddr     []byte         `json:"side_vote_addr,omitempty"`    // bls vote address on the side chain
 
 	StakeSnapshots   []sdk.Dec `json:"stake_snapshots,omitempty"`   // staked tokens snapshot over a period of time, e.g. 30 days
 	AccumulatedStake sdk.Dec   `json:"accumulated_stake,omitempty"` // accumulated stake, sum of StakeSnapshots
+
+	SideVoteAddr []byte `json:"side_vote_addr,omitempty"` // bls vote address on the side chain
 }
 
 // NewValidator - initialize a new validator


### PR DESCRIPTION
This prs drafts the release v0.26.4, which is a bug fix release.

## Change Log
(https://github.com/bnb-chain/bnc-cosmos-sdk/pull/345) fix: fix validator unmarshal failed issue
