### PR TITLE
fix: support querying history about malicious vote slash

### DIFF
--- a/x/slashing/client/cli/query_sidechain.go
+++ b/x/slashing/client/cli/query_sidechain.go
@@ -176,7 +176,7 @@ func GetCmdQuerySideChainSlashRecord(storeName string, cdc *codec.Codec) *cobra.
 			return nil
 		},
 	}
-	cmd.Flags().String(FlagInfractionType, "", "infraction type, 'DoubleSign;Downtime'")
+	cmd.Flags().String(FlagInfractionType, "", "infraction type, 'DoubleSign;Downtime;MaliciousVote'")
 	cmd.Flags().Int64(FlagInfractionHeight, 0, "infraction height")
 	cmd.Flags().String(FlagSideChainId, "", "chain-id of the side chain the validator belongs to")
 	cmd.MarkFlagRequired(FlagInfractionType)
@@ -264,7 +264,7 @@ func GetCmdQuerySideChainSlashRecords(cdc *codec.Codec) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().String(FlagInfractionType, "", "infraction type, 'DoubleSign;Downtime'")
+	cmd.Flags().String(FlagInfractionType, "", "infraction type, 'DoubleSign;Downtime;MaliciousVote'")
 	cmd.Flags().String(FlagSideChainId, "", "chain-id of the side chain the validator belongs to")
 	return cmd
 }
@@ -290,6 +290,8 @@ func convertInfractionType(infractionTypeS string) (byte, error) {
 		res = slashing.DoubleSign
 	} else if infractionTypeS == "Downtime" {
 		res = slashing.Downtime
+	} else if infractionTypeS == "MaliciousVote" {
+		res = slashing.MaliciousVote
 	} else {
 		return 0, errors.New("unknown infraction type")
 	}

--- a/x/slashing/slash_record.go
+++ b/x/slashing/slash_record.go
@@ -32,6 +32,8 @@ func (r SlashRecord) HumanReadableString() (string, error) {
 		infraType = "DoubleSign"
 	} else if r.InfractionType == 1 {
 		infraType = "Downtime"
+	} else if r.InfractionType == 2 {
+		infraType = "MaliciousVote"
 	}
 
 	var consAddr string


### PR DESCRIPTION
Description
support query history about malicious vote slash

Rationale

Example
tested in new qa

Changes
NA