### PR TITLE
fix: publish completed UnbondingDelegation events to kafka in EndBlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+##v0.26.8
+* [fix] [\#388] (https://github.com/bnb-chain/bnc-cosmos-sdk/pull/388) fix: publish completed UnbondingDelegation events to kafka in EndBlock
+
 ##v0.26.7
 * [sdk] [\#381] (https://github.com/bnb-chain/bnc-cosmos-sdk/pull/381) feat: implement BEP-333(BNB Chain Fusion) 
 * [fix] [\#356] (https://github.com/bnb-chain/bnc-cosmos-sdk/pull/356) fix: fix nil validator when publishing message

--- a/x/stake/endblock.go
+++ b/x/stake/endblock.go
@@ -49,10 +49,12 @@ func EndBlocker(ctx sdk.Context, k keeper.Keeper) (validatorUpdates []abci.Valid
 	if len(storePrefixes) > 0 && sdk.IsUpgrade(sdk.FirstSunsetFork) {
 		for i := range storePrefixes {
 			sideChainCtx := ctx.WithSideChainKeyPrefix(storePrefixes[i])
-			_, unBoundedEvents := handleMatureUnbondingDelegations(k, sideChainCtx)
+			ubd, unBoundedEvents := handleMatureUnbondingDelegations(k, sideChainCtx)
 
 			events = append(events, unBoundedEvents...)
+			publishCompletedUBD(k, ubd, sideChainIds[i], ctx.BlockHeight())
 		}
+
 	}
 
 	if sdk.IsUpgrade(sdk.BEP153) {


### PR DESCRIPTION
## Description
publish UnbondingDelegation events to `kafka` in EndBlock