### PR TITLE
feat: add IsAutoUnDelegate field to CrossStakeDistributeUndelegatedSynPackage and  prevent too many failed in auto refund

### DIFF
--- a/x/stake/cross_stake/cross_stake.go
+++ b/x/stake/cross_stake/cross_stake.go
@@ -38,17 +38,9 @@ func (app *CrossStakeApp) ExecuteSynPackage(ctx sdk.Context, payload []byte, rel
 	var errCode uint8
 	switch p := pack.(type) {
 	case *types.CrossStakeDelegateSynPackage:
-		if sdk.IsUpgrade(sdk.FirstSunsetFork) {
-			result, errCode, err = sdk.ExecuteResult{}, CrossStakeErrBadDelegation, sdk.ErrMsgNotSupported("")
-		} else {
-			result, errCode, err = app.handleDelegate(ctx, p, relayFee)
-		}
+		result, errCode, err = app.handleDelegate(ctx, p, relayFee)
 	case *types.CrossStakeUndelegateSynPackage:
-		if sdk.IsUpgrade(sdk.SecondSunsetFork) {
-			result, errCode, err = sdk.ExecuteResult{}, CrossStakeErrBadDelegation, sdk.ErrMsgNotSupported("")
-		} else {
-			result, errCode, err = app.handleUndelegate(ctx, p, relayFee)
-		}
+		result, errCode, err = app.handleUndelegate(ctx, p, relayFee)
 	case *types.CrossStakeRedelegateSynPackage:
 		result, errCode, err = app.handleRedelegate(ctx, p, relayFee)
 	default:

--- a/x/stake/cross_stake/cross_stake.go
+++ b/x/stake/cross_stake/cross_stake.go
@@ -38,9 +38,17 @@ func (app *CrossStakeApp) ExecuteSynPackage(ctx sdk.Context, payload []byte, rel
 	var errCode uint8
 	switch p := pack.(type) {
 	case *types.CrossStakeDelegateSynPackage:
-		result, errCode, err = app.handleDelegate(ctx, p, relayFee)
+		if sdk.IsUpgrade(sdk.FirstSunsetFork) {
+			result, errCode, err = sdk.ExecuteResult{}, CrossStakeErrBadDelegation, sdk.ErrMsgNotSupported("")
+		} else {
+			result, errCode, err = app.handleDelegate(ctx, p, relayFee)
+		}
 	case *types.CrossStakeUndelegateSynPackage:
-		result, errCode, err = app.handleUndelegate(ctx, p, relayFee)
+		if sdk.IsUpgrade(sdk.SecondSunsetFork) {
+			result, errCode, err = sdk.ExecuteResult{}, CrossStakeErrBadDelegation, sdk.ErrMsgNotSupported("")
+		} else {
+			result, errCode, err = app.handleUndelegate(ctx, p, relayFee)
+		}
 	case *types.CrossStakeRedelegateSynPackage:
 		result, errCode, err = app.handleRedelegate(ctx, p, relayFee)
 	default:

--- a/x/stake/cross_stake/cross_stake.go
+++ b/x/stake/cross_stake/cross_stake.go
@@ -127,6 +127,14 @@ func (app *CrossStakeApp) ExecuteFailAckPackage(ctx sdk.Context, payload []byte)
 			Recipient: p.Recipient,
 		}
 		result, err = app.handleDistributeUndelegatedRefund(ctx, refundPackage)
+	case *types.CrossStakeDistributeUndelegatedSynPackageV2:
+		bcAmount := bsc.ConvertBSCAmountToBCAmount(p.Amount)
+		refundPackage := &types.CrossStakeRefundPackage{
+			EventType: types.CrossStakeTypeDistributeUndelegated,
+			Amount:    big.NewInt(bcAmount),
+			Recipient: p.Recipient,
+		}
+		result, err = app.handleDistributeUndelegatedRefund(ctx, refundPackage)
 	default:
 		app.stakeKeeper.Logger(ctx).Error("unknown cross stake fail ack event type", "err", err.Error(), "package", string(payload))
 		return sdk.ExecuteResult{}

--- a/x/stake/cross_stake/serialize.go
+++ b/x/stake/cross_stake/serialize.go
@@ -84,6 +84,17 @@ func DeserializeCrossStakeFailAckPackage(serializedPackage []byte) (interface{},
 			}
 			return &pack, nil
 		},
+		func(serializedPackage []byte) (interface{}, error) {
+			var pack types.CrossStakeDistributeUndelegatedSynPackageV2
+			err := rlp.DecodeBytes(serializedPackage, &pack)
+			if err != nil {
+				return nil, err
+			}
+			if pack.EventType != types.CrossStakeTypeDistributeUndelegated {
+				return nil, fmt.Errorf("wrong cross stake event type")
+			}
+			return &pack, nil
+		},
 	}
 
 	var pack interface{}

--- a/x/stake/endblock.go
+++ b/x/stake/endblock.go
@@ -320,6 +320,8 @@ func handleRefundStake(ctx sdk.Context, sideChainPrefix []byte, k keeper.Keeper)
 			if failedCount >= maxProcessedRefundFailed {
 				break
 			}
+
+			continue
 		}
 
 		if result.IsOK() && delegation.CrossStake {

--- a/x/stake/endblock.go
+++ b/x/stake/endblock.go
@@ -307,6 +307,13 @@ func handleRefundStake(ctx sdk.Context, sideChainPrefix []byte, k keeper.Keeper)
 		}, k)
 		refundEvents = refundEvents.AppendEvents(result.Events)
 		if !result.IsOK() {
+			ctx.Logger().Debug("handleRefundStake failed",
+				"delegator", delegation.DelegatorAddr.String(),
+				"validator", delegation.ValidatorAddr.String(),
+				"amount", delegation.GetShares().String(),
+				"sideChainId", bscSideChainId,
+				"result", fmt.Sprintf("%+v", result),
+			)
 			// this is to prevent too many delegation is in unbounded state
 			// if too many delegation is in unbounded state, it will cause too many iteration in the block
 			failedCount++

--- a/x/stake/endblock.go
+++ b/x/stake/endblock.go
@@ -304,6 +304,9 @@ func handleRefundStake(ctx sdk.Context, sideChainPrefix []byte, k keeper.Keeper)
 			SideChainId:   bscSideChainId,
 		}, k)
 		refundEvents = refundEvents.AppendEvents(result.Events)
