### PR TITLE
fix: publish ChainUndelegate event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+##v0.26.9
+* [fix] [\#389] (https://github.com/bnb-chain/bnc-cosmos-sdk/pull/389) fix: publish ChainUndelegate event
+* [fix] [\#390] (https://github.com/bnb-chain/bnc-cosmos-sdk/pull/390) fix: ledger sig conversion
+
 ##v0.26.8
 * [fix] [\#388] (https://github.com/bnb-chain/bnc-cosmos-sdk/pull/388) fix: publish completed UnbondingDelegation events to kafka in EndBlock
 

--- a/x/stake/handler_sidechain.go
+++ b/x/stake/handler_sidechain.go
@@ -461,16 +461,17 @@ func handleMsgSideChainUndelegate(ctx sdk.Context, msg MsgSideChainUndelegate, k
 
 	// publish undelegate event
 	if k.PbsbServer != nil && ctx.IsDeliverTx() {
+		txHash, isFromTx := ctx.Value(baseapp.TxHashKey).(string)
 		event := types.ChainUndelegateEvent{
 			UndelegateEvent: types.UndelegateEvent{
 				StakeEvent: types.StakeEvent{
-					IsFromTx: true,
+					IsFromTx: isFromTx,
 				},
 				Delegator: msg.DelegatorAddr,
 				Validator: msg.ValidatorAddr,
 				Amount:    msg.Amount.Amount,
 				Denom:     msg.Amount.Denom,
-				TxHash:    ctx.Value(baseapp.TxHashKey).(string),
+				TxHash:    txHash,
 			},
 			ChainId: msg.SideChainId,
 		}


### PR DESCRIPTION
## Description

```
E[2024-03-01|08:41:26.665] CONSENSUS FAILURE!!!                         module=consensus err="interface conversion: interface {} is nil, not string" stack="goroutine 282 [running]:\nruntime/debug.Stack()\n\truntime/debug/stack.go:24 +0x5e\ngithub.com/tendermint/tendermint/consensus.(*ConsensusState).receiveRoutine.func2()\n\tgithub.com/tendermint/tendermint@v0.35.9/consensus/state.go:614 +0x46\npanic({0x161dac0?, 0xc003bbfdd0?})\n\truntime/panic.go:914 +0x21f\ngithub.com/cosmos/cosmos-sdk/x/stake.handleMsgSideChainUndelegate({{0x1ca1da0, 0x2a86680}, {0x1cac1d0, 0xc019920dc0}, {{0xa, 0x0, {}, {0x0, 0x0, 0x0}, ...}, ...}, ...}, ...)\n\tgithub.com/cosmos/cosmos-sdk@v0.25.0/x/stake/handler_sidechain.go:473 +0xef0\ngithub.com/cosmos/cosmos-sdk/x/stake.handleRefundStake({{0x1ca1da0, 0x2a86680}, {0x1cac1d0, 0xc019920dc0}, {{0xa, 0x0, {}, {0x0, 0x0, 0x0}, ...}, ...}, ...}, ...)\n\tgithub.com/cosmos/cosmos-sdk@v0.25.0/x/stake/endblock.go:306 +0x8bb\ngithub.com/cosmos/cosmos-sdk/x/stake.EndBlocker({{0x1ca1da0, 0x2a86680}, {0x1cac1d0, 0xc019920dc0}, {{0xa, 0x0, {}, {0x0, 0x0, 0x0}, ...}, ...}, ...}, ...)\n\tgithub.com/cosmos/cosmos-sdk@v0.25.0/x/stake/endblock.go:45 +0xe5b\ngithub.com/bnb-chain/node/app.(*BNBBeaconChain).EndBlocker(_, {{0x1ca1da0, 0x2a86680}, {0x1cac1d0, 0xc019920dc0}, {{0xa, 0x0, {}, {0x0, 0x0, ...}, ...}, ...}, ...}, ...)\n\tgithub.com/bnb-chain/node/app/app.go:965 +0x121b\ngithub.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).EndBlock(0xc000c7e690, {0x3f813, {}, {0x0, 0x0, 0x0}, 0x0})\n\tgithub.com/cosmos/cosmos-sdk@v0.25.0/baseapp/baseapp.go:934 +0x1bd\ngithub.com/cosmos/cosmos-sdk/server/concurrent.(*asyncLocalClient).EndBlockSync(0xc000600a50, {0x3f813, {}, {0x0, 0x0, 0x0}, 0x0})\n\tgithub.com/cosmos/cosmos-sdk@v0.25.0/server/concurrent/async_local_client.go:408 +0x246\ngithub.com/tendermint/tendermint/proxy.(*appConnConsensus).EndBlockSync(0xc003b8dee0?, {0x3f813, {}, {0x0, 0x0, 0x0}, 0x0})\n\tgithub.com/tendermint/tendermint@v0.35.9/proxy/app_conn.go:115 +0x48\ngithub.com/tendermint/tendermint/state.execBlockOnProxyApp({0x1ca2388, 0xc000d93460}, {0x1ca9740, 0xc0025bb760}, 0xc01ea6e5a0, 0x14?, {0x1cad928, 0xc0142e82f0})\n\tgithub.com/tendermint/tendermint@v0.35.9/state/execution.go:298 +0x6b9\ngithub.com/tendermint/tendermint/state.(*BlockExecutor).ApplyBlock(_, {{{0xa, 0x0}, {0xc006ba7b50, 0x6}}, {0xc001babd40, 0x14}, 0x3f812, 0x10f, {{0xc003036e40, ...}, ...}, ...}, ...)\n\tgithub.com/tendermint/tendermint@v0.35.9/state/execution.go:128 +0x189\ngithub.com/tendermint/tendermint/consensus.(*ConsensusState).finalizeCommit(0xc0025d8380, 0x3f813)\n\tgithub.com/tendermint/tendermint@v0.35.9/consensus/state.go:1380 +0x93e\ngithub.com/tendermint/tendermint/consensus.(*ConsensusState).tryFinalizeCommit(0xc0025d8380, 0x3f813)\n\tgithub.com/tendermint/tendermint@v0.35.9/consensus/state.go:1308 +0x2f8\ngithub.com/tendermint/tendermint/consensus.(*ConsensusState).enterCommit.func1()\n\tgithub.com/tendermint/tendermint@v0.35.9/consensus/state.go:1253 +0x88\ngithub.com/tendermint/tendermint/consensus.(*ConsensusState).enterCommit(0xc0025d8380, 0x3f813, 0x0)\n\tgithub.com/tendermint/tendermint@v0.35.9/consensus/state.go:1285 +0xacb\ngithub.com/tendermint/tendermint/consensus.(*ConsensusState).addVote(0xc0025d8380, 0xc0030f1860, {0xc01eb7bf50, 0x28})\n\tgithub.com/tendermint/tendermint@v0.35.9/consensus/state.go:1737 +0x731\ngithub.com/tendermint/tendermint/consensus.(*ConsensusState).tryAddVote(0xc0025d8380, 0xc0030f1860, {0xc01eb7bf50?, 0x2a4bd01?})\n\tgithub.com/tendermint/tendermint@v0.35.9/consensus/state.go:1567 +0x26\ngithub.com/tendermint/tendermint/consensus.(*ConsensusState).handleMsg(0xc0025d8380, {{0x1c8f400, 0xc01ea8fb90}, {0xc01eb7bf50, 0x28}})\n\tgithub.com/tendermint/tendermint@v0.35.9/consensus/state.go:703 +0x2fe\ngithub.com/tendermint/tendermint/consensus.(*ConsensusState).receiveRoutine(0xc0025d8380, 0x0)\n\tgithub.com/tendermint/tendermint@v0.35.9/consensus/state.go:645 +0x325\ncreated by github.com/tendermint/tendermint/consensus.(*ConsensusState).OnStart in goroutine 191\n\tgithub.com/tendermint/tendermint@v0.35.9/consensus/state.go:346 +0x40f\n"
```

## Rationale
After `SecondSunsetFork` the delegation will be returned by `EndBlock` function. 
It's not called by tx, so the `txHash` will be nil.