### PR TITLE
fix: disable MsgEditSideChainValidator after FirstSunsetFork and refine codes

### DIFF
--- a/x/stake/endblock.go
+++ b/x/stake/endblock.go
@@ -309,7 +309,7 @@ func handleRefundStake(ctx sdk.Context, sideChainPrefix []byte, k keeper.Keeper)
 		}, k)
 		refundEvents = refundEvents.AppendEvents(result.Events)
 		if !result.IsOK() {
-			ctx.Logger().Debug("handleRefundStake failed",
+			ctx.Logger().Info("handleRefundStake failed",
 				"delegator", delegation.DelegatorAddr.String(),
 				"validator", delegation.ValidatorAddr.String(),
 				"amount", delegation.GetShares().String(),

--- a/x/stake/handler.go
+++ b/x/stake/handler.go
@@ -48,6 +48,9 @@ func NewHandler(k keeper.Keeper, govKeeper gov.Keeper) sdk.Handler {
 			}
 			return handleMsgCreateSideChainValidator(ctx, msg, k)
 		case types.MsgEditSideChainValidator:
+			if sdk.IsUpgrade(sdk.FirstSunsetFork) {
+				return sdk.ErrMsgNotSupported("").Result()
+			}
 			return handleMsgEditSideChainValidator(ctx, msg, k)
 		case types.MsgCreateSideChainValidatorWithVoteAddr:
 			if sdk.IsUpgrade(sdk.FirstSunsetFork) {

--- a/x/stake/keeper/delegation.go
+++ b/x/stake/keeper/delegation.go
@@ -873,7 +873,8 @@ func (k Keeper) crossDistributeUndelegated(ctx sdk.Context, delAddr sdk.AccAddre
 	amount := k.BankKeeper.GetCoins(ctx, delAddr).AmountOf(denom)
 
 	var relayFeeCalc fees.FeeCalculator
-	if sdk.IsUpgrade(sdk.SecondSunsetFork) && k.IsAutoUnDelegate(ctx, delAddr, valAddr) {
+	isAutoUnDelegate := k.IsAutoUnDelegate(ctx, delAddr, valAddr)
+	if sdk.IsUpgrade(sdk.SecondSunsetFork) && isAutoUnDelegate {
 		relayFeeCalc = fees.FreeFeeCalculator()
 	} else {
 		relayFeeCalc = fees.GetCalculator(types.CrossDistributeUndelegatedRelayFee)
@@ -910,7 +911,7 @@ func (k Keeper) crossDistributeUndelegated(ctx sdk.Context, delAddr sdk.AccAddre
 			Amount:           bscTransferAmount,
 			Recipient:        recipient,
 			Validator:        valAddr,
-			IsAutoUnDelegate: k.IsAutoUnDelegate(ctx, delAddr, valAddr),
+			IsAutoUnDelegate: isAutoUnDelegate,
 		}
 	}
 


### PR DESCRIPTION
## Description

fix: disable MsgEditSideChainValidator after FirstSunsetFork and refine codes