+		if result.IsOK() && delegation.CrossStake {
+			k.SetAutoUnDelegate(sideChainCtx, delegation.DelegatorAddr, delegation.ValidatorAddr)
+		}
 
 		ctx.Logger().Info("handleRefundStake after SecondSunsetFork",
 			"delegator", delegation.DelegatorAddr.String(),

--- a/x/stake/handler.go
+++ b/x/stake/handler.go
@@ -70,6 +70,9 @@ func NewHandler(k keeper.Keeper, govKeeper gov.Keeper) sdk.Handler {
 			}
 			return handleMsgSideChainRedelegate(ctx, msg, k)
 		case types.MsgSideChainUndelegate:
+			if sdk.IsUpgrade(sdk.SecondSunsetFork) {
+				return sdk.ErrMsgNotSupported("").Result()
+			}
 			return handleMsgSideChainUndelegate(ctx, msg, k)
 		case types.MsgSideChainStakeMigration:
 			if !sdk.IsUpgrade(sdk.FirstSunsetFork) || sdk.IsUpgrade(sdk.SecondSunsetFork) {

--- a/x/stake/keeper/delegation.go
+++ b/x/stake/keeper/delegation.go
@@ -890,12 +890,15 @@ func (k Keeper) crossDistributeUndelegated(ctx sdk.Context, delAddr sdk.AccAddre
 	}
 
 	transferPackage := types.CrossStakeDistributeUndelegatedSynPackage{
-		EventType:        types.CrossStakeTypeDistributeUndelegated,
-		Amount:           bscTransferAmount,
-		Recipient:        recipient,
-		Validator:        valAddr,
-		IsAutoUnDelegate: k.IsAutoUnDelegate(ctx, delAddr, valAddr),
+		EventType: types.CrossStakeTypeDistributeUndelegated,
+		Amount:    bscTransferAmount,
+		Recipient: recipient,
+		Validator: valAddr,
 	}
+	if sdk.IsUpgrade(sdk.SecondSunsetFork) {
+		transferPackage.IsAutoUnDelegate = k.IsAutoUnDelegate(ctx, delAddr, valAddr)
+	}
+
 	encodedPackage, err := rlp.EncodeToBytes(transferPackage)
 	if err != nil {
 		return sdk.Events{}, sdk.ErrInternal(err.Error())

--- a/x/stake/keeper/delegation.go
+++ b/x/stake/keeper/delegation.go
@@ -889,14 +889,22 @@ func (k Keeper) crossDistributeUndelegated(ctx sdk.Context, delAddr sdk.AccAddre
 		return sdk.Events{}, sdk.ErrInternal(err.Error())
 	}
 
-	transferPackage := types.CrossStakeDistributeUndelegatedSynPackage{
-		EventType: types.CrossStakeTypeDistributeUndelegated,
-		Amount:    bscTransferAmount,
-		Recipient: recipient,
-		Validator: valAddr,
-	}
-	if sdk.IsUpgrade(sdk.SecondSunsetFork) {
-		transferPackage.IsAutoUnDelegate = k.IsAutoUnDelegate(ctx, delAddr, valAddr)
+	var transferPackage interface{}
+	if !sdk.IsUpgrade(sdk.SecondSunsetFork) {
+		transferPackage = types.CrossStakeDistributeUndelegatedSynPackage{
+			EventType: types.CrossStakeTypeDistributeUndelegated,
+			Amount:    bscTransferAmount,
+			Recipient: recipient,
+			Validator: valAddr,
+		}
+	} else {
+		transferPackage = types.CrossStakeDistributeUndelegatedSynPackageV2{
+			EventType:        types.CrossStakeTypeDistributeUndelegated,
+			Amount:           bscTransferAmount,
+			Recipient:        recipient,
+			Validator:        valAddr,
+			IsAutoUnDelegate: k.IsAutoUnDelegate(ctx, delAddr, valAddr),
+		}
 	}
 
 	encodedPackage, err := rlp.EncodeToBytes(transferPackage)

--- a/x/stake/keeper/key.go
+++ b/x/stake/keeper/key.go
@@ -50,6 +50,8 @@ var (
 	// Keys for reward store prefix
 	RewardBatchKey       = []byte{0x01} // key for batch of rewards
 	RewardValDistAddrKey = []byte{0x02} // key for rewards' validator <-> distribution address mapping
+
+	AutoUndelegateIndexKey = []byte{0x61} // prefix for each key for an auto undelegate, by validator operator
 )
 
 const (
@@ -339,4 +341,15 @@ func GetREDsByDelToValDstIndexKey(delAddr sdk.AccAddress, valDstAddr sdk.ValAddr
 
 func GetValLatestUpdateConsAddrTimeKey(valAddr sdk.ValAddress) []byte {
 	return append(ValLatestUpdateConsAddrTimeKey, valAddr.Bytes()...)
+}
+
+// gets the prefix keyspace for the indexes of auto unDelegate delegations for a validator
+func GetAutoUnDelegateByValIndexKey(valAddr sdk.ValAddress) []byte {
+	return append(AutoUndelegateIndexKey, valAddr.Bytes()...)
+}
+
+// gets the index-key for an auto unDelegate delegation, stored by validator-index
+// VALUE: none (key rearrangement used)
+func GetAutoUnDelegateIndexKey(delAddr sdk.AccAddress, valAddr sdk.ValAddress) []byte {
+	return append(GetAutoUnDelegateByValIndexKey(valAddr), delAddr.Bytes()...)
 }

--- a/x/stake/types/cross_stake.go
+++ b/x/stake/types/cross_stake.go
@@ -74,6 +74,13 @@ type CrossStakeDistributeRewardSynPackage struct {
 }
 
 type CrossStakeDistributeUndelegatedSynPackage struct {
+	EventType CrossStakeEventType
+	Recipient sdk.SmartChainAddress
+	Validator sdk.ValAddress
+	Amount    *big.Int
+}
+
+type CrossStakeDistributeUndelegatedSynPackageV2 struct {
 	EventType        CrossStakeEventType
 	Recipient        sdk.SmartChainAddress
 	Validator        sdk.ValAddress

--- a/x/stake/types/cross_stake.go
+++ b/x/stake/types/cross_stake.go
@@ -74,10 +74,11 @@ type CrossStakeDistributeRewardSynPackage struct {
 }
 
 type CrossStakeDistributeUndelegatedSynPackage struct {
-	EventType CrossStakeEventType
-	Recipient sdk.SmartChainAddress
-	Validator sdk.ValAddress
-	Amount    *big.Int
+	EventType        CrossStakeEventType
+	Recipient        sdk.SmartChainAddress
+	Validator        sdk.ValAddress
+	Amount           *big.Int
+	IsAutoUnDelegate bool
 }
 
 type RefundError uint32


### PR DESCRIPTION
## Description

1. feat: add IsAutoUnDelegate field to CrossStakeDistributeUndelegatedSynPackage
2. fix: disable undelegate after SecondSunsetFork and prevent too many failed in auto refund