### PR TITLE
docs: update change log for release v0.26.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+##v0.26.6
+* [sdk] [\#349] (https://github.com/bnb-chain/bnc-cosmos-sdk/pull/349) feat: add upgrade config for bep255
+* [fix] [\#353] (https://github.com/bnb-chain/bnc-cosmos-sdk/pull/353) fix: add proof of possession for side vote addrs
+
+
 ##v0.26.5
 * [cli] [\#348] (https://github.com/bnb-chain/bnc-cosmos-sdk/pull/348) fix: support querying history about malicious vote slash
 * [cli] [\#350] (https://github.com/bnb-chain/bnc-cosmos-sdk/pull/350) fix: reading pubkey from ledger panic


### PR DESCRIPTION
This pr prepares for release v0.26.6, which mainly includes following changes.

For more information about bep255, please refer to https://github.com/bnb-chain/BEPs/blob/master/BEP255.md

## Change Log
* #349
* #353